### PR TITLE
Add original version material + source material database validation

### DIFF
--- a/src/models/Material.js
+++ b/src/models/Material.js
@@ -1,7 +1,7 @@
 import { getDuplicateBaseInstanceIndices, getDuplicateNameIndices } from '../lib/get-duplicate-indices';
 import { isValidYear } from '../lib/is-valid-year';
 import MaterialBase from './MaterialBase';
-import { CharacterGroup, SubMaterial, WritingCredit } from '.';
+import { CharacterGroup, OriginalVersionMaterial, SubMaterial, WritingCredit } from '.';
 
 export default class Material extends MaterialBase {
 
@@ -25,7 +25,7 @@ export default class Material extends MaterialBase {
 
 		this.year = parseInt(year) || year?.trim() || '';
 
-		this.originalVersionMaterial = new MaterialBase(originalVersionMaterial);
+		this.originalVersionMaterial = new OriginalVersionMaterial(originalVersionMaterial);
 
 		this.writingCredits = writingCredits
 			? writingCredits.map(writingCredit => new WritingCredit(writingCredit))
@@ -104,6 +104,12 @@ export default class Material extends MaterialBase {
 	async runDatabaseValidations () {
 
 		await this.validateUniquenessInDatabase();
+
+		await this.originalVersionMaterial.runDatabaseValidations({ subjectMaterialUuid: this.uuid });
+
+		for (const writingCredit of this.writingCredits) {
+			await writingCredit.runDatabaseValidations({ subjectMaterialUuid: this.uuid });
+		}
 
 		for (const subMaterial of this.subMaterials) {
 			await subMaterial.runDatabaseValidations({ subjectMaterialUuid: this.uuid });

--- a/src/models/OriginalVersionMaterial.js
+++ b/src/models/OriginalVersionMaterial.js
@@ -1,0 +1,50 @@
+import { prepareAsParams } from '../lib/prepare-as-params';
+import MaterialBase from './MaterialBase';
+import { validationQueries } from '../neo4j/cypher-queries';
+import { neo4jQuery } from '../neo4j/query';
+
+export default class OriginalVersionMaterial extends MaterialBase {
+
+	constructor (props = {}) {
+
+		super(props);
+
+	}
+
+	async runDatabaseValidations ({ subjectMaterialUuid = null }) {
+
+		if (this.name) {
+
+			const { getOriginalVersionMaterialChecksQuery } = validationQueries;
+
+			const preparedParams = prepareAsParams(this);
+
+			const {
+				isSubsequentVersionMaterialOfSubjectMaterial
+			} = await neo4jQuery({
+				query: getOriginalVersionMaterialChecksQuery(),
+				params: {
+					name: preparedParams.name,
+					differentiator: preparedParams.differentiator,
+					subjectMaterialUuid
+				}
+			});
+
+			if (isSubsequentVersionMaterialOfSubjectMaterial) {
+				this.addPropertyError(
+					'name',
+					'Material with these attributes is this material\'s subsequent version material'
+				);
+				this.addPropertyError(
+					'differentiator',
+					'Material with these attributes is this material\'s subsequent version material'
+				);
+			}
+
+		}
+
+		return;
+
+	}
+
+}

--- a/src/models/SourceMaterial.js
+++ b/src/models/SourceMaterial.js
@@ -1,0 +1,50 @@
+import { prepareAsParams } from '../lib/prepare-as-params';
+import MaterialBase from './MaterialBase';
+import { validationQueries } from '../neo4j/cypher-queries';
+import { neo4jQuery } from '../neo4j/query';
+
+export default class SourceMaterial extends MaterialBase {
+
+	constructor (props = {}) {
+
+		super(props);
+
+	}
+
+	async runDatabaseValidations ({ subjectMaterialUuid = null }) {
+
+		if (this.name) {
+
+			const { getSourceMaterialChecksQuery } = validationQueries;
+
+			const preparedParams = prepareAsParams(this);
+
+			const {
+				isSourcingMaterialOfSubjectMaterial
+			} = await neo4jQuery({
+				query: getSourceMaterialChecksQuery(),
+				params: {
+					name: preparedParams.name,
+					differentiator: preparedParams.differentiator,
+					subjectMaterialUuid
+				}
+			});
+
+			if (isSourcingMaterialOfSubjectMaterial) {
+				this.addPropertyError(
+					'name',
+					'Material with these attributes is this material\'s sourcing material'
+				);
+				this.addPropertyError(
+					'differentiator',
+					'Material with these attributes is this material\'s sourcing material'
+				);
+			}
+
+		}
+
+		return;
+
+	}
+
+}

--- a/src/models/WritingCredit.js
+++ b/src/models/WritingCredit.js
@@ -1,6 +1,6 @@
 import { getDuplicateEntityIndices } from '../lib/get-duplicate-indices';
 import Base from './Base';
-import { Company, Person, MaterialBase } from '.';
+import { Company, Person, SourceMaterial } from '.';
 import { CREDIT_TYPES, MODELS } from '../utils/constants';
 
 export default class WritingCredit extends Base {
@@ -19,7 +19,7 @@ export default class WritingCredit extends Base {
 					case MODELS.COMPANY:
 						return new Company(entity);
 					case MODELS.MATERIAL:
-						return new MaterialBase(entity);
+						return new SourceMaterial(entity);
 					default:
 						return new Person(entity);
 				}
@@ -59,6 +59,20 @@ export default class WritingCredit extends Base {
 			}
 
 		});
+
+	}
+
+	async runDatabaseValidations ({ subjectMaterialUuid = null }) {
+
+		for (const entity of this.entities) {
+
+			if (entity.model === MODELS.MATERIAL) {
+
+				await entity.runDatabaseValidations({ subjectMaterialUuid });
+
+			}
+
+		}
 
 	}
 

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -16,12 +16,14 @@ import Material from './Material';
 import MaterialBase from './MaterialBase';
 import NominatedProductionIdentifier from './NominatedProductionIdentifier';
 import Nomination from './Nomination';
+import OriginalVersionMaterial from './OriginalVersionMaterial';
 import Person from './Person';
 import ProducerCredit from './ProducerCredit';
 import Production from './Production';
 import ProductionIdentifier from './ProductionIdentifier';
 import Role from './Role';
 import Season from './Season';
+import SourceMaterial from './SourceMaterial';
 import SubMaterial from './SubMaterial';
 import SubProductionIdentifier from './SubProductionIdentifier';
 import SubVenue from './SubVenue';
@@ -48,12 +50,14 @@ export {
 	MaterialBase,
 	NominatedProductionIdentifier,
 	Nomination,
+	OriginalVersionMaterial,
 	Person,
 	ProducerCredit,
 	Production,
 	ProductionIdentifier,
 	Role,
 	Season,
+	SourceMaterial,
 	SubMaterial,
 	SubProductionIdentifier,
 	SubVenue,

--- a/src/neo4j/cypher-queries/index.js
+++ b/src/neo4j/cypher-queries/index.js
@@ -44,6 +44,8 @@ import {
 	getAwardContextualDuplicateRecordCheckQuery,
 	getDuplicateRecordCheckQuery,
 	getExistenceCheckQuery,
+	getOriginalVersionMaterialChecksQuery,
+	getSourceMaterialChecksQuery,
 	getSubMaterialChecksQuery,
 	getSubProductionChecksQuery,
 	getSubVenueChecksQuery
@@ -115,6 +117,8 @@ const validationQueries = {
 	getAwardContextualDuplicateRecordCheckQuery,
 	getDuplicateRecordCheckQuery,
 	getExistenceCheckQuery,
+	getOriginalVersionMaterialChecksQuery,
+	getSourceMaterialChecksQuery,
 	getSubMaterialChecksQuery,
 	getSubProductionChecksQuery,
 	getSubVenueChecksQuery

--- a/src/neo4j/cypher-queries/validation/index.js
+++ b/src/neo4j/cypher-queries/validation/index.js
@@ -1,6 +1,8 @@
 import getAwardContextualDuplicateRecordCheckQuery from './award-contextual-duplicate-record-check';
 import getDuplicateRecordCheckQuery from './duplicate-record-check';
 import getExistenceCheckQuery from './existence-check';
+import getOriginalVersionMaterialChecksQuery from './original-version-material-checks';
+import getSourceMaterialChecksQuery from './source-material-checks';
 import getSubMaterialChecksQuery from './sub-material-checks';
 import getSubProductionChecksQuery from './sub-production-checks';
 import getSubVenueChecksQuery from './sub-venue-checks';
@@ -9,6 +11,8 @@ export {
 	getAwardContextualDuplicateRecordCheckQuery,
 	getDuplicateRecordCheckQuery,
 	getExistenceCheckQuery,
+	getOriginalVersionMaterialChecksQuery,
+	getSourceMaterialChecksQuery,
 	getSubMaterialChecksQuery,
 	getSubProductionChecksQuery,
 	getSubVenueChecksQuery

--- a/src/neo4j/cypher-queries/validation/original-version-material-checks.js
+++ b/src/neo4j/cypher-queries/validation/original-version-material-checks.js
@@ -1,0 +1,15 @@
+export default () => `
+	MATCH (m:Material { name: $name })
+		WHERE
+			(
+				($differentiator IS NULL AND m.differentiator IS NULL) OR
+				$differentiator = m.differentiator
+			)
+
+	OPTIONAL MATCH (subjectMaterial:Material { uuid: $subjectMaterialUuid })
+
+	OPTIONAL MATCH (m)-[originalVersionMaterialRelWithSubjectMaterial:SUBSEQUENT_VERSION_OF]->(subjectMaterial)
+
+	RETURN
+		TOBOOLEAN(COUNT(originalVersionMaterialRelWithSubjectMaterial)) AS isSubsequentVersionMaterialOfSubjectMaterial
+`;

--- a/src/neo4j/cypher-queries/validation/source-material-checks.js
+++ b/src/neo4j/cypher-queries/validation/source-material-checks.js
@@ -1,0 +1,15 @@
+export default () => `
+	MATCH (m:Material { name: $name })
+		WHERE
+			(
+				($differentiator IS NULL AND m.differentiator IS NULL) OR
+				$differentiator = m.differentiator
+			)
+
+	OPTIONAL MATCH (subjectMaterial:Material { uuid: $subjectMaterialUuid })
+
+	OPTIONAL MATCH (m)-[sourceMaterialRelWithSubjectMaterial:USES_SOURCE_MATERIAL]->(subjectMaterial)
+
+	RETURN
+		TOBOOLEAN(COUNT(sourceMaterialRelWithSubjectMaterial)) AS isSourcingMaterialOfSubjectMaterial
+`;

--- a/test-int/input-validation-failures/material.test.js
+++ b/test-int/input-validation-failures/material.test.js
@@ -27,6 +27,8 @@ describe('Input validation failures: Material instance', () => {
 				isExistent: true,
 				isDuplicate: false,
 				isAssignedToSurMaterial: false,
+				isSourcingMaterialOfSubjectMaterial: false,
+				isSubsequentVersionMaterialOfSubjectMaterial: false,
 				isSurSurMaterial: false,
 				isSurMaterialOfSubjectMaterial: false,
 				isSubjectMaterialASubSubMaterial: false

--- a/test-unit/src/models/Material.test.js
+++ b/test-unit/src/models/Material.test.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import proxyquire from 'proxyquire';
 import { assert, createStubInstance, spy, stub } from 'sinon';
 
-import { CharacterGroup, MaterialBase, SubMaterial, WritingCredit } from '../../../src/models';
+import { CharacterGroup, MaterialBase, OriginalVersionMaterial, SubMaterial, WritingCredit } from '../../../src/models';
 
 describe('Material model', () => {
 
@@ -11,6 +11,12 @@ describe('Material model', () => {
 	const CharacterGroupStub = function () {
 
 		return createStubInstance(CharacterGroup);
+
+	};
+
+	const OriginalVersionMaterialStub = function () {
+
+		return createStubInstance(OriginalVersionMaterial);
 
 	};
 
@@ -38,6 +44,7 @@ describe('Material model', () => {
 			},
 			models: {
 				CharacterGroup: CharacterGroupStub,
+				OriginalVersionMaterial: OriginalVersionMaterialStub,
 				SubMaterial: SubMaterialStub,
 				WritingCredit: WritingCreditStub
 			}
@@ -367,8 +374,6 @@ describe('Material model', () => {
 			spy(instance, 'validateSubtitle');
 			spy(instance, 'validateFormat');
 			spy(instance, 'validateYear');
-			spy(instance.originalVersionMaterial, 'validateName');
-			spy(instance.originalVersionMaterial, 'validateDifferentiator');
 			instance.runInputValidations();
 			assert.callOrder(
 				instance.validateName,
@@ -518,10 +523,19 @@ describe('Material model', () => {
 
 			const props = {
 				uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
-				name: 'The Coast of Utopia',
+				name: 'Foo',
+				originalVersionMaterial: {
+					name: 'Ur-Foo'
+				},
+				writingCredits: [
+					{
+						model: 'MATERIAL',
+						name: 'Pre-Foo'
+					}
+				],
 				subMaterials: [
 					{
-						name: 'Voyage'
+						name: 'Sub-Foo'
 					}
 				]
 			};
@@ -530,6 +544,16 @@ describe('Material model', () => {
 			await instance.runDatabaseValidations();
 			assert.calledOnce(instance.validateUniquenessInDatabase);
 			assert.calledWithExactly(instance.validateUniquenessInDatabase);
+			assert.calledOnce(instance.originalVersionMaterial.runDatabaseValidations);
+			assert.calledWithExactly(
+				instance.originalVersionMaterial.runDatabaseValidations,
+				{ subjectMaterialUuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' }
+			);
+			assert.calledOnce(instance.writingCredits[0].runDatabaseValidations);
+			assert.calledWithExactly(
+				instance.writingCredits[0].runDatabaseValidations,
+				{ subjectMaterialUuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' }
+			);
 			assert.calledOnce(instance.subMaterials[0].runDatabaseValidations);
 			assert.calledWithExactly(
 				instance.subMaterials[0].runDatabaseValidations,

--- a/test-unit/src/models/OriginalVersionMaterial.test.js
+++ b/test-unit/src/models/OriginalVersionMaterial.test.js
@@ -1,0 +1,129 @@
+import { assert, createSandbox, spy } from 'sinon';
+
+import * as prepareAsParamsModule from '../../../src/lib/prepare-as-params';
+import { OriginalVersionMaterial } from '../../../src/models';
+import * as cypherQueries from '../../../src/neo4j/cypher-queries';
+import * as neo4jQueryModule from '../../../src/neo4j/query';
+
+describe('OriginalVersionMaterial model', () => {
+
+	let stubs;
+	let instance;
+
+	const neo4jQueryMockResponse = { neo4jQueryMockResponseProperty: 'neo4jQueryMockResponseValue' };
+
+	const sandbox = createSandbox();
+
+	beforeEach(() => {
+
+		stubs = {
+			prepareAsParams: sandbox.stub(prepareAsParamsModule, 'prepareAsParams').returns({
+				name: 'NAME_VALUE',
+				differentiator: 'DIFFERENTIATOR_VALUE'
+			}),
+			validationQueries: {
+				getOriginalVersionMaterialChecksQuery:
+					sandbox.stub(cypherQueries.validationQueries, 'getOriginalVersionMaterialChecksQuery')
+						.returns('getOriginalVersionMaterialChecksQuery response')
+			},
+			neo4jQuery: sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves(neo4jQueryMockResponse)
+		};
+
+		instance = new OriginalVersionMaterial({ name: 'NAME_VALUE', differentiator: '1' });
+
+	});
+
+	afterEach(() => {
+
+		sandbox.restore();
+
+	});
+
+	describe('runDatabaseValidations method', () => {
+
+		context('valid data', () => {
+
+			it('will not call addPropertyError method', async () => {
+
+				stubs.neo4jQuery.resolves({
+					isSubsequentVersionMaterialOfSubjectMaterial: false
+				});
+				spy(instance, 'addPropertyError');
+				await instance.runDatabaseValidations({
+					subjectMaterialUuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+				});
+				assert.callOrder(
+					stubs.prepareAsParams,
+					stubs.validationQueries.getOriginalVersionMaterialChecksQuery,
+					stubs.neo4jQuery
+				);
+				assert.calledOnce(stubs.prepareAsParams);
+				assert.calledWithExactly(stubs.prepareAsParams, instance);
+				assert.calledOnce(stubs.validationQueries.getOriginalVersionMaterialChecksQuery);
+				assert.calledWithExactly(stubs.validationQueries.getOriginalVersionMaterialChecksQuery);
+				assert.calledOnce(stubs.neo4jQuery);
+				assert.calledWithExactly(
+					stubs.neo4jQuery,
+					{
+						query: 'getOriginalVersionMaterialChecksQuery response',
+						params: {
+							name: 'NAME_VALUE',
+							differentiator: 'DIFFERENTIATOR_VALUE',
+							subjectMaterialUuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+						}
+					}
+				);
+				assert.notCalled(instance.addPropertyError);
+
+			});
+
+		});
+
+		context('invalid data (instance is the subject material\'s subsequent version material)', () => {
+
+			it('will call addPropertyError method', async () => {
+
+				stubs.neo4jQuery.resolves({
+					isSubsequentVersionMaterialOfSubjectMaterial: true
+				});
+				spy(instance, 'addPropertyError');
+				await instance.runDatabaseValidations({ subjectMaterialUuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' });
+				assert.callOrder(
+					stubs.prepareAsParams,
+					stubs.validationQueries.getOriginalVersionMaterialChecksQuery,
+					stubs.neo4jQuery,
+					instance.addPropertyError
+				);
+				assert.calledOnce(stubs.prepareAsParams);
+				assert.calledWithExactly(stubs.prepareAsParams, instance);
+				assert.calledOnce(stubs.validationQueries.getOriginalVersionMaterialChecksQuery);
+				assert.calledWithExactly(stubs.validationQueries.getOriginalVersionMaterialChecksQuery);
+				assert.calledOnce(stubs.neo4jQuery);
+				assert.calledWithExactly(
+					stubs.neo4jQuery,
+					{
+						query: 'getOriginalVersionMaterialChecksQuery response',
+						params: {
+							name: 'NAME_VALUE',
+							differentiator: 'DIFFERENTIATOR_VALUE',
+							subjectMaterialUuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+						}
+					}
+				);
+				assert.calledTwice(instance.addPropertyError);
+				assert.calledWithExactly(
+					instance.addPropertyError.firstCall,
+					'name', 'Material with these attributes is this material\'s subsequent version material'
+				);
+				assert.calledWithExactly(
+					instance.addPropertyError.secondCall,
+					'differentiator', 'Material with these attributes is this material\'s subsequent version material'
+				);
+
+			});
+
+		});
+
+	});
+
+});

--- a/test-unit/src/models/SourceMaterial.test.js
+++ b/test-unit/src/models/SourceMaterial.test.js
@@ -1,0 +1,129 @@
+import { assert, createSandbox, spy } from 'sinon';
+
+import * as prepareAsParamsModule from '../../../src/lib/prepare-as-params';
+import { SourceMaterial } from '../../../src/models';
+import * as cypherQueries from '../../../src/neo4j/cypher-queries';
+import * as neo4jQueryModule from '../../../src/neo4j/query';
+
+describe('SourceMaterial model', () => {
+
+	let stubs;
+	let instance;
+
+	const neo4jQueryMockResponse = { neo4jQueryMockResponseProperty: 'neo4jQueryMockResponseValue' };
+
+	const sandbox = createSandbox();
+
+	beforeEach(() => {
+
+		stubs = {
+			prepareAsParams: sandbox.stub(prepareAsParamsModule, 'prepareAsParams').returns({
+				name: 'NAME_VALUE',
+				differentiator: 'DIFFERENTIATOR_VALUE'
+			}),
+			validationQueries: {
+				getSourceMaterialChecksQuery:
+					sandbox.stub(cypherQueries.validationQueries, 'getSourceMaterialChecksQuery')
+						.returns('getSourceMaterialChecksQuery response')
+			},
+			neo4jQuery: sandbox.stub(neo4jQueryModule, 'neo4jQuery').resolves(neo4jQueryMockResponse)
+		};
+
+		instance = new SourceMaterial({ name: 'NAME_VALUE', differentiator: '1' });
+
+	});
+
+	afterEach(() => {
+
+		sandbox.restore();
+
+	});
+
+	describe('runDatabaseValidations method', () => {
+
+		context('valid data', () => {
+
+			it('will not call addPropertyError method', async () => {
+
+				stubs.neo4jQuery.resolves({
+					isSourcingMaterialOfSubjectMaterial: false
+				});
+				spy(instance, 'addPropertyError');
+				await instance.runDatabaseValidations({
+					subjectMaterialUuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+				});
+				assert.callOrder(
+					stubs.prepareAsParams,
+					stubs.validationQueries.getSourceMaterialChecksQuery,
+					stubs.neo4jQuery
+				);
+				assert.calledOnce(stubs.prepareAsParams);
+				assert.calledWithExactly(stubs.prepareAsParams, instance);
+				assert.calledOnce(stubs.validationQueries.getSourceMaterialChecksQuery);
+				assert.calledWithExactly(stubs.validationQueries.getSourceMaterialChecksQuery);
+				assert.calledOnce(stubs.neo4jQuery);
+				assert.calledWithExactly(
+					stubs.neo4jQuery,
+					{
+						query: 'getSourceMaterialChecksQuery response',
+						params: {
+							name: 'NAME_VALUE',
+							differentiator: 'DIFFERENTIATOR_VALUE',
+							subjectMaterialUuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+						}
+					}
+				);
+				assert.notCalled(instance.addPropertyError);
+
+			});
+
+		});
+
+		context('invalid data (instance is the subject material\'s sourcing material)', () => {
+
+			it('will call addPropertyError method', async () => {
+
+				stubs.neo4jQuery.resolves({
+					isSourcingMaterialOfSubjectMaterial: true
+				});
+				spy(instance, 'addPropertyError');
+				await instance.runDatabaseValidations({ subjectMaterialUuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' });
+				assert.callOrder(
+					stubs.prepareAsParams,
+					stubs.validationQueries.getSourceMaterialChecksQuery,
+					stubs.neo4jQuery,
+					instance.addPropertyError
+				);
+				assert.calledOnce(stubs.prepareAsParams);
+				assert.calledWithExactly(stubs.prepareAsParams, instance);
+				assert.calledOnce(stubs.validationQueries.getSourceMaterialChecksQuery);
+				assert.calledWithExactly(stubs.validationQueries.getSourceMaterialChecksQuery);
+				assert.calledOnce(stubs.neo4jQuery);
+				assert.calledWithExactly(
+					stubs.neo4jQuery,
+					{
+						query: 'getSourceMaterialChecksQuery response',
+						params: {
+							name: 'NAME_VALUE',
+							differentiator: 'DIFFERENTIATOR_VALUE',
+							subjectMaterialUuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+						}
+					}
+				);
+				assert.calledTwice(instance.addPropertyError);
+				assert.calledWithExactly(
+					instance.addPropertyError.firstCall,
+					'name', 'Material with these attributes is this material\'s sourcing material'
+				);
+				assert.calledWithExactly(
+					instance.addPropertyError.secondCall,
+					'differentiator', 'Material with these attributes is this material\'s sourcing material'
+				);
+
+			});
+
+		});
+
+	});
+
+});

--- a/test-unit/src/models/WritingCredit.test.js
+++ b/test-unit/src/models/WritingCredit.test.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import proxyquire from 'proxyquire';
 import { assert, createStubInstance, spy, stub } from 'sinon';
 
-import { Company, Person, MaterialBase } from '../../../src/models';
+import { Company, Person, SourceMaterial } from '../../../src/models';
 
 describe('WritingCredit model', () => {
 
@@ -14,9 +14,9 @@ describe('WritingCredit model', () => {
 
 	};
 
-	const MaterialBaseStub = function () {
+	const SourceMaterialStub = function () {
 
-		return createStubInstance(MaterialBase);
+		return createStubInstance(SourceMaterial);
 
 	};
 
@@ -34,7 +34,7 @@ describe('WritingCredit model', () => {
 			},
 			models: {
 				Company: CompanyStub,
-				MaterialBase: MaterialBaseStub,
+				SourceMaterial: SourceMaterialStub,
 				Person: PersonStub
 			}
 		};
@@ -144,13 +144,13 @@ describe('WritingCredit model', () => {
 				expect(instance.entities.length).to.equal(9);
 				expect(instance.entities[0] instanceof Person).to.be.true;
 				expect(instance.entities[1] instanceof Company).to.be.true;
-				expect(instance.entities[2] instanceof MaterialBase).to.be.true;
+				expect(instance.entities[2] instanceof SourceMaterial).to.be.true;
 				expect(instance.entities[3] instanceof Person).to.be.true;
 				expect(instance.entities[4] instanceof Company).to.be.true;
-				expect(instance.entities[5] instanceof MaterialBase).to.be.true;
+				expect(instance.entities[5] instanceof SourceMaterial).to.be.true;
 				expect(instance.entities[6] instanceof Person).to.be.true;
 				expect(instance.entities[7] instanceof Company).to.be.true;
-				expect(instance.entities[8] instanceof MaterialBase).to.be.true;
+				expect(instance.entities[8] instanceof SourceMaterial).to.be.true;
 
 			});
 
@@ -230,6 +230,40 @@ describe('WritingCredit model', () => {
 			assert.calledWithExactly(
 				instance.entities[2].validateNoAssociationWithSelf,
 				{ name: 'The Indian Boy', differentiator: '1' }
+			);
+
+		});
+
+	});
+
+	describe('runDatabaseValidations method', () => {
+
+		it('calls associated subMaterials\' runDatabaseValidations method', async () => {
+
+			const props = {
+				name: 'version by',
+				entities: [
+					{
+						name: 'David Eldridge'
+					},
+					{
+						model: 'COMPANY',
+						name: 'Told by an Idiot'
+					},
+					{
+						model: 'MATERIAL',
+						name: 'A Midsummer Night\'s Dream'
+					}
+				]
+			};
+			const instance = createInstance(props);
+			await instance.runDatabaseValidations({ subjectMaterialUuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' });
+			assert.notCalled(instance.entities[0].runDatabaseValidations);
+			assert.notCalled(instance.entities[1].runDatabaseValidations);
+			assert.calledOnce(instance.entities[2].runDatabaseValidations);
+			assert.calledWithExactly(
+				instance.entities[2].runDatabaseValidations,
+				{ subjectMaterialUuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' }
 			);
 
 		});


### PR DESCRIPTION
This PR adds validation for a material instance's original version material and source material, e.g.
- Material validation will validate that its original version material adheres to an allowed structure
- Material validation will validate that its source material (which appears in its writing credits) adheres to an allowed structure

It performs similar validations as were added in the below PRs — namely for instances to avoid having circular references to the instances with which they are creating relationships:
- https://github.com/andygout/dramatis-api/pull/546
- https://github.com/andygout/dramatis-api/pull/540

The validation checks added here are less than those added for sur- and sub-instances, which means that while direct circular references will be prevented, any that are larger will not be. This could be possible by using a variable length relationship pattern in the Cypher query, though I believe the maximum is 10 (based on [this](https://neo4j.com/developer/kb/achieving-longestpath-using-cypher)), so it would still not exclude the presence of an even larger circular reference and would also require substantial test setup for a circular reference involving a path a larger number of Material nodes.

Instead I've opted to err on the side of preventing the most obvious (and more likely to be accidental) errors and trusting users inputting the data not to add deliberately incorrect relationships (which could be done in many other ways far more easily).

N.B. Both below examples apply equally to `SUBSEQUENT_VERSION_OF` and `USES_SOURCE_MATERIAL` relationships.

---

### Example 1

This scenario will be prevented:

```mermaid
graph TB
    A(Material)
    B(Material)
    A --> |SUBSEQUENT_VERSION_OF| B
    B --> |SUBSEQUENT_VERSION_OF| A
```

---

### Example 2

This scenario, and those of a circular reference involving even more Material nodes, will not be prevented:

```mermaid
graph TB
    A(Material)
    B(Material)
    C(Material)
    A --> |SUBSEQUENT_VERSION_OF| B
    B --> |SUBSEQUENT_VERSION_OF| C
    C --> |SUBSEQUENT_VERSION_OF| A
```

---

### References:
- [Neo4j Knowledge Base: Achieving longestPath using Cypher](https://neo4j.com/developer/kb/achieving-longestpath-using-cypher)