### PR TITLE
Add production review database seeds

### DIFF
--- a/db-seeding/seeds/productions/3-winters-nt-lyttelton.json
+++ b/db-seeding/seeds/productions/3-winters-nt-lyttelton.json
@@ -476,5 +476,87 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.dailymail.co.uk/tvshowbiz/article-2860124/Croatia-sore-history-one-character-puts-colony-QUENTIN-LETTS-reviews-3-Winters.html",
+			"date": "2014-12-04",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Quentin Letts"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/3-winters-at-the-lyttelton-se1-rfv72xwqp2j",
+			"date": "2014-12-04",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Dominic Maxwell"
+			}
+		},
+		{
+			"url": "https://www.standard.co.uk/culture/theatre/3-winters-nationals-lyttelton-theatre-review-9902553.html",
+			"date": "2014-12-04",
+			"publication": {
+				"name": "Evening Standard"
+			},
+			"critic": {
+				"name": "Fiona Mountford"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2014/dec/04/3-winters-lyttelton-london-review",
+			"date": "2014-12-04",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/b656f39c-7bba-11e4-a695-00144feabdc0",
+			"date": "2014-12-05",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2014/dec/07/3-winters-review-croatia-national-theatre-tena-stivicic",
+			"date": "2014-12-07",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.thejc.com/life-and-culture/theatre/review-3-winters-sa5tglb6",
+			"date": "2014-12-11",
+			"publication": {
+				"name": "The Jewish Chronicle"
+			},
+			"critic": {
+				"name": "John Nathan"
+			}
+		},
+		{
+			"url": "https://www.spectator.co.uk/article/national-theatre-s-3-winters-a-hideous-balkans-ballyhoo/",
+			"date": "2015-01-03",
+			"publication": {
+				"name": "The Spectator"
+			},
+			"critic": {
+				"name": "Lloyd Evans"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/a-disappearing-number-barbican.json
+++ b/db-seeding/seeds/productions/a-disappearing-number-barbican.json
@@ -112,5 +112,57 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2007/sep/12/theatre2",
+			"date": "2007-09-12",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/drama/3667884/A-Disappearing-Number-Maths-emotion-a-hit.html",
+			"date": "2007-09-13",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/5fabfa80-626b-11dc-bdf6-0000779fd2ac",
+			"date": "2007-09-14",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2007/sep/16/theatre1",
+			"date": "2007-09-16",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/a-disappearing-number-barbican-londonblack-eyed-susan-theatre-royal-bury-st-edmundsawake-and-sing-almeida-london-464341.html",
+			"date": "2007-09-16",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/a-dolls-house-donmar.json
+++ b/db-seeding/seeds/productions/a-dolls-house-donmar.json
@@ -172,5 +172,77 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2009/may/20/a-dolls-house-theatre-review",
+			"date": "2009-05-20",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.express.co.uk/entertainment/theatre/102320/A-Doll-s-House-Donmar-Warehouse",
+			"date": "2009-05-20",
+			"publication": {
+				"name": "Daily Express"
+			},
+			"critic": {
+				"name": "Paul Callan"
+			}
+		},
+		{
+			"url": "https://www.dailymail.co.uk/tvshowbiz/article-1186173/A-Dolls-House-Another-house-scandal.html",
+			"date": "2009-05-21",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Quentin Letts"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/a-doll-s-house-donmar-warehouse-london-1688864.html",
+			"date": "2009-05-21",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Michael Coveney"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/3ccee504-4626-11de-803f-00144feabdc0",
+			"date": "2009-05-21",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/a-doll-s-house-donmar-londonthe-observer-nt-cottesloe-londongrasses-of-a-thousand-colours-royal-court-upstairs-london-1689909.html",
+			"date": "2009-05-24",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/a-dolls-house-at-the-donmar-warehouse-wc2-n3k3wldkp6k",
+			"date": "2009-05-24",
+			"publication": {
+				"name": "The Sunday Times"
+			},
+			"critic": {
+				"name": "Sam Leith"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/a-midsummer-nights-dream-globe.json
+++ b/db-seeding/seeds/productions/a-midsummer-nights-dream-globe.json
@@ -142,5 +142,27 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2012/may/02/midsummer-nights-dream-review",
+			"date": "2012-05-02",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Brian Logan"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2012/may/06/enquirer-love-royal-court-midsummers-night",
+			"date": "2012-05-06",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/a-midsummer-nights-dream-novello.json
+++ b/db-seeding/seeds/productions/a-midsummer-nights-dream-novello.json
@@ -301,5 +301,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2006/feb/08/theatre",
+			"date": "2006-02-08",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/a-midsummer-nights-dream-swan.json
+++ b/db-seeding/seeds/productions/a-midsummer-nights-dream-swan.json
@@ -253,5 +253,57 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2006/jun/09/theatre.rsc",
+			"date": "2006-06-09",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/a-midsummer-night-s-dream-swan-theatre-stratforduponavon-6098441.html",
+			"date": "2006-06-11",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/drama/3653094/A-fantastical-unforgettable-Dream.html",
+			"date": "2006-06-12",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/27d27322-fa35-11da-b7ff-0000779e2340",
+			"date": "2006-06-12",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/3653236/Play-revolution-for-me.html",
+			"date": "2006-06-18",
+			"publication": {
+				"name": "The Sunday Telegraph"
+			},
+			"critic": {
+				"name": "Rebecca Tyrrel"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/a-streetcar-named-desire-donmar.json
+++ b/db-seeding/seeds/productions/a-streetcar-named-desire-donmar.json
@@ -155,5 +155,77 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2009/jul/29/review-streetcar-named-desire-donmar",
+			"date": "2009-07-29",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/a-streetcar-named-desire-donmar-warehouse-london-1764540.html",
+			"date": "2009-07-30",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Michael Coveney"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/8929d754-7d28-11de-b8ee-00144feabdc0",
+			"date": "2009-07-30",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		},
+		{
+			"url": "https://www.express.co.uk/entertainment/theatre/117342/A-Streetcar-Named-Desire-Donmar-Warehouse-London",
+			"date": "2009-07-31",
+			"publication": {
+				"name": "Daily Express"
+			},
+			"critic": {
+				"name": "Paul Callan"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2009/aug/02/streetcar-named-desire-review",
+			"date": "2009-08-02",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Kate Kellaway"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/a-streetcar-named-desire-donmar-warehouse-londonghosts-arcola-londonsixteen-kensal-house-estate-london-1765989.html",
+			"date": "2009-08-02",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/a-streetcar-named-desire-at-the-donmar-wc2-sr5bv2zlhf5",
+			"date": "2009-08-02",
+			"publication": {
+				"name": "The Sunday Times"
+			},
+			"critic": {
+				"name": "Christopher Hart"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/a-view-from-the-bridge-duke-of-yorks.json
+++ b/db-seeding/seeds/productions/a-view-from-the-bridge-duke-of-yorks.json
@@ -211,5 +211,67 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.thetimes.co.uk/article/a-view-from-the-bridge-at-the-duke-of-yorks-wc2-8mk5dlgr9t2",
+			"date": "2009-02-06",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Benedict Nightingale"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2009/feb/06/view-from-bridge-review",
+			"date": "2009-02-06",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/culture/2009/feb/08/view-bridge-shun-kin-sloane",
+			"date": "2009-02-08",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/c7d44986-f465-11dd-8e76-0000779fd2ac",
+			"date": "2009-02-08",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/a-view-from-the-bridge-duke-of-york-s-london-1605273.html",
+			"date": "2009-02-10",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Michael Coveney"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/a-view-from-the-bridge-duke-of-york-8217-s-london-1628647.html",
+			"date": "2009-02-22",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/absurdia-4-collection-donmar.json
+++ b/db-seeding/seeds/productions/absurdia-4-collection-donmar.json
@@ -16,5 +16,47 @@
 		{
 			"uuid": "aa0d868f-072f-4b91-b562-bc382f78b61f"
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2007/aug/01/theatre1",
+			"date": "2007-08-01",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/absurdia-mc2zxxhc5wh",
+			"date": "2007-08-02",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Sam Marlowe"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/32096de8-414f-11dc-8f37-0000779fd2ac",
+			"date": "2007-08-03",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/drama/3666954/Absurdia-an-inspector-calls-and-an-elephant-appears.html",
+			"date": "2007-08-06",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Dominic Cavendish"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/after-miss-julie-donmar.json
+++ b/db-seeding/seeds/productions/after-miss-julie-donmar.json
@@ -70,5 +70,57 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2003/nov/26/theatre",
+			"date": "2003-11-26",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/after-miss-julie-donmar-warehouse-earlham-st-wc2-5q5jw93hc9s",
+			"date": "2003-11-27",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Benedict Nightingale"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/after-miss-julie-donmar-warehouse-london-80159.html",
+			"date": "2003-11-27",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/drama/3607352/Night-of-guilty-pleasures.html",
+			"date": "2003-11-27",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/mourning-becomes-electra-nt-lyttelton-londonafter-miss-julie-donmar-warehouse-londonthe-god-botherers-bush-london-80767.html",
+			"date": "2003-11-30",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/after-miss-julie-young-vic-maria.json
+++ b/db-seeding/seeds/productions/after-miss-julie-young-vic-maria.json
@@ -102,5 +102,57 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.standard.co.uk/culture/theatre/after-miss-julie-young-vic-review-7581384.html",
+			"date": "2012-03-22",
+			"publication": {
+				"name": "Evening Standard"
+			},
+			"critic": {
+				"name": "Fiona Mountford"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2012/mar/22/after-miss-julie-review",
+			"date": "2012-03-22",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Lyn Gardner"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/theatre-reviews/9160273/After-Miss-Julie-Young-Vic-review.html",
+			"date": "2012-03-22",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Dominic Cavendish"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/theatre-reviews/9171625/After-Miss-Julie-Young-Vic-Seven-magazine-review.html",
+			"date": "2012-03-25",
+			"publication": {
+				"name": "The Sunday Telegraph"
+			},
+			"critic": {
+				"name": "Tim Walker"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/7c27d436-74d1-11e1-ab8b-00144feab49a",
+			"date": "2012-03-25",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/ailie-and-the-alien-nt-shed.json
+++ b/db-seeding/seeds/productions/ailie-and-the-alien-nt-shed.json
@@ -151,5 +151,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.ft.com/content/7992caa6-e946-11e2-9f11-00144feabdc0",
+			"date": "2013-07-12",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alexander Gilmour"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/alls-well-that-ends-well-globe.json
+++ b/db-seeding/seeds/productions/alls-well-that-ends-well-globe.json
@@ -114,5 +114,27 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.ft.com/content/88304a32-a597-11e1-a77b-00144feabdc0",
+			"date": "2012-05-24",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Griselda Murray Brown"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2012/jun/01/alls-well-that-ends-well-review",
+			"date": "2012-06-01",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Andrew Dickson"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/angels-in-america-nt-lyttelton-3-collection.json
+++ b/db-seeding/seeds/productions/angels-in-america-nt-lyttelton-3-collection.json
@@ -17,5 +17,87 @@
 		{
 			"uuid": "4ea42855-2708-4ca2-93b8-5c229e617224"
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.telegraph.co.uk/theatre/what-to-see/angels-america-national-theatre-reviewdazzling-quirky-often/",
+			"date": "2017-05-04",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Dominic Cavendish"
+			}
+		},
+		{
+			"url": "https://www.standard.co.uk/culture/theatre/angels-in-america-review-andrew-garfield-makes-a-profound-impression-in-a-true-theatrical-epic-a3680726.html",
+			"date": "2017-05-05",
+			"publication": {
+				"name": "Evening Standard"
+			},
+			"critic": {
+				"name": "Henry Hitchings"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/6e8de008-3188-11e7-9555-23ef563ecf9a",
+			"date": "2017-05-05",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2017/may/05/angels-in-america-review-andrew-garfield-nathan-lane-tony-kushner",
+			"date": "2017-05-05",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2017/may/07/angels-in-america-review-nathan-lane-andrew-garfield-denise-gough",
+			"date": "2017-05-07",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/angels-in-america-review-national-theatre-marianne-elliott-tony-kushner-andrew-garfield-aids-reagan-new-york-a7725596.html",
+			"date": "2017-05-11",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.dailymail.co.uk/home/event/article-4499132/Angels-America-review-half-marathon-plenty.html",
+			"date": "2017-05-13",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Georgina Brown"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/theatre-review-david-jays-angels-in-america-226tbbgns",
+			"date": "2017-05-14",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "David Jays"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/antony-and-cleopatra-globe.json
+++ b/db-seeding/seeds/productions/antony-and-cleopatra-globe.json
@@ -222,5 +222,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2012/may/28/antony-and-cleopatra-review",
+			"date": "2012-05-28",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/antony-and-cleopatra-swan.json
+++ b/db-seeding/seeds/productions/antony-and-cleopatra-swan.json
@@ -320,5 +320,77 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/drama/3651709/Middle-aged-passion-goes-to-the-heart.html",
+			"date": "2006-04-20",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2006/apr/20/theatre.rsc",
+			"date": "2006-04-20",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/antony-and-cleopatra-h2xhcktr6qq",
+			"date": "2006-04-21",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Benedict Nightingale"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2006/apr/23/theatre",
+			"date": "2006-04-23",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/the-world-will-love-these-lovers-wf2f2xgbspp",
+			"date": "2006-04-23",
+			"publication": {
+				"name": "The Sunday Times"
+			},
+			"critic": {
+				"name": "Christopher Hart"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/5ed2020a-d3b3-11da-b2f3-0000779e2340",
+			"date": "2006-04-24",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alastair Macauley"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/twelfth-night-lowry-salfordantony-and-cleopatra-swan-stratford-much-ado-about-nothing-swan-stratford-480115.html",
+			"date": "2006-05-28",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/as-you-like-it-globe.json
+++ b/db-seeding/seeds/productions/as-you-like-it-globe.json
@@ -124,5 +124,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2012/may/22/as-you-like-it-globe-review",
+			"date": "2012-05-22",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Kate Kellaway"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/august-osage-country-nt-lyttelton.json
+++ b/db-seeding/seeds/productions/august-osage-country-nt-lyttelton.json
@@ -213,5 +213,77 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2008/nov/27/august-osage-county-theatre-review",
+			"date": "2008-11-27",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/drama/3563719/August-Osage-County-at-the-National-Theatre.html",
+			"date": "2008-11-27",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/90e03b90-bc95-11dd-9efc-0000779fd18c",
+			"date": "2008-11-27",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/august-osage-county-nt-lyttelton-londonwig-out-royal-court-downstairs-londontombstone-tales-and-boothill-ballads-arcola-london-1041116.html",
+			"date": "2008-11-30",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2008/nov/30/august-osage-county-theatre-review",
+			"date": "2008-11-30",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/august-osage-county-the-sunday-times-review-ttzf60zsgxd",
+			"date": "2008-11-30",
+			"publication": {
+				"name": "The Sunday Times"
+			},
+			"critic": {
+				"name": "Christopher Hart"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/august-osage-county-national-theatre-lyttelton-london-1042377.html",
+			"date": "2008-12-01",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Michael Coveney"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/black-watch-barbican.json
+++ b/db-seeding/seeds/productions/black-watch-barbican.json
@@ -179,5 +179,77 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2008/jun/25/theatre.reviews1",
+			"date": "2008-06-25",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.dailymail.co.uk/tvshowbiz/reviews/article-1029789/Black-Watch-Explosive--thats-just-language.html",
+			"date": "2008-06-26",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Quentin Letts"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/black-watch-barbican-london-854183.html",
+			"date": "2008-06-26",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/drama/3555126/Black-Watch-searing-insights-into-the-horrors-of-modern-warfare.html",
+			"date": "2008-06-26",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/d1ac4d78-43e9-11dd-842e-0000779fd2ac",
+			"date": "2008-06-28",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/black-watch-barbican-londonthe-diver-soho-londonthe-merry-wives-of-windsor-globe-london-856388.html",
+			"date": "2008-06-29",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/black-watch-at-the-barbican-ec2-the-sunday-times-review-fj683wxtzjk",
+			"date": "2008-06-29",
+			"publication": {
+				"name": "The Sunday Times"
+			},
+			"critic": {
+				"name": "Christopher Hart"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/boeing-boeing-comedy.json
+++ b/db-seeding/seeds/productions/boeing-boeing-comedy.json
@@ -141,5 +141,47 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2007/feb/16/theatre2",
+			"date": "2007-02-16",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2007/feb/18/theatre",
+			"date": "2007-02-18",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/the-glass-menagerie-apollo-shaftesbury-londonunderneath-the-lintel-duchess-londonboeing-boeing-comedy-londonas-you-like-it-crucible-sheffield-6228787.html",
+			"date": "2007-02-18",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/d1fbc250-bf91-11db-9ac2-000b5df10621",
+			"date": "2007-02-19",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alastair Macauley"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/calendar-girls-noel-coward.json
+++ b/db-seeding/seeds/productions/calendar-girls-noel-coward.json
@@ -202,5 +202,47 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2009/apr/15/calendar-girls-theatre-review",
+			"date": "2009-04-16",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.dailymail.co.uk/tvshowbiz/reviews/article-1170781/Calendar-Girls-As-sweet-artfully-placed-ice-buns.html",
+			"date": "2009-04-16",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Patrick Marmion"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/2ec3679a-2dbd-11de-9eba-00144feabdc0",
+			"date": "2009-04-20",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2009/apr/26/calendar-girls-stageplay-review",
+			"date": "2009-04-26",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Carole Cadwalladr"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/cat-on-a-hot-tin-roof-novello.json
+++ b/db-seeding/seeds/productions/cat-on-a-hot-tin-roof-novello.json
@@ -273,5 +273,87 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2009/dec/02/cat-on-a-hot-tin-roof-billington",
+			"date": "2009-12-02",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.express.co.uk/entertainment/theatre/143682/Cat-On-A-Hot-Tin-Roof-Novello-Theatre-London",
+			"date": "2009-12-02",
+			"publication": {
+				"name": "Daily Express"
+			},
+			"critic": {
+				"name": "Paul Callan"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/theatre-reviews/6708794/Cat-On-A-Hot-Tin-Roof-at-the-Novello-Theatre-review.html",
+			"date": "2009-12-02",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/cat-on-a-hot-tin-roof-novello-theatre-london-1832995.html",
+			"date": "2009-12-03",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.express.co.uk/entertainment/theatre/144461/Theatre-reviews-Sweet-Charity-and-Cat-On-A-Hot-Tin-Roof",
+			"date": "2009-12-06",
+			"publication": {
+				"name": "Sunday Express"
+			},
+			"critic": {
+				"name": "Mark Shenton"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2009/dec/06/tennessee-williams-sweet-charity-review",
+			"date": "2009-12-06",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/cat-on-a-hot-tin-roof-novello-londondetaining-justice-tricycle-londonsweet-charity-menier-london-1834823.html",
+			"date": "2009-12-06",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/192dd0ba-e0ef-11de-9f58-00144feab49a",
+			"date": "2009-12-06",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/category-b-tricycle.json
+++ b/db-seeding/seeds/productions/category-b-tricycle.json
@@ -166,5 +166,27 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2009/oct/13/category-b-michael-billington-review",
+			"date": "2009-10-13",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/theatre-reviews/6318449/Category-B-at-the-Tricycle-Kilburn-review.html",
+			"date": "2009-10-13",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/charged-7-collection-soho.json
+++ b/db-seeding/seeds/productions/charged-7-collection-soho.json
@@ -116,5 +116,47 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.ft.com/content/03acd8ee-f0de-11df-bf4b-00144feab49a",
+			"date": "2010-11-15",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2010/nov/15/charged-review",
+			"date": "2010-11-15",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Maddy Costa"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/theatre-reviews/8138516/Charged-Clean-Break-Soho-Theatre-review.html",
+			"date": "2011-11-16",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Daisy Bowie-Sell"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/charged-soho-theatre-london-2135919.html",
+			"date": "2011-11-17",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/coriolanus-barbican.json
+++ b/db-seeding/seeds/productions/coriolanus-barbican.json
@@ -713,5 +713,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2007/apr/27/theatre3",
+			"date": "2007-04-27",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Lyn Gardner"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/coriolanus-globe.json
+++ b/db-seeding/seeds/productions/coriolanus-globe.json
@@ -108,5 +108,27 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.ft.com/content/88304a32-a597-11e1-a77b-00144feabdc0",
+			"date": "2012-05-24",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "David Cheal"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2012/may/25/coriolanus-review",
+			"date": "2012-05-25",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Chris Michael"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/coriolanus-rst.json
+++ b/db-seeding/seeds/productions/coriolanus-rst.json
@@ -319,5 +319,47 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2007/mar/07/theatre.rsc",
+			"date": "2007-03-07",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/coriolanus-sfm62bvwlrj",
+			"date": "2007-03-08",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Benedict Nightingale"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/368f658a-cd9a-11db-839d-000b5df10621",
+			"date": "2007-03-08",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alastair Macauley"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2007/mar/11/theatre",
+			"date": "2007-03-11",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/cymbeline-globe.json
+++ b/db-seeding/seeds/productions/cymbeline-globe.json
@@ -124,5 +124,27 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.ft.com/content/6930e45e-9514-11e1-ad72-00144feab49a",
+			"date": "2012-05-03",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alexander Gilmour"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2012/may/04/cymbeline-globe-review",
+			"date": "2012-05-04",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Matt Trueman"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/cymbeline-swan.json
+++ b/db-seeding/seeds/productions/cymbeline-swan.json
@@ -139,5 +139,47 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2006/sep/22/theatre1",
+			"date": "2006-09-22",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2006/sep/24/theatre1",
+			"date": "2006-09-24",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/drama/3655572/A-shot-in-the-arm-from-the-junkie-king.html",
+			"date": "2006-09-26",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Dominic Cavendish"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/on-insomnia-and-midnight-theatre-upstairs-royal-court-london-cymbeline-swan-theatre-stratford-6231304.html",
+			"date": "2006-09-27",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/days-of-significance-swan.json
+++ b/db-seeding/seeds/productions/days-of-significance-swan.json
@@ -204,5 +204,47 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.ft.com/content/cd31f394-a645-11db-937f-0000779e2340",
+			"date": "2007-01-17",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2007/jan/18/theatre",
+			"date": "2007-01-18",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/days-of-significance-swan-theatre-stratforduponavon-6229029.html",
+			"date": "2007-01-18",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2007/jan/21/theatre1",
+			"date": "2007-01-21",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/decade-21-collection-commodity-quay.json
+++ b/db-seeding/seeds/productions/decade-21-collection-commodity-quay.json
@@ -219,5 +219,47 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.dailymail.co.uk/tvshowbiz/reviews/article-2035290/Decade-theatre-review-A-towering-9-11-tribute.html",
+			"date": "2011-09-08",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Quentin Letts"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2011/sep/09/decade-review",
+			"date": "2011-09-09",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.express.co.uk/entertainment/theatre/270205/First-Night-Review-Decade-Commodity-Quay",
+			"date": "2011-09-09",
+			"publication": {
+				"name": "Daily Express"
+			},
+			"critic": {
+				"name": "Neil Norman"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/279fd1fc-dad0-11e0-a58b-00144feabdc0",
+			"date": "2011-09-11",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/detaining-justice-tricycle.json
+++ b/db-seeding/seeds/productions/detaining-justice-tricycle.json
@@ -174,5 +174,57 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/theatre-reviews/6702723/Detaining-Justice-at-the-Tricycle-Theatre-review.html",
+			"date": "2009-12-01",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2009/dec/02/detaining-justice-review",
+			"date": "2009-12-02",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/detaining-justice-tricycle-theatre-london-1833000.html",
+			"date": "2009-12-02",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/a295cb12-e02e-11de-8494-00144feab49a",
+			"date": "2009-12-04",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/cat-on-a-hot-tin-roof-novello-londondetaining-justice-tricycle-londonsweet-charity-menier-london-1834823.html",
+			"date": "2009-12-06",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/dont-feed-the-animals-nt-shed.json
+++ b/db-seeding/seeds/productions/dont-feed-the-animals-nt-shed.json
@@ -299,5 +299,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.ft.com/content/7992caa6-e946-11e2-9f11-00144feabdc0",
+			"date": "2013-07-12",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alexander Gilmour"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/duet-for-one-almeida.json
+++ b/db-seeding/seeds/productions/duet-for-one-almeida.json
@@ -261,5 +261,47 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2009/jan/30/review-almeida-duet-for-one",
+			"date": "2009-01-30",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.express.co.uk/entertainment/theatre/82781/Duet-For-One",
+			"date": "2009-01-31",
+			"publication": {
+				"name": "Daily Express"
+			},
+			"critic": {
+				"name": "Paul Callan"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/duet-for-one-almeida-theatre-london-1522812.html",
+			"date": "2009-02-02",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Michael Coveney"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/shunkin-barbican-londonduet-for-one-almeida-londonspring-awakening-lyric-hammersmith-london-1603713.html",
+			"date": "2009-02-08",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/duet-for-one-vaudeville.json
+++ b/db-seeding/seeds/productions/duet-for-one-vaudeville.json
@@ -79,5 +79,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.thetimes.co.uk/article/duet-for-one-at-the-vaudeville-wc2-rtgqd0xbk5g",
+			"date": "2009-05-13",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Dominic Maxwell"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/dusk-rings-a-bell-old-print-works.json
+++ b/db-seeding/seeds/productions/dusk-rings-a-bell-old-print-works.json
@@ -49,5 +49,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2011/may/15/dining-with-alice-review",
+			"date": "2011-05-15",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/elling-trafalgar-studio-1.json
+++ b/db-seeding/seeds/productions/elling-trafalgar-studio-1.json
@@ -143,5 +143,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.ft.com/content/bc45b644-2fcd-11dc-a68f-0000779fd2ac",
+			"date": "2007-07-11",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/england-people-very-nice-nt-olivier.json
+++ b/db-seeding/seeds/productions/england-people-very-nice-nt-olivier.json
@@ -412,5 +412,67 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2009/feb/12/england-people-very-nice-review",
+			"date": "2009-02-12",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/england-people-very-nice-at-olivier-se1-g7p8cdjd8ct",
+			"date": "2009-02-12",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Benedict Nightingale"
+			}
+		},
+		{
+			"url": "https://www.dailymail.co.uk/tvshowbiz/reviews/article-1144031/England-People-Very-Nice-Mr-Bean-mad-mullah.html",
+			"date": "2009-02-12",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Quentin Letts"
+			}
+		},
+		{
+			"url": "https://www.express.co.uk/entertainment/theatre/84637/England-People-Very-Nice",
+			"date": "2009-02-13",
+			"publication": {
+				"name": "Daily Express"
+			},
+			"critic": {
+				"name": "Neil Norman"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/culture/2009/feb/15/england-people-very-nice-review",
+			"date": "2009-02-15",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/england-people-very-nice-olivier-national-theatre-london-1623651.html",
+			"date": "2009-02-17",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Michael Coveney"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/enron-noel-coward.json
+++ b/db-seeding/seeds/productions/enron-noel-coward.json
@@ -340,5 +340,57 @@
 				}
 			]
 		}
+	]	,
+	"reviews": [
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/theatre-reviews/7080788/Enron-at-the-Noel-Coward-Theatre-review.html",
+			"date": "2010-01-27",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/enron-at-the-noel-coward-theatre-wc2-0c60jxz22r2",
+			"date": "2010-01-27",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Benedict Nightingale"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2010/jan/27/enron-noel-coward-london",
+			"date": "2010-01-27",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Lyn Gardner"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/a5b74e7c-0b69-11df-8232-00144feabdc0",
+			"date": "2010-01-27",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2010/jan/31/three-sisters-trilogy-yusuf-enron",
+			"date": "2010-01-31",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/enron-royal-court-downstairs.json
+++ b/db-seeding/seeds/productions/enron-royal-court-downstairs.json
@@ -276,5 +276,37 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2009/sep/23/enron-review",
+			"date": "2009-09-23",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/enron-at-the-royal-court-hbw7tbbxqtd",
+			"date": "2009-09-24",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Benedict Nightingale"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/f5d129de-a91f-11de-9b7f-00144feabdc0",
+			"date": "2009-09-24",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/entertaining-mr-sloane-trafalgar-studio-1.json
+++ b/db-seeding/seeds/productions/entertaining-mr-sloane-trafalgar-studio-1.json
@@ -132,5 +132,47 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2009/feb/02/entertaining-mr-sloane-review",
+			"date": "2009-02-02",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/entertaining-mr-sloane-trafalgar-studios-london-1543510.html",
+			"date": "2009-02-03",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Michael Coveney"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/5b4a6b40-f20a-11dd-9678-0000779fd2ac",
+			"date": "2009-02-03",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		},
+		{
+			"url": "https://www.dailymail.co.uk/tvshowbiz/reviews/article-1136948/Entertaining-Mr-Sloane-Leather-lust--This-Orton-like-ought-be.html",
+			"date": "2009-02-05",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Quentin Letts"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/fat-pig-trafalgar-studio-1.json
+++ b/db-seeding/seeds/productions/fat-pig-trafalgar-studio-1.json
@@ -128,5 +128,47 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2008/may/28/theatre",
+			"date": "2008-05-28",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.dailymail.co.uk/tvshowbiz/article-1022412/FIRST-NIGHT-REVIEW-This-Fat-Pig-lame.html",
+			"date": "2008-05-31",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Quentin Letts"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2008/jun/01/theatre",
+			"date": "2008-06-01",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/50cf994e-2de6-11dd-b92a-000077b07658",
+			"date": "2008-06-03",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/forty-five-minutes-nt-shed.json
+++ b/db-seeding/seeds/productions/forty-five-minutes-nt-shed.json
@@ -111,5 +111,17 @@
 
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.ft.com/content/7992caa6-e946-11e2-9f11-00144feabdc0",
+			"date": "2013-07-12",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alexander Gilmour"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/god-of-carnage-gielgud.json
+++ b/db-seeding/seeds/productions/god-of-carnage-gielgud.json
@@ -106,5 +106,67 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2008/mar/26/theatre1",
+			"date": "2008-03-26",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/drama/3672098/God-of-Carnage-Electrifying-despite-lights-failing.html",
+			"date": "2008-03-26",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/god-of-carnage-gielgud-theatre-london-801139.html",
+			"date": "2008-03-27",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Alice Jones"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/god-of-carnage-gielgud-londonnever-so-good-lyttelton-london-802478.html",
+			"date": "2008-03-30",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2008/mar/30/theatre3",
+			"date": "2008-03-30",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/god-of-carnage-gielgud-never-so-good-national-the-sunday-times-reviews-gl29zfj0jlq",
+			"date": "2008-03-30",
+			"publication": {
+				"name": "The Sunday Times"
+			},
+			"critic": {
+				"name": "Christopher Hart"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/grounded-gate.json
+++ b/db-seeding/seeds/productions/grounded-gate.json
@@ -113,5 +113,37 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.ft.com/content/4c0efe06-115a-11e3-8321-00144feabdc0",
+			"date": "2013-09-01",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alexander Gilmour"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/theatre-review-blue-stockings-laughing-all-the-way-to-the-lecture-hall-8792724.html",
+			"date": "2013-09-01",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.standard.co.uk/culture/theatre/grounded-gate-theatre-theatre-review-8793929.html",
+			"date": "2013-09-02",
+			"publication": {
+				"name": "Evening Standard"
+			},
+			"critic": {
+				"name": "William Moore"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/hamlet-globe.json
+++ b/db-seeding/seeds/productions/hamlet-globe.json
@@ -151,5 +151,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2012/jun/03/hamlet-review",
+			"date": "2012-06-03",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/hamlet-nt-olivier.json
+++ b/db-seeding/seeds/productions/hamlet-nt-olivier.json
@@ -419,5 +419,117 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.dailymail.co.uk/tvshowbiz/reviews/article-1318713/Hamlets-hoodie-want-hug-.html",
+			"date": "2010-10-08",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Quentin Letts"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/theatre-reviews/8050155/Hamlet-National-Theatre-review.html",
+			"date": "2010-10-08",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/culture/2010/oct/08/hamlet-review-rory-kinnear",
+			"date": "2010-10-08",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/first-night-hamlet-national-theatre-london-2100704.html",
+			"date": "2010-10-08",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "David Lister"
+			}
+		},
+		{
+			"url": "https://www.express.co.uk/entertainment/theatre/204319/Review-Hamlet-National-Theatre",
+			"date": "2010-10-08",
+			"publication": {
+				"name": "Daily Express"
+			},
+			"critic": {
+				"name": "Neil Norman"
+			}
+		},
+		{
+			"url": "https://www.standard.co.uk/culture/theatre/rory-kinnear-good-show-sweet-prince-6541358.html",
+			"date": "2010-10-08",
+			"publication": {
+				"name": "Evening Standard"
+			},
+			"critic": {
+				"name": "Henry Hitchings"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/1f8d723c-d2fa-11df-9ae9-00144feabdc0",
+			"date": "2010-10-08",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		},
+		{
+			"url": "https://www.express.co.uk/entertainment/theatre/204701/Reviews-Hamlet-Or-You-Could-Kiss-Me-Beautiful-Burnout-Enlightenment-and-Lower-Ninth",
+			"date": "2010-10-10",
+			"publication": {
+				"name": "Sunday Express"
+			},
+			"critic": {
+				"name": "Mark Shenton"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/hamlet-national-theatre-mqg7dfsh2vb",
+			"date": "2010-10-10",
+			"publication": {
+				"name": "The Sunday Times"
+			},
+			"critic": {
+				"name": "Christopher Hart"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2010/oct/10/hamlet-a-number-enlightenment-faust-review",
+			"date": "2010-10-10",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/hamlet-nt-olivier-londonhamlet-crucible-sheffieldenlightenment-hampstead-theatre-london-2102427.html",
+			"date": "2010-10-10",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/hamlet-swan.json
+++ b/db-seeding/seeds/productions/hamlet-swan.json
@@ -177,5 +177,67 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2006/may/04/theatre.rsc",
+			"date": "2006-05-04",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/hamlet-mx59p7lk2tq",
+			"date": "2006-05-04",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Benedict Nightingale"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/hamlet-swan-theatre-stratforduponavon-6101832.html",
+			"date": "2006-05-05",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/drama/3652091/The-shadow-of-a-real-tragedy.html",
+			"date": "2006-05-05",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Dominic Cavendish"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/hamlet-swan-stratford-362605.html",
+			"date": "2006-05-07",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/b885d1d4-ddf2-11da-af29-0000779e2340",
+			"date": "2006-05-07",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alastair Macauley"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/hamlet-wyndhams.json
+++ b/db-seeding/seeds/productions/hamlet-wyndhams.json
@@ -271,5 +271,77 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/first-night-hamlet-wyndham-s-theatre-london-1696528.html",
+			"date": "2009-06-04",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Michael Coveney"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2009/jun/04/review-theatre-hamlet-jude-law",
+			"date": "2009-06-04",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.dailymail.co.uk/tvshowbiz/reviews/article-1190716/Jude-Law-stuns-critics-lucid-excellent-performance-Hamlet.html",
+			"date": "2009-06-04",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Quentin Letts"
+			}
+		},
+		{
+			"url": "https://www.express.co.uk/entertainment/theatre/105392/Hamlet-Wyndham-s-Theatre-London",
+			"date": "2009-06-05",
+			"publication": {
+				"name": "Daily Express"
+			},
+			"critic": {
+				"name": "Mark Shenton"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/fc7469be-5388-11de-be08-00144feabdc0",
+			"date": "2009-06-07",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2009/jun/07/hamlet-wyndhams-jude-law",
+			"date": "2009-06-07",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/hamlet-wyndham-s-londonsister-act-palladium-londonarcadia-duke-of-york-s-london-1698487.html",
+			"date": "2009-06-07",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/happy-days-nt-lyttelton.json
+++ b/db-seeding/seeds/productions/happy-days-nt-lyttelton.json
@@ -169,5 +169,47 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2007/jan/25/theatre",
+			"date": "2007-01-25",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/happy-days-dgcm9pdkdh9",
+			"date": "2007-01-25",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Benedict Nightingale"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/happy-days-lyttelton-nt-london-433755.html",
+			"date": "2007-01-26",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/472d5ec8-ad70-11db-8709-0000779e2340",
+			"date": "2007-01-26",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alastair Macauley"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/henry-iv-part-1-globe.json
+++ b/db-seeding/seeds/productions/henry-iv-part-1-globe.json
@@ -111,5 +111,27 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2012/may/17/henry-iv-part-i-ii-review",
+			"date": "2012-05-17",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Laura Barnett"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/6091bdd0-a024-11e1-90f3-00144feabdc0",
+			"date": "2012-05-19",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "David Cheal"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/henry-iv-part-1-nt-olivier.json
+++ b/db-seeding/seeds/productions/henry-iv-part-1-nt-olivier.json
@@ -443,5 +443,57 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2005/may/05/theatre1",
+			"date": "2005-05-05",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/henry-iv-parts-1-amp-2-national-theatre-olivier-london-495277.html",
+			"date": "2005-05-06",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/henry-iv-parts-1-and-2-hx8pfbbrp3v",
+			"date": "2005-05-06",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Benedict Nightingale"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2005/may/08/theatre1",
+			"date": "2005-05-08",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/henry-iv-parts-1-amp-2-nt-olivier-london-the-importance-of-being-earnest-old-vic-bristol-if-destroyed-true-menier-chocolate-factory-london-490093.html",
+			"date": "2005-05-08",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/henry-iv-part-1-rst.json
+++ b/db-seeding/seeds/productions/henry-iv-part-1-rst.json
@@ -304,5 +304,97 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.standard.co.uk/culture/theatre/henry-iv-parts-i-and-ii-royal-shakespeare-theatre-stratforduponavon-theatre-review-9267204.html",
+			"date": "2014-04-17",
+			"publication": {
+				"name": "Evening Standard"
+			},
+			"critic": {
+				"name": "Henry Hitchings"
+			}
+		},
+		{
+			"url": "https://www.dailymail.co.uk/tvshowbiz/article-2606561/Are-21st-century-theatre-Celtic-heritage-park-QUENTIN-LETTS-reviews-Henry-IV-Part-I.html",
+			"date": "2014-04-17",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Quentin Letts"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/theatre-reviews/10772492/Henry-IV-Parts-I-and-II-RSC-review-full-blooded-life.html",
+			"date": "2014-04-17",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Dominic Cavendish"
+			}
+		},
+		{
+			"url": "https://www.dailymail.co.uk/tvshowbiz/article-2607432/QUENTIN-LETTS-Huzzah-Prince-Hal-Falstaff-needs-bit-bottle.html",
+			"date": "2014-04-18",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Quentin Letts"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2014/apr/17/henry-iv-parts-i-and-ii-review-antony-sher-falstaff",
+			"date": "2014-04-17",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/henry-iv-parts-i-and-ii-royal-shakespeare-theatre-stratford-upon-avon-tfpvsghksrv",
+			"date": "2014-04-18",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/henry-iv-parts-i-and-ii-royal-shakespeare-theatre-stratforduponavon-review-9269377.html",
+			"date": "2014-04-18",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2014/apr/20/roaring-girl-henry-iv-parts-i-ii-rsc-review-stratford",
+			"date": "2014-04-20",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/0815ef7e-c614-11e3-ba0e-00144feabdc0",
+			"date": "2014-04-20",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/henry-iv-part-1-swan.json
+++ b/db-seeding/seeds/productions/henry-iv-part-1-swan.json
@@ -291,5 +291,27 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2006/jul/13/theatre.rsc",
+			"date": "2006-07-13",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/henry-iv-parts-i-and-ii-swan-theatre-stratforduponavon-6095585.html",
+			"date": "2006-07-13",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/henry-iv-part-2-globe.json
+++ b/db-seeding/seeds/productions/henry-iv-part-2-globe.json
@@ -89,5 +89,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2012/may/17/henry-iv-part-i-ii-review",
+			"date": "2012-05-17",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Laura Barnett"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/henry-iv-part-2-nt-olivier.json
+++ b/db-seeding/seeds/productions/henry-iv-part-2-nt-olivier.json
@@ -451,5 +451,57 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2005/may/05/theatre1",
+			"date": "2005-05-05",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/henry-iv-parts-1-amp-2-national-theatre-olivier-london-495277.html",
+			"date": "2005-05-06",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/henry-iv-parts-1-and-2-hx8pfbbrp3v",
+			"date": "2005-05-06",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Benedict Nightingale"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2005/may/08/theatre1",
+			"date": "2005-05-08",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/henry-iv-parts-1-amp-2-nt-olivier-london-the-importance-of-being-earnest-old-vic-bristol-if-destroyed-true-menier-chocolate-factory-london-490093.html",
+			"date": "2005-05-08",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/henry-iv-part-2-rst.json
+++ b/db-seeding/seeds/productions/henry-iv-part-2-rst.json
@@ -297,5 +297,87 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.standard.co.uk/culture/theatre/henry-iv-parts-i-and-ii-royal-shakespeare-theatre-stratforduponavon-theatre-review-9267204.html",
+			"date": "2014-04-17",
+			"publication": {
+				"name": "Evening Standard"
+			},
+			"critic": {
+				"name": "Henry Hitchings"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/theatre-reviews/10772492/Henry-IV-Parts-I-and-II-RSC-review-full-blooded-life.html",
+			"date": "2014-04-17",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Dominic Cavendish"
+			}
+		},
+		{
+			"url": "https://www.dailymail.co.uk/tvshowbiz/article-2607432/QUENTIN-LETTS-Huzzah-Prince-Hal-Falstaff-needs-bit-bottle.html",
+			"date": "2014-04-18",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Quentin Letts"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2014/apr/17/henry-iv-parts-i-and-ii-review-antony-sher-falstaff",
+			"date": "2014-04-17",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/henry-iv-parts-i-and-ii-royal-shakespeare-theatre-stratford-upon-avon-tfpvsghksrv",
+			"date": "2014-04-18",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/henry-iv-parts-i-and-ii-royal-shakespeare-theatre-stratforduponavon-review-9269377.html",
+			"date": "2014-04-18",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2014/apr/20/roaring-girl-henry-iv-parts-i-ii-rsc-review-stratford",
+			"date": "2014-04-20",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/0815ef7e-c614-11e3-ba0e-00144feabdc0",
+			"date": "2014-04-20",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/henry-iv-part-2-swan.json
+++ b/db-seeding/seeds/productions/henry-iv-part-2-swan.json
@@ -320,5 +320,27 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2006/jul/13/theatre.rsc",
+			"date": "2006-07-13",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/henry-iv-parts-i-and-ii-swan-theatre-stratforduponavon-6095585.html",
+			"date": "2006-07-13",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/henry-v-globe.json
+++ b/db-seeding/seeds/productions/henry-v-globe.json
@@ -272,5 +272,87 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.standard.co.uk/culture/theatre/henry-v-globe-review-7850779.html",
+			"date": "2012-06-14",
+			"publication": {
+				"name": "Evening Standard"
+			},
+			"critic": {
+				"name": "Fiona Mountford"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/theatre-reviews/9329868/Henry-V-Shakespeares-Globe-review.html",
+			"date": "2012-06-14",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Dominic Cavendish"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2012/jun/14/henry-v-review",
+			"date": "2012-06-14",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Lyn Gardner"
+			}
+		},
+		{
+			"url": "https://www.express.co.uk/entertainment/theatre/326621/Stage-Review-Henry-V-Globe-Theatre-London",
+			"date": "2012-06-15",
+			"publication": {
+				"name": "Daily Express"
+			},
+			"critic": {
+				"name": "Julie Carpenter"
+			}
+		},
+		{
+			"url": "https://www.dailymail.co.uk/tvshowbiz/reviews/article-2159592/Henry-V-theatre-review-Japes-jigs-conquering-King-Henry-Globe.html",
+			"date": "2012-06-15",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Quentin Letts"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/henry-v-at-shakespeares-globe-se1-9b0097qkw0k",
+			"date": "2012-06-15",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Dominic Maxwell"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/henry-v-shakespeare-s-globe-london-7854958.html",
+			"date": "2012-06-15",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/9a784adc-b6cc-11e1-8a95-00144feabdc0",
+			"date": "2012-06-17",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/henry-v-nt-olivier.json
+++ b/db-seeding/seeds/productions/henry-v-nt-olivier.json
@@ -465,5 +465,57 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2003/may/14/theatre.artsfeatures2",
+			"date": "2003-05-14",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/henry-v-olivier-national-theatre-london-104805.html",
+			"date": "2003-05-15",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/drama/3594575/A-tale-for-our-time-summons-the-blood.html",
+			"date": "2003-05-15",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/theatre-long-live-the-king-x55762878qn",
+			"date": "2003-05-18",
+			"publication": {
+				"name": "The Sunday Times"
+			},
+			"critic": {
+				"name": "John Peter"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/theobserver/2003/may/18/features.review117",
+			"date": "2003-03-18",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/henry-v-rst.json
+++ b/db-seeding/seeds/productions/henry-v-rst.json
@@ -341,5 +341,77 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.telegraph.co.uk/theatre/what-to-see/henry-v-royal-shakespeare-company-review/",
+			"date": "2015-09-23",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Dominic Cavendish"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2015/sep/23/henry-v-review-alex-hassell-royal-shakespeare-theatre",
+			"date": "2015-09-23",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/henry-v-at-the-royal-shakespeare-theatre-stratford-upon-avon-9z8mc9bq758",
+			"date": "2015-09-24",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Dominic Maxwell"
+			}
+		},
+		{
+			"url": "https://www.standard.co.uk/culture/theatre/henry-v-theatre-review-harry-for-our-times-a2955006.html",
+			"date": "2015-09-24",
+			"publication": {
+				"name": "Evening Standard"
+			},
+			"critic": {
+				"name": "Fiona Mountford"
+			}
+		},
+		{
+			"url": "https://www.dailymail.co.uk/tvshowbiz/reviews/article-3248289/A-ravishing-display-s-fit-king-QUENTIN-LETTS-reviews.html",
+			"date": "2015-09-25",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Quentin Letts"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/0b9ffe54-6371-11e5-a28b-50226830d644",
+			"date": "2015-09-27",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/henry-v-royal-shakespeare-theatre-stratforduponavon-review-a-production-of-huge-flair-and-bite-a6670251.html",
+			"date": "2015-09-28",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/henry-vi-part-1-courtyard-2006.json
+++ b/db-seeding/seeds/productions/henry-vi-part-1-courtyard-2006.json
@@ -341,5 +341,67 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.ft.com/content/a5a7340a-2892-11db-a2c1-0000779e2340",
+			"date": "2006-08-10",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alastair Macauley"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2006/aug/11/theatre.rsc",
+			"date": "2006-08-11",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/henry-vi-df0mrsf9twn",
+			"date": "2006-08-11",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Benedict Nightingale"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/the-tempest-royal-shakespeare-theatre-stratford-henry-vi-parts-13-courtyard-stratford-411700.html",
+			"date": "2006-08-13",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/henry-vi-parts-1-2-amp-3-courtyard-theatre-stratforduponavon-411741.html",
+			"date": "2006-08-14",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/theatre-a-right-royal-performance-rrwc9d5g5cr",
+			"date": "2006-08-20",
+			"publication": {
+				"name": "The Sunday Times"
+			},
+			"critic": {
+				"name": "Christopher Hart"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/henry-vi-part-1-globe.json
+++ b/db-seeding/seeds/productions/henry-vi-part-1-globe.json
@@ -212,5 +212,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2012/may/16/henry-vi-parts-1-2-3-review",
+			"date": "2012-05-16",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Matt Trueman"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/henry-vi-part-2-globe.json
+++ b/db-seeding/seeds/productions/henry-vi-part-2-globe.json
@@ -140,5 +140,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2012/may/16/henry-vi-parts-1-2-3-review",
+			"date": "2012-05-16",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Matt Trueman"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/henry-vi-part-3-globe.json
+++ b/db-seeding/seeds/productions/henry-vi-part-3-globe.json
@@ -124,5 +124,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2012/may/16/henry-vi-parts-1-2-3-review",
+			"date": "2012-05-16",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Matt Trueman"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/henry-viii-globe.json
+++ b/db-seeding/seeds/productions/henry-viii-globe.json
@@ -145,5 +145,27 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2012/may/31/henry-viii-review-globe-to-globe",
+			"date": "2012-05-31",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Laura Barnett"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/cba68df6-ab11-11e1-b675-00144feabdc0",
+			"date": "2012-06-02",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Raphael Abraham"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/henry-viii-holy-trinity-church.json
+++ b/db-seeding/seeds/productions/henry-viii-holy-trinity-church.json
@@ -206,5 +206,67 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2006/aug/26/theatre",
+			"date": "2006-08-26",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/henry-viii-7pqsfh2bh2p",
+			"date": "2006-08-26",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Benedict Nightingale"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/0db16ee8-36ae-11db-89d6-0000779e2340",
+			"date": "2006-08-08",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alastair Macauley"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/frost-nixon-donmar-london-henry-viii-holy-trinity-church-stratford-look-back-in-anger-theatre-royal-bath-413573.html",
+			"date": "2006-08-27",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/henry-viii-holy-trinity-church-stratforduponavon-413962.html",
+			"date": "2006-08-30",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.spectator.co.uk/article/wives-and-wooings",
+			"date": "2006-09-16",
+			"publication": {
+				"name": "The Spectator"
+			},
+			"critic": {
+				"name": "Patrick Carnegy"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/his-dark-materials-brt-house-3-collection.json
+++ b/db-seeding/seeds/productions/his-dark-materials-brt-house-3-collection.json
@@ -17,5 +17,47 @@
 		{
 			"uuid": "4ab87bf3-b49b-497a-8bb1-a1d07d024580"
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2009/mar/28/theatre-review-his-dark-materials",
+			"date": "2009-03-28",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Lyn Gardner"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/his-dark-materials-at-the-birmingham-repertory-d9vjc5zmkxr",
+			"date": "2009-03-28",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Dominic Maxwell"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/his-dark-materials-birmingham-rep-birmingham-1666088.html",
+			"date": "2009-04-09",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Lynne Walker"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/his-dark-materials-at-the-birmingham-repertory-theatre-7b3nvqnwbsc",
+			"date": "2009-04-12",
+			"publication": {
+				"name": "The Sunday Times"
+			},
+			"critic": {
+				"name": "David Jays"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/his-dark-materials-nt-olivier-3-collection.json
+++ b/db-seeding/seeds/productions/his-dark-materials-nt-olivier-3-collection.json
@@ -17,5 +17,57 @@
 		{
 			"uuid": "00d11b13-e1c8-47ae-a141-ba7c9ebf572b"
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/his-dark-materials-national-theatre-olivier-london-74757.html",
+			"date": "2004-01-04",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Madeleine North"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/drama/3609641/Working-with-the-wrong-material.html",
+			"date": "2004-01-05",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2004/jan/05/theatre.fiction",
+			"date": "2004-01-05",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/his-dark-materials-olivier-theatre-london-75801.html",
+			"date": "2004-01-05",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/voices/columnists/thomas-sutcliffe/an-epic-battle-of-theatre-vs-cinema-72635.html",
+			"date": "2004-01-09",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Thomas Sutcliffe"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/his-dark-materials-nt-olivier-6-collection.json
+++ b/db-seeding/seeds/productions/his-dark-materials-nt-olivier-6-collection.json
@@ -17,5 +17,37 @@
 		{
 			"uuid": "44d2dae3-94a2-4332-9ec4-1287bc65c524"
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/his-dark-materials-national-theatre-london-686118.html",
+			"date": "2004-12-14",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Robert Hanks"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2004/dec/10/theatre",
+			"date": "2004-12-10",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Lyn Gardner"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/3633079/Triumphant-transformation.html",
+			"date": "2004-12-10",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/im-spilling-my-heart-out-here-nt-shed.json
+++ b/db-seeding/seeds/productions/im-spilling-my-heart-out-here-nt-shed.json
@@ -126,5 +126,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.ft.com/content/7992caa6-e946-11e2-9f11-00144feabdc0",
+			"date": "2013-07-12",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alexander Gilmour"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/incoming-old-print-works.json
+++ b/db-seeding/seeds/productions/incoming-old-print-works.json
@@ -61,5 +61,27 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2011/may/08/incoming-theatre-review-andrew-motion",
+			"date": "2011-05-08",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2011/may/15/dining-with-alice-review",
+			"date": "2011-05-15",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/ivanov-wyndhams.json
+++ b/db-seeding/seeds/productions/ivanov-wyndhams.json
@@ -221,5 +221,77 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/first-night-ivanov-wyndhams-theatre-london-934237.html",
+			"date": "2008-09-18",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/ivanov-at-the-wyndhams-wc2-c05mlkkt5ll",
+			"date": "2008-09-18",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Benedict Nightingale"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2008/sep/18/theatre",
+			"date": "2008-09-18",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.dailymail.co.uk/tvshowbiz/reviews/article-1058053/Ivanov-Branaghs-brilliant-mid-life-crisis.html",
+			"date": "2008-09-19",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Quentin Letts"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/drama/3560826/Ivanov-high-praise-for-a-lowering-play.html",
+			"date": "2008-09-18",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.express.co.uk/entertainment/theatre/62317/Ivanov",
+			"date": "2008-09-19",
+			"publication": {
+				"name": "Daily Express"
+			},
+			"critic": {
+				"name": "Paul Callan"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2008/sep/21/theatre",
+			"date": "2008-09-21",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/jerusalem-apollo.json
+++ b/db-seeding/seeds/productions/jerusalem-apollo.json
@@ -257,5 +257,57 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2010/feb/10/jerusalem-review",
+			"date": "2010-02-10",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/london-shows/7205537/Jerusalem-at-the-Apollo-Theatre-review.html",
+			"date": "2010-02-10",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/jerusalem-apollo-theatre-london-1895571.html",
+			"date": "2010-02-11",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.express.co.uk/entertainment/theatre/157712/Jerusalem-Apollo-Theatre-London",
+			"date": "2010-02-12",
+			"publication": {
+				"name": "Daily Express"
+			},
+			"critic": {
+				"name": "Julie Carpenter"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/86b7168a-17fb-11df-91d2-00144feab49a",
+			"date": "2010-02-14",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/jerusalem-royal-court-downstairs.json
+++ b/db-seeding/seeds/productions/jerusalem-royal-court-downstairs.json
@@ -223,5 +223,77 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.thetimes.co.uk/article/jerusalem-at-the-royal-court-sw1-lbvpsx36m5v",
+			"date": "2009-07-16",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Benedict Nightingale"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2009/jul/16/jerusalem-review",
+			"date": "2009-07-16",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/54333e50-7229-11de-ba94-00144feabdc0",
+			"date": "2009-07-16",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		},
+		{
+			"url": "https://www.express.co.uk/entertainment/theatre/114388/Jerusalem-Royal-Court-Theatre-London",
+			"date": "2009-07-17",
+			"publication": {
+				"name": "Daily Express"
+			},
+			"critic": {
+				"name": "Paul Callan"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2009/jul/19/jerusalem-royal-court-review",
+			"date": "2009-07-19",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/jerusalem-royal-court-downstairs-londonthe-apple-cart-theatre-royal-bathbassline-barbican-centre-car-park-london-1752047.html",
+			"date": "2009-07-19",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/jerusalem-royal-court-london-1752715.html",
+			"date": "2009-07-20",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Michael Coveney"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/john-gabriel-borkman-donmar.json
+++ b/db-seeding/seeds/productions/john-gabriel-borkman-donmar.json
@@ -136,5 +136,37 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2007/feb/21/theatre3",
+			"date": "2007-02-21",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/fd220a04-c269-11db-9e1c-000b5df10621",
+			"date": "2007-02-22",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alastair Macauley"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/rest-of-the-weeks-theatre-6zdp38838zd",
+			"date": "2007-02-25",
+			"publication": {
+				"name": "The Sunday Times"
+			},
+			"critic": {
+				"name": "John Peter"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/julie-nt-lyttelton.json
+++ b/db-seeding/seeds/productions/julie-nt-lyttelton.json
@@ -492,5 +492,77 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.telegraph.co.uk/theatre/what-to-see/vanessa-kirby-crown-jewel-lacklustre-julie-national-theatre/",
+			"date": "2018-06-08",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Dominic Cavendish"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/theatre-review-julie-lyttelton-se1-8vng83pl7",
+			"date": "2018-06-08",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Ann Treneman"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2018/jun/08/julie-review-polly-stenham-strindberg-lyttelton-theatre",
+			"date": "2018-06-08",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.standard.co.uk/culture/theatre/julie-review-problematic-take-on-strindberg-lacks-danger-a3858321.html",
+			"date": "2018-06-08",
+			"publication": {
+				"name": "Evening Standard"
+			},
+			"critic": {
+				"name": "Henry Hitchings"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/julie-review-national-theatre-vanessa-kirby-polly-stenham-a8389466.html",
+			"date": "2018-06-08",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/a18fe43e-6b10-11e8-b6eb-4acfcfb08c11",
+			"date": "2018-06-11",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		},
+		{
+			"url": "https://www.dailymail.co.uk/home/event/article-5840407/Theatre.html",
+			"date": "2018-06-16",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Robert Gore-Langton"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/julius-caesar-barbican.json
+++ b/db-seeding/seeds/productions/julius-caesar-barbican.json
@@ -381,5 +381,47 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/drama/3640790/Brutus-the-right-on-guy.html",
+			"date": "2005-04-21",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/julius-caesar-s3kzh8h6mmt",
+			"date": "2005-04-21",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Benedict Nightingale"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2005/apr/21/theatre",
+			"date": "2005-04-21",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/julius-caesar-barbican-london-someone-who-ll-watch-over-me-new-ambassadors-london-the-far-pavilions-shaftesbury-london-vanishing-points-german-gym-london-518101.html",
+			"date": "2005-04-24",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/julius-caesar-globe.json
+++ b/db-seeding/seeds/productions/julius-caesar-globe.json
@@ -92,5 +92,27 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.ft.com/content/6930e45e-9514-11e1-ad72-00144feab49a",
+			"date": "2012-05-03",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alexander Gilmour"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2012/may/03/julius-caesar-globe-review",
+			"date": "2012-05-03",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Melissa Denes"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/julius-caesar-rst.json
+++ b/db-seeding/seeds/productions/julius-caesar-rst.json
@@ -289,5 +289,47 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2006/may/17/theatre.rsc1",
+			"date": "2006-05-17",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/38f7bd24-e68f-11da-a36e-0000779e2340",
+			"date": "2006-05-18",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alastair Macauley"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/3652578/Honourable-men.html",
+			"date": "2006-05-21",
+			"publication": {
+				"name": "The Sunday Telegraph"
+			},
+			"critic": {
+				"name": "Rebecca Tyrrel"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/much-ado-about-nothing-swan-theatre-julius-caesar-royal-shakespeare-theatre-stratforduponavon-479672.html",
+			"date": "2006-05-25",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/king-john-globe.json
+++ b/db-seeding/seeds/productions/king-john-globe.json
@@ -106,5 +106,27 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.ft.com/content/6091bdd0-a024-11e1-90f3-00144feabdc0",
+			"date": "2012-05-19",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alexander Gilmour"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2012/may/21/king-john-review",
+			"date": "2012-05-21",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Theresa Malone"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/king-john-swan.json
+++ b/db-seeding/seeds/productions/king-john-swan.json
@@ -374,5 +374,37 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2006/aug/04/theatre.rsc",
+			"date": "2006-08-04",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/894cdb78-256a-11db-a12e-0000779e2340",
+			"date": "2006-08-06",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alastair Macauley"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/king-john-swan-theatre-stratforduponavon-411044.html",
+			"date": "2006-07-07",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Rhoda Koenig"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/king-lear-courtyard.json
+++ b/db-seeding/seeds/productions/king-lear-courtyard.json
@@ -290,5 +290,37 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2007/jun/01/theatre1",
+			"date": "2007-06-01",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/king-lear-phvx8mfz22g",
+			"date": "2007-06-01",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Benedict Nightingale"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2007/jun/03/rsc.theatre",
+			"date": "2007-06-03",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/king-lear-globe.json
+++ b/db-seeding/seeds/productions/king-lear-globe.json
@@ -116,5 +116,27 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.ft.com/content/6091bdd0-a024-11e1-90f3-00144feabdc0",
+			"date": "2012-05-19",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Griselda Murray Brown"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2012/may/23/king-lear-review",
+			"date": "2012-05-23",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Andrew Dickson"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/king-lear-new-london.json
+++ b/db-seeding/seeds/productions/king-lear-new-london.json
@@ -288,5 +288,27 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2007/nov/28/theatre3",
+			"date": "2007-11-28",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/40f058e4-9ea1-11dc-b4e4-0000779fd2ac",
+			"date": "2007-11-29",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/love-story-cft-minerva.json
+++ b/db-seeding/seeds/productions/love-story-cft-minerva.json
@@ -182,5 +182,67 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/theatre-reviews/7810387/Love-Story-at-the-Minerva-Theatre-Chichester-review.html",
+			"date": "2010-06-07",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2010/jun/08/love-story-review",
+			"date": "2010-06-08",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/66cb4d1e-7313-11df-ae73-00144feabdc0",
+			"date": "2010-06-08",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		},
+		{
+			"url": "https://www.dailymail.co.uk/tvshowbiz/reviews/article-1285681/Love-Story-Romantic-gem-thatll-tears-flowing.html",
+			"date": "2010-06-11",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Quentin Letts"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/love-story-minerva-theatre-chichester-1997234.html",
+			"date": "2010-06-11",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Michael Coveney"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/after-the-dance-nt-lyttelton-londonlove-story-minerva-chichesterthe-fantasticks-duchess-london-1998836.html",
+			"date": "2010-06-13",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/loves-labours-lost-globe.json
+++ b/db-seeding/seeds/productions/loves-labours-lost-globe.json
@@ -165,5 +165,27 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.ft.com/content/88304a32-a597-11e1-a77b-00144feabdc0",
+			"date": "2012-05-24",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alexander Gilmour"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2012/may/25/review-loves-labours-lost-globe",
+			"date": "2012-05-25",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Lucy Howard"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/loves-labours-lost-swan.json
+++ b/db-seeding/seeds/productions/loves-labours-lost-swan.json
@@ -248,5 +248,27 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2006/aug/19/theatre.rsc",
+			"date": "2006-08-19",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/loves-labours-lost-ccpjq6lvg2t",
+			"date": "2006-08-21",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Benedict Nightingale"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/macbeth-gielgud.json
+++ b/db-seeding/seeds/productions/macbeth-gielgud.json
@@ -401,5 +401,47 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.telegraph.co.uk/culture/3668183/The-best-Macbeth-I-have-seen.html",
+			"date": "2007-09-27",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2007/sep/27/theatre4",
+			"date": "2007-09-27",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/d01a540e-6d58-11dc-ab19-0000779fd2ac",
+			"date": "2007-09-28",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/macbeth-gielgud-theatre-london-395847.html",
+			"date": "2007-10-03",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/macbeth-globe.json
+++ b/db-seeding/seeds/productions/macbeth-globe.json
@@ -124,5 +124,27 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2012/may/09/macbeth-shakespeares-globe-review",
+			"date": "2012-05-09",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/b4c19792-9a96-11e1-83bf-00144feabdc0",
+			"date": "2012-05-10",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Griselda Murray Brown"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/madame-de-sade-wyndhams.json
+++ b/db-seeding/seeds/productions/madame-de-sade-wyndhams.json
@@ -137,5 +137,57 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/madame-de-sade-wyndham-s-theatre-london-1651602.html",
+			"date": "2009-03-23",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Michael Coveney"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2009/mar/19/madame-de-sade-grandage",
+			"date": "2009-03-19",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.express.co.uk/entertainment/theatre/90197/Madame-De-Sade",
+			"date": "2009-03-20",
+			"publication": {
+				"name": "Daily Express"
+			},
+			"critic": {
+				"name": "Paul Callan"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2009/mar/21/theatre",
+			"date": "2009-03-22",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/madame-de-sade-wyndhams-londonkafka-s-monkey-young-vic-londonthe-last-cigarette-minerva-chichester-1651029.html",
+			"date": "2009-03-22",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/measure-for-measure-globe.json
+++ b/db-seeding/seeds/productions/measure-for-measure-globe.json
@@ -187,5 +187,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2012/apr/25/measure-for-measure-review",
+			"date": "2012-04-25",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/merry-wives-the-musical-rst.json
+++ b/db-seeding/seeds/productions/merry-wives-the-musical-rst.json
@@ -411,5 +411,67 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2006/dec/13/theatre.rsc",
+			"date": "2006-12-13",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/merry-wives-the-musical-rbk8z88t8rz",
+			"date": "2006-12-13",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Benedict Nightingale"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/drama/3657104/Trying-too-hard-to-be-merry.html",
+			"date": "2006-12-13",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/f825bf46-8abf-11db-8940-0000779e2340",
+			"date": "2006-12-13",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alastair Macauley"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/merry-wives-the-musical-royal-shakespeare-theatre-stratforduponavon-6229542.html",
+			"date": "2006-12-14",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2006/dec/17/theatre",
+			"date": "2006-12-17",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/midsummer-mischief-courtyard-5-collection.json
+++ b/db-seeding/seeds/productions/midsummer-mischief-courtyard-5-collection.json
@@ -160,5 +160,58 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/theatre-reviews/10917888/Midsummer-Mischief-The-Other-Place-at-the-Courtyard-Theatre-Stratford-upon-Avon-review.html",
+			"date": "2014-06-22",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Dominic Cavendish"
+			}
+		},
+		{
+			"url": "https://www.standard.co.uk/culture/theatre/rsc-midsummer-mischief-festival-the-other-place-stratforduponavon-theatre-review-9555817.html",
+			"date": "2014-06-23",
+			"publication": {
+				"name": "Evening Standard"
+			},
+			"critic": {
+				"name": "Fiona Mountford"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/midsummer-mischief-at-the-other-place-stratford-upon-avon-g2s52zwdgng",
+			"date": "2014-06-24",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Dominic Maxwell"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2014/jun/23/midsummer-mischief-royal-shakespeare-company-stratford-review",
+			"date": "2014-06-23",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/0667f616-fabe-11e3-8993-00144feab7de",
+			"date": "2014-06-25",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		}
 	]
+
 }

--- a/db-seeding/seeds/productions/mobile-phone-show-nt-olivier.json
+++ b/db-seeding/seeds/productions/mobile-phone-show-nt-olivier.json
@@ -185,5 +185,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.ft.com/content/7992caa6-e946-11e2-9f11-00144feabdc0",
+			"date": "2013-07-12",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alexander Gilmour"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/mrs-affleck-nt-cottesloe.json
+++ b/db-seeding/seeds/productions/mrs-affleck-nt-cottesloe.json
@@ -290,5 +290,37 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/culture/2009/jan/28/mrs-affleck-cottesloe-review-ibsen",
+			"date": "2009-01-28",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.express.co.uk/entertainment/theatre/82580/Mrs-Affleck",
+			"date": "2009-01-30",
+			"publication": {
+				"name": "Daily Express"
+			},
+			"critic": {
+				"name": "Simon Edge"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/dbe7cdea-f13f-11dd-8790-0000779fd2ac",
+			"date": "2009-02-02",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/much-ado-about-nothing-globe.json
+++ b/db-seeding/seeds/productions/much-ado-about-nothing-globe.json
@@ -159,5 +159,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2012/jun/05/much-ado-about-nothing-french",
+			"date": "2012-06-05",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Chris Michael"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/much-ado-about-nothing-swan-rsc.json
+++ b/db-seeding/seeds/productions/much-ado-about-nothing-swan-rsc.json
@@ -287,5 +287,67 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2006/may/19/theatre.rsc",
+			"date": "2006-05-19",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/3652588/Bursting-with-life-wit-and-feeling.html",
+			"date": "2006-05-22",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/c5dfde64-e9b0-11da-a33b-0000779e2340",
+			"date": "2006-05-22",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alastair Macauley"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/much-ado-about-nothing-swan-theatre-julius-caesar-royal-shakespeare-theatre-stratforduponavon-479672.html",
+			"date": "2006-05-25",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/twelfth-night-lowry-salfordantony-and-cleopatra-swan-stratford-much-ado-about-nothing-swan-stratford-480115.html",
+			"date": "2006-05-28",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2006/may/28/theatre1",
+			"date": "2006-05-28",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Kate Kellaway"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/no-mans-land-duke-of-yorks.json
+++ b/db-seeding/seeds/productions/no-mans-land-duke-of-yorks.json
@@ -113,5 +113,57 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.dailymail.co.uk/tvshowbiz/reviews/article-1076034/No-Mans-Land-Even-great-Gambon-save-Pinter-stinker.html",
+			"date": "2008-10-09",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Quentin Letts"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/3561818/Review-No-Mans-Land.html",
+			"date": "2008-10-08",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2008/oct/08/pinter",
+			"date": "2008-10-08",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/the-norman-conquests-at-the-old-vic-no-mans-land-at-duke-of-yorks-the-sunday-times-reviews-vq6jl8wmnsj",
+			"date": "2008-10-12",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Christopher Hart"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2008/oct/12/theatre",
+			"date": "2008-10-12",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/nothing-like-the-sun-courtyard.json
+++ b/db-seeding/seeds/productions/nothing-like-the-sun-courtyard.json
@@ -191,5 +191,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/music/2007/feb/26/classicalmusicandopera2",
+			"date": "2007-02-26",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Alfred Hickling"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/now-or-later-royal-court-downstairs.json
+++ b/db-seeding/seeds/productions/now-or-later-royal-court-downstairs.json
@@ -135,5 +135,47 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2008/sep/12/theatre1",
+			"date": "2008-09-12",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/first-night-now-or-later-royal-court-london-927096.html",
+			"date": "2008-09-12",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/now-or-later-royal-court-downstairs-londonkicking-a-dead-horse-almeida-londonlipsynch-barbican-london-929563.html",
+			"date": "2008-09-14",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/cf9e5a1e-8406-11dd-bf00-000077b07658",
+			"date": "2008-09-16",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/othello-donmar.json
+++ b/db-seeding/seeds/productions/othello-donmar.json
@@ -200,5 +200,87 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/drama/3669710/Othello-review-Ewan-McGregor-loses-the-plot.html",
+			"date": "2007-12-05",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2007/dec/05/theatre.shakespeare",
+			"date": "2007-12-05",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/othello-donmar-warehouse-londno-763213.html",
+			"date": "2007-12-06",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/eaa770ba-a41a-11dc-a28d-0000779fd2ac",
+			"date": "2007-12-06",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		},
+		{
+			"url": "https://www.express.co.uk/entertainment/theatre/27639/Othello-triumphs-over-a-testy-Iago",
+			"date": "2007-12-07",
+			"publication": {
+				"name": "Daily Express"
+			},
+			"critic": {
+				"name": "Paul Callan"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2007/dec/09/theatre",
+			"date": "2007-12-09",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/curtain-up-on-a-force-too-powerful-even-for-a-jedi-z9jljbpgxv7",
+			"date": "2007-12-09",
+			"publication": {
+				"name": "The Sunday Times"
+			},
+			"critic": {
+				"name": "Christopher Hart"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/othello-donmar-warehouse-londonikrisma-kherol-impempe-yomlingo-young-vic-londongod-in-ruins-soho-london-766054.html",
+			"date": "2007-12-09",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/othello-rst.json
+++ b/db-seeding/seeds/productions/othello-rst.json
@@ -138,5 +138,37 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2006/apr/28/theatre.rsc",
+			"date": "2006-04-28",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/othello-qzmpm87c8cd",
+			"date": "2006-05-01",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Sam Marlowe"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/51c257d0-dac6-11da-aa09-0000779e2340",
+			"date": "2006-04-03",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alastair Macauley"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/othello-the-remix-globe.json
+++ b/db-seeding/seeds/productions/othello-the-remix-globe.json
@@ -89,5 +89,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2012/may/07/othello-review",
+			"date": "2012-05-07",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Kieran Yates"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/parlour-song-almeida.json
+++ b/db-seeding/seeds/productions/parlour-song-almeida.json
@@ -122,5 +122,57 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2009/mar/28/theatre-review-parlour-song",
+			"date": "2009-03-28",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2009/mar/29/priscilla-queen-of-the-desert",
+			"date": "2009-03-29",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/8d4d1e70-1af1-11de-8aa3-0000779fd2ac",
+			"date": "2009-03-29",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/parlour-song-almeida-theatre-london-1656856.html",
+			"date": "2009-03-30",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Michael Coveney"
+			}
+		},
+		{
+			"url": "https://www.express.co.uk/entertainment/theatre/92330/Parlour-Song-Comedy-reveals-dark-side-of-suburbia",
+			"date": "2009-03-31",
+			"publication": {
+				"name": "Daily Express"
+			},
+			"critic": {
+				"name": "Paul Callan"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/peer-gynt-barbican.json
+++ b/db-seeding/seeds/productions/peer-gynt-barbican.json
@@ -171,5 +171,27 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2007/mar/02/theatre",
+			"date": "2007-03-02",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Lyn Gardner"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/3ea984f0-c8e3-11db-9f7b-000b5df10621",
+			"date": "2007-03-04",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/peer-gynt-nt-olivier.json
+++ b/db-seeding/seeds/productions/peer-gynt-nt-olivier.json
@@ -505,5 +505,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2000/nov/15/theatre.artsfeatures",
+			"date": "2000-11-15",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/pericles-globe.json
+++ b/db-seeding/seeds/productions/pericles-globe.json
@@ -194,5 +194,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2012/apr/30/world-shakespeare-festival-shakespeare",
+			"date": "2012-04-30",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Alex Needham"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/pericles-swan.json
+++ b/db-seeding/seeds/productions/pericles-swan.json
@@ -375,5 +375,47 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2006/nov/16/theatre.rsc",
+			"date": "2006-11-16",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/d5873c2e-758b-11db-aea1-0000779e2340",
+			"date": "2006-11-16",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/the-winters-talepericles-krg0frx0z6j",
+			"date": "2006-11-17",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Benedict Nightingale"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/the-winter-s-tale-pericles-swan-theatre-stratforduponavon-424690.html",
+			"date": "2006-11-17",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/plenty-sheffield-theatres-studio.json
+++ b/db-seeding/seeds/productions/plenty-sheffield-theatres-studio.json
@@ -171,5 +171,67 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/8314042/Plenty-Sheffield-Crucible-review.html",
+			"date": "2011-02-09",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2011/feb/09/plenty-review",
+			"date": "2011-02-09",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/plenty-at-crucible-sheffield-zl5kpq67zkw",
+			"date": "2011-02-11",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Sam Marlowe"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/the-children-s-hour-comedy-theatre-londonplenty-crucible-studio-sheffieldthe-heretic-royal-court-downstairs-london-2213032.html",
+			"date": "2011-02-13",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2011/feb/13/childrens-hour-keira-knightley-review",
+			"date": "2011-02-13",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/plenty-crucible-studio-sheffield-2214962.html",
+			"date": "2011-02-15",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Jonathan Brown"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/punk-rock-lyric-hammersmith.json
+++ b/db-seeding/seeds/productions/punk-rock-lyric-hammersmith.json
@@ -160,5 +160,67 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2009/sep/09/punk-rock-review",
+			"date": "2009-09-09",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/b9197be6-9e1f-11de-b0aa-00144feabdc0",
+			"date": "2009-09-10",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		},
+		{
+			"url": "https://www.express.co.uk/entertainment/theatre/126432/Punk-Rock-Lyric-Hammersmith-London",
+			"date": "2009-09-11",
+			"publication": {
+				"name": "Daily Express"
+			},
+			"critic": {
+				"name": "Julie Carpenter"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/punk-rock-lyric-hammersmith-london-2077473.html",
+			"date": "2009-09-13",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Matilda Battersby"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/the-shawl-arcola-londonpunk-rock-lyric-hammersmith-londonkatrina-bargehouse-london-1786337.html",
+			"date": "2009-09-13",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/punk-rock-at-the-lyric-hammersmith-w6-3krchj62lft",
+			"date": "2009-09-13",
+			"publication": {
+				"name": "The Sunday Times"
+			},
+			"critic": {
+				"name": "Christopher Hart"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/racing-demon-sheffield-theatres-crucible.json
+++ b/db-seeding/seeds/productions/racing-demon-sheffield-theatres-crucible.json
@@ -164,5 +164,47 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/regional-shows/8331383/Racing-Demon-Sheffield-Crucible-review.html",
+			"date": "2011-02-17",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/culture/2011/feb/17/racing-demon-review",
+			"date": "2011-02-17",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.dailymail.co.uk/tvshowbiz/reviews/article-1360385/Daniel-Evans-production-David-Hares-Racing-Demon-Crucible-Sheffield-Perhaps-little-sympathy-Devil.html",
+			"date": "2011-02-25",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Patrick Marmion"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/culture/2011/feb/27/racing-demon-hare-review",
+			"date": "2011-02-27",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Clare Brennan"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/rafta-rafta-nt-lyttelton.json
+++ b/db-seeding/seeds/productions/rafta-rafta-nt-lyttelton.json
@@ -159,5 +159,37 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2007/apr/27/theatre2",
+			"date": "2007-04-27",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/drama/3664755/Rafta-Rafta-at-the-National-Theatre-review.html",
+			"date": "2007-04-27",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/5342feea-f733-11db-86b0-000b5df10621",
+			"date": "2007-04-30",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/rain-man-apollo.json
+++ b/db-seeding/seeds/productions/rain-man-apollo.json
@@ -165,5 +165,47 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/first-night-rain-man-apollo-theatre-london-936326.html",
+			"date": "2008-09-20",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2008/sep/20/theatre1",
+			"date": "2008-09-20",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/92b718dc-88bd-11dd-a179-0000779fd18c",
+			"date": "2008-09-22",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2008/sep/28/theatre1",
+			"date": "2008-09-28",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/red-donmar.json
+++ b/db-seeding/seeds/productions/red-donmar.json
@@ -87,5 +87,77 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/theatre-reviews/6767740/Red-at-the-Donmar-Warehouse-review.html",
+			"date": "2009-12-09",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/first-night-red-donmar-warehouse-london-1836780.html",
+			"date": "2009-12-09",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2009/dec/09/theatre-review-red-donmar-warehouse",
+			"date": "2009-12-09",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.express.co.uk/entertainment/theatre/145306/Red-Donmar-Warehouse-London",
+			"date": "2009-12-11",
+			"publication": {
+				"name": "Daily Express"
+			},
+			"critic": {
+				"name": "Paul Callan"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/d868d52c-e515-11de-9a25-00144feab49a",
+			"date": "2009-12-11",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2009/dec/13/red-jack-and-the-beanstalk",
+			"date": "2009-12-13",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/red-at-the-donmar-warehouse-wc2-hlrx8mpc6jr",
+			"date": "2009-12-13",
+			"publication": {
+				"name": "The Sunday Times"
+			},
+			"critic": {
+				"name": "Christopher Hart"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/richard-ii-globe.json
+++ b/db-seeding/seeds/productions/richard-ii-globe.json
@@ -165,5 +165,37 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2012/may/06/richard-ii-ashtar-ramallah-review",
+			"date": "2012-05-06",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Lyn Gardner"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/richard-ii-at-shakespeares-globe-se1-mcxp9j3szg6",
+			"date": "2012-05-07",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Libby Purves"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/b4c19792-9a96-11e1-83bf-00144feabdc0",
+			"date": "2012-05-10",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alexander Gilmour"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/richard-iii-an-arab-tragedy-swan.json
+++ b/db-seeding/seeds/productions/richard-iii-an-arab-tragedy-swan.json
@@ -195,5 +195,37 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/drama/3663182/Putting-the-sheikh-into-Shakespeare.html",
+			"date": "2007-02-15",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Dominic Cavendish"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/43ed090a-bc59-11db-9cbc-0000779e2340",
+			"date": "2007-02-15",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2007/feb/16/theatre1",
+			"date": "2007-02-16",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Brian Logan"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/richard-iii-courtyard.json
+++ b/db-seeding/seeds/productions/richard-iii-courtyard.json
@@ -454,5 +454,47 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2007/jan/24/theatre1",
+			"date": "2007-01-24",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/9bf720ae-abba-11db-a0ed-0000779e2340",
+			"date": "2007-01-24",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alastair Macauley"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/drama/3662739/Truly-nasty-and-thats-a-compliment.html",
+			"date": "2007-01-27",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2007/jan/28/theatre1",
+			"date": "2007-01-28",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Kate Kellaway"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/richard-iii-globe.json
+++ b/db-seeding/seeds/productions/richard-iii-globe.json
@@ -73,5 +73,27 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2012/may/02/richard-iii-review",
+			"date": "2012-05-02",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Andrew Dickson"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/enquirer-the-hub-at-pacific-quay-glasgow-richard-iii-shakespeare-s-globe-london-making-noises-quietly-donmar-london-7717374.html",
+			"date": "2012-05-06",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/rock-n-roll-royal-court-downstairs.json
+++ b/db-seeding/seeds/productions/rock-n-roll-royal-court-downstairs.json
@@ -179,5 +179,77 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2006/jun/15/theatre",
+			"date": "2006-06-15",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/first-night-rock-n-roll-royal-court-london-6098178.html",
+			"date": "2006-06-15",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/rock-n-roll-nt5sh3rx2bg",
+			"date": "2006-06-15",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Benedict Nightingale"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/drama/3653139/More-than-rock-n-roll-and-I-love-it.html",
+			"date": "2006-06-15",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/3653236/Play-revolution-for-me.html",
+			"date": "2006-06-18",
+			"publication": {
+				"name": "The Sunday Telegraph"
+			},
+			"critic": {
+				"name": "Rebecca Tyrrel"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/rock-n-roll-royal-court-downstairs-london-a-voyage-round-my-father-donmar-london-fool-for-love-apollo-shaftesbury-london-8704705.html",
+			"date": "2006-06-18",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2006/jun/18/theatre1",
+			"date": "2006-06-18",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/romeo-and-juliet-globe.json
+++ b/db-seeding/seeds/productions/romeo-and-juliet-globe.json
@@ -157,5 +157,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2012/may/22/romeo-and-juliet-review",
+			"date": "2012-05-22",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Maddy Costa"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/romeo-and-juliet-rst.json
+++ b/db-seeding/seeds/productions/romeo-and-juliet-rst.json
@@ -308,5 +308,37 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2006/apr/19/theatre.rsc",
+			"date": "2006-04-19",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/2f029b20-d08e-11da-b160-0000779e2340",
+			"date": "2006-04-20",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alastair Macauley"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/romeo-and-juliet-rst-stratford-6103054.html",
+			"date": "2006-04-23",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/rope-almeida.json
+++ b/db-seeding/seeds/productions/rope-almeida.json
@@ -150,5 +150,57 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2009/dec/17/michael-billington-rope-almeida",
+			"date": "2009-12-17",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2009/dec/20/keira-knightley-misanthrope-rope-almeida",
+			"date": "2009-12-20",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/the-misanthrope-comedy-londonrope-almeida-londonthe-cat-in-the-hat-national-young-vic-london-1845567.html",
+			"date": "2009-12-20",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/767352de-ebff-11de-8070-00144feab49a",
+			"date": "2009-12-20",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/theatre-reviews/6875002/Rope-Almeida-Theatre-review.html",
+			"date": "2012-12-23",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/rosencrantz-and-guildenstern-are-dead-cft.json
+++ b/db-seeding/seeds/productions/rosencrantz-and-guildenstern-are-dead-cft.json
@@ -277,5 +277,57 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2011/jun/01/rosencrantz-guildernstern-dead-review",
+			"date": "2011-06-01",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/rosencrantz-and-guildenstern-are-dead-at-the-chichester-festival-theatre-399qwmpjtfp",
+			"date": "2011-06-01",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Libby Purves"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/rosencrantz-and-guildenstern-are-dead-chichester-festival-theatre-2292355.html",
+			"date": "2011-06-03",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Michael Coveney"
+			}
+		},
+		{
+			"url": "https://www.dailymail.co.uk/tvshowbiz/reviews/article-1393647/Rosencratz-Guildenstern-Are-Dead-This-play-wit-lacks-wonder-Shakespeare.html",
+			"date": "2011-06-02",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Quentin Letts"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/much-ado-about-nothing-wyndham-s-londonmuch-ado-about-nothing-shakespeare-s-globe-londonrosencrantz-and-guildenstern-are-dead-festival-theatre-chichester-2293003.html",
+			"date": "201-06-05",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/rosencrantz-and-guildenstern-are-dead-old-vic.json
+++ b/db-seeding/seeds/productions/rosencrantz-and-guildenstern-are-dead-old-vic.json
@@ -200,5 +200,77 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.telegraph.co.uk/theatre/what-to-see/daniel-radcliffe-rosencrantz-guildenstern-dead-old-vic-review/",
+			"date": "2017-03-08",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Dominic Cavendish"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/theatre-rosencrantz-and-guildenstern-are-dead-the-old-vic-se1-09clqlh2c",
+			"date": "2017-03-08",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Ann Treneman"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2017/mar/08/rosencrantz-and-guildenstern-are-dead-review-daniel-radcliffe-stoppard-old-vic-london",
+			"date": "2017-03-08",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/rosencrantz-and-guildenstern-are-dead-review-old-vic-daniel-radcliffe-david-leveaux-joshua-mcguire-david-haig-tom-stoppard-a7618096.html",
+			"date": "2017-03-08",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.dailymail.co.uk/tvshowbiz/article-4291830/Quentin-Letts-review-Rosencrantz-Guildenstern-Dead.html",
+			"date": "2017-03-08",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Quentin Letts"
+			}
+		},
+		{
+			"url": "https://ft.com/content/e3a2b158-03e7-11e7-aa5b-6bb07f5c8e12",
+			"date": "2017-03-08",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		},
+		{
+			"url": "https://www.standard.co.uk/culture/theatre/rosencrantz-and-guildenstern-are-dead-theatre-review-daniel-radcliffe-excels-at-this-game-of-intellectual-ping-pong-a3680216.html",
+			"date": "2017-03-08",
+			"publication": {
+				"name": "Evening Standard"
+			},
+			"critic": {
+				"name": "Henry Hitchings"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/rosencrantz-and-guildenstern-are-dead-tr-haymarket.json
+++ b/db-seeding/seeds/productions/rosencrantz-and-guildenstern-are-dead-tr-haymarket.json
@@ -277,5 +277,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2011/jun/25/emperor-galilean-rosencrantz-guildenstern-takeaway",
+			"date": "2011-06-25",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/saint-joan-nt-olivier.json
+++ b/db-seeding/seeds/productions/saint-joan-nt-olivier.json
@@ -275,5 +275,67 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2007/jul/12/theatre2",
+			"date": "2007-07-12",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/saint-joan-3svglxm80vm",
+			"date": "2007-07-12",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Benedict Nightingale"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/drama/3666497/St-Joan-is-topical-fresh-and-deeply-moving-are-you-Shaw.html",
+			"date": "2007-07-12",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.express.co.uk/entertainment/theatre/13242/Saint-Joan",
+			"date": "2007-07-13",
+			"publication": {
+				"name": "Daily Express"
+			},
+			"critic": {
+				"name": "Julie Carpenter"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/cf33df4c-30e5-11dc-9a81-0000779fd2ac",
+			"date": "2007-07-13",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2007/jul/15/theatre1",
+			"date": "2007-07-15",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/seize-the-day-tricycle.json
+++ b/db-seeding/seeds/productions/seize-the-day-tricycle.json
@@ -172,5 +172,37 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2009/nov/03/seize-the-day-review",
+			"date": "2009-11-03",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/seize-the-day-tricycle-theatre-london-1814137.html",
+			"date": "2009-12-04",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Michael Coveney"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/4bc7acf6-ca62-11de-a3a3-00144feabdc0",
+			"date": "2009-11-06",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/sixty-six-books-69-collection-bush.json
+++ b/db-seeding/seeds/productions/sixty-six-books-69-collection-bush.json
@@ -181,5 +181,67 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.thetimes.co.uk/article/sixty-six-books-at-the-bush-london-v2wq67hzzrf",
+			"date": "2011-10-16",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Ruth Gledhill"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2011/oct/16/sixty-six-books-review",
+			"date": "2011-10-16",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/theatre-reviews/8832518/Sixty-Six-Books-Bush-Theatre-London-review.html",
+			"date": "2011-10-17",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/8c33109a-f8bf-11e0-ad8f-00144feab49a",
+			"date": "2011-10-17",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/sixtysix-books-bush-theatre-london-2373067.html",
+			"date": "2011-10-22",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2011/oct/23/jumpy-inadmissible-sixty-six-review",
+			"date": "2011-10-23",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/soundclash-nt-shed.json
+++ b/db-seeding/seeds/productions/soundclash-nt-shed.json
@@ -223,5 +223,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.ft.com/content/7992caa6-e946-11e2-9f11-00144feabdc0",
+			"date": "2013-07-12",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alexander Gilmour"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/that-face-duke-of-yorks.json
+++ b/db-seeding/seeds/productions/that-face-duke-of-yorks.json
@@ -138,5 +138,67 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/drama/3673321/That-Face-into-the-West-End-raw-power-intact.html",
+			"date": "2008-05-12",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2008/may/12/theatre1",
+			"date": "2008-05-13",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/that-face-at-the-duke-of-yorks-theatre-wc2-g5drld8l23w",
+			"date": "2008-05-12",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Benedict Nightingale"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/e3e0c7cc-2043-11dd-80b4-000077b07658",
+			"date": "2008-05-12",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2008/may/18/theatre",
+			"date": "2008-05-18",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Killian Fox"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/that-face-duke-of-yorks-the-sunday-times-review-hbcbm5v6z2g",
+			"date": "2008-05-18",
+			"publication": {
+				"name": "The Sunday Times"
+			},
+			"critic": {
+				"name": "Christopher Hart"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/that-face-royal-court-upstairs.json
+++ b/db-seeding/seeds/productions/that-face-royal-court-upstairs.json
@@ -127,5 +127,47 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.ft.com/content/76a6b7ba-f34a-11db-9845-000b5df10621",
+			"date": "2007-04-25",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2007/apr/26/theatre3",
+			"date": "2007-04-26",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Lyn Gardner"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/drama/3664728/One-of-the-most-thrilling-debuts-for-decades.html",
+			"date": "2007-04-26",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2007/may/06/theatre1",
+			"date": "2007-05-06",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-bomb-14-collection-tricycle.json
+++ b/db-seeding/seeds/productions/the-bomb-14-collection-tricycle.json
@@ -271,5 +271,47 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2012/feb/21/the-bomb-review",
+			"date": "2012-02-21",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/theatre-reviews/9096699/The-Bomb-Tricycle-Theatre-review.html",
+			"date": "2012-02-21",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/cb6fbd26-5c92-11e1-911f-00144feabdc0",
+			"date": "2012-02-22",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		},
+		{
+			"url": "https://www.dailymail.co.uk/tvshowbiz/article-2105544/The-Bomb-theatre-review-Political-theatre-thats-going-big-bang.html",
+			"date": "2012-02-23",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Patrick Marmion"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-breath-of-life-sheffield-theatres-lyceum.json
+++ b/db-seeding/seeds/productions/the-breath-of-life-sheffield-theatres-lyceum.json
@@ -81,5 +81,47 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/theatre-reviews/8341120/The-Breath-of-Life-Sheffield-Lyceum-review.html",
+			"date": "2011-02-22",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Dominic Cavendish"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/the-breath-of-life-at-the-lyceum-sheffield-9m75b9rbc0l",
+			"date": "2011-02-23",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Dominic Maxwell"
+			}
+		},
+		{
+			"url": "https://www.express.co.uk/entertainment/theatre/231057/Theatre-review-Breath-of-life-The-Lyceum-Sheffield",
+			"date": "2011-02-25",
+			"publication": {
+				"name": "Daily Express"
+			},
+			"critic": {
+				"name": "Neil Norman"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2011/feb/24/the-breath-of-life-review",
+			"date": "2011-02-24",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Lyn Gardner"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-chalk-garden-donmar.json
+++ b/db-seeding/seeds/productions/the-chalk-garden-donmar.json
@@ -143,5 +143,37 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2008/jun/12/theatre1",
+			"date": "2008-06-12",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/the-chalk-garden-donmar-warehouse-london-846196.html",
+			"date": "2008-06-13",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/drama/3554230/The-Chalk-Garden-fertile-ground-for-wit-and-wisdom.html",
+			"date": "2008-06-13",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-coast-of-utopia-4-collection-nt-olivier.json
+++ b/db-seeding/seeds/productions/the-coast-of-utopia-4-collection-nt-olivier.json
@@ -19,5 +19,57 @@
 		{
 			"uuid": "26860468-0c27-4fc0-99d5-de86d4b44239"
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/news/stoppard-s-magnificent-spectacle-just-the-five-hours-too-long-172180.html",
+			"date": "2002-08-05",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2002/aug/05/theatre.artsfeatures",
+			"date": "2002-08-05",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/drama/3581055/Excellent-in-parts-but-less-than-Utopian.html",
+			"date": "2002-08-05",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/the-coast-of-utopia-nt-olivier-london-on-an-average-day-comedy-london-173094.html",
+			"date": "2002-08-11",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/theobserver/2002/aug/11/artsfeatures",
+			"date": "2002-08-11",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-comedy-of-errors-globe.json
+++ b/db-seeding/seeds/productions/the-comedy-of-errors-globe.json
@@ -95,5 +95,27 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.ft.com/content/cba68df6-ab11-11e1-b675-00144feabdc0",
+			"date": "2012-06-02",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Griselda Murray Brown"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2012/jun/07/comedy-of-errors-shakespeares-globe",
+			"date": "2012-06-07",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Andrew Dickson"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-dark-philosophers-riverfront.json
+++ b/db-seeding/seeds/productions/the-dark-philosophers-riverfront.json
@@ -98,5 +98,27 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2010/nov/14/the-dark-philosophers-review",
+			"date": "2010-11-14",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Lyn Gardner"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/the-dark-philosophers-at-the-riverfront-newport-fhknz6tflpk",
+			"date": "2010-11-16",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Donald Hutera"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-dumb-waiter-trafalgar-studio-1.json
+++ b/db-seeding/seeds/productions/the-dumb-waiter-trafalgar-studio-1.json
@@ -71,5 +71,67 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/the-dumb-waiter-trafalgar-studios-london-436003.html",
+			"date": "2007-02-09",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Rhoda Koenig"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/arts/theatre/drama/reviews/story/0,,2009375,00.html",
+			"date": "2007-02-09",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/drama/3663038/Short-sharp-lesson-from-Pinter-master.html",
+			"date": "2007-02-09",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/rest-of-the-weeks-theatre-7x8q7s3ctpq",
+			"date": "2007-02-11",
+			"publication": {
+				"name": "The Sunday Times"
+			},
+			"critic": {
+				"name": "Christopher Hart"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/the-man-of-mode-nt-olivier-london-the-dumb-waiter-trafalgar-studios-london-nothing-but-the-truth-hampstead-london-6228912.html",
+			"date": "2007-02-11",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2007/feb/11/theatre",
+			"date": "2007-02-11",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-female-of-the-species-vaudeville.json
+++ b/db-seeding/seeds/productions/the-female-of-the-species-vaudeville.json
@@ -136,5 +136,47 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2008/jul/17/theatre.reviews2",
+			"date": "2008-07-17",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/the-female-of-the-species-vaudeville-theatre-london-870725.html",
+			"date": "2008-07-18",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Rhoda Koenig"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/the-female-of-the-species-the-sunday-times-review-27fjf7s28tp",
+			"date": "2008-07-20",
+			"publication": {
+				"name": "The Sunday Times"
+			},
+			"critic": {
+				"name": "Christopher Hart"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/be04377e-572e-11dd-916c-000077b07658",
+			"date": "2008-07-21",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-girl-on-the-train-duke-of-yorks.json
+++ b/db-seeding/seeds/productions/the-girl-on-the-train-duke-of-yorks.json
@@ -154,5 +154,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.standard.co.uk/culture/theatre/the-girl-on-the-train-review-clumsy-and-mechanical-thriller-goes-off-the-rails-a4202051.html",
+			"date": "2019-07-31",
+			"publication": {
+				"name": "Evening Standard"
+			},
+			"critic": {
+				"name": "Nick Curtis"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-great-game-16-collection-tricycle.json
+++ b/db-seeding/seeds/productions/the-great-game-16-collection-tricycle.json
@@ -148,5 +148,67 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2009/apr/25/tricycle-theatre-great-game-afghanistan",
+			"date": "2009-04-25",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2009/apr/26/great-game-tricycle-season",
+			"date": "2009-04-26",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/the-great-game-afghanistan-tricycle-theatre-london-1675070.html",
+			"date": "2009-04-28",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Michael Coveney"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/c883f546-333c-11de-8f1b-00144feabdc0",
+			"date": "2009-04-27",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		},
+		{
+			"url": "https://www.express.co.uk/entertainment/theatre/98598/The-Great-Game",
+			"date": "2009-05-03",
+			"publication": {
+				"name": "Sunday Express"
+			},
+			"critic": {
+				"name": "Mark Shenton"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/rookery-nook-menier-chocolate-factory-londonwuthering-heights-lyric-hammersmith-londonthe-great-game-afghanistan-tricycle-london-1677827.html",
+			"date": "2009-05-03",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-guffin-nt-shed.json
+++ b/db-seeding/seeds/productions/the-guffin-nt-shed.json
@@ -161,5 +161,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.ft.com/content/7992caa6-e946-11e2-9f11-00144feabdc0",
+			"date": "2013-07-12",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alexander Gilmour"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-indian-boy-rst-cube.json
+++ b/db-seeding/seeds/productions/the-indian-boy-rst-cube.json
@@ -153,5 +153,37 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2006/nov/12/rsc.theatre",
+			"date": "2006-11-12",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Kate Kellaway"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/the-indian-boy-pf69zspvllc",
+			"date": "2006-11-13",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Sam Marlowe"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/e02f0610-73f7-11db-8dd7-0000779e2340",
+			"date": "2006-11-14",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-ladykillers-gielgud.json
+++ b/db-seeding/seeds/productions/the-ladykillers-gielgud.json
@@ -173,5 +173,67 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2011/dec/08/the-ladykillers-review-michael-billington",
+			"date": "2011-12-08",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/theatre-reviews/8941353/The-Ladykillers-Gielgud-Theatre-review.html",
+			"date": "2011-12-08",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.dailymail.co.uk/tvshowbiz/reviews/article-2071885/Ladykillers-review-Killer-comedy-stage--dead-funny.html",
+			"date": "2011-12-09",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Quentin Letts"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2011/dec/11/richard-ii-company-ladykillers-review",
+			"date": "2011-12-11",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/richard-ii-donmar-warehouse-london-company-crucible-sheffield-the-ladykillers-gielgud-london-6275248.html",
+			"date": "2011-12-11",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.thejc.com/life-and-culture/theatre/review-the-ladykillers-ww0jcuwj",
+			"date": "2011-12-15",
+			"publication": {
+				"name": "The Jewish Chronicle"
+			},
+			"critic": {
+				"name": "John Nathan"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-letter-wyndhams.json
+++ b/db-seeding/seeds/productions/the-letter-wyndhams.json
@@ -175,5 +175,27 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2007/may/02/theatre2",
+			"date": "2007-05-02",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/096d6136-fa33-11db-8bd0-000b5df10621",
+			"date": "2007-05-04",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-life-and-adventures-of-nicholas-nickleby-cft-festival-3-collection.json
+++ b/db-seeding/seeds/productions/the-life-and-adventures-of-nicholas-nickleby-cft-festival-3-collection.json
@@ -492,5 +492,57 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2006/jul/22/theatre",
+			"date": "2006-07-22",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/1bea3cbe-1a62-11db-848c-0000779e2340",
+			"date": "2006-07-23",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/nicholas-nickleby-j76ncgcmfq9",
+			"date": "2006-07-24",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Benedict Nightingale"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/nicholas-nickleby-festival-theatre-chichestertonight-at-8-30-minerva-chichesterthe-last-five-years-menier-chocolate-factory-london-409919.html",
+			"date": "2006-07-30",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/theatre-not-for-the-faint-hearted-s6p6ld2fjw0",
+			"date": "2006-07-30",
+			"publication": {
+				"name": "The Sunday Times"
+			},
+			"critic": {
+				"name": "A A Gill"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-life-and-adventures-of-nicholas-nickleby-gielgud-3-collection.json
+++ b/db-seeding/seeds/productions/the-life-and-adventures-of-nicholas-nickleby-gielgud-3-collection.json
@@ -539,5 +539,27 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2007/dec/10/theatre.pantoseason",
+			"date": "2007-12-10",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Lyn Gardner"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/nicholas-nickleby-gielgud-theatre-london-764284.html",
+			"date": "2007-12-11",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Rhoda Koenig"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-merchant-of-venice-globe.json
+++ b/db-seeding/seeds/productions/the-merchant-of-venice-globe.json
@@ -173,5 +173,57 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.standard.co.uk/culture/theatre/the-merchant-of-venice-shakespeares-globe-review-7799799.html",
+			"date": "2012-05-29",
+			"publication": {
+				"name": "Evening Standard"
+			},
+			"critic": {
+				"name": "Fiona Mountford"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2012/may/29/merchant-of-venice-review",
+			"date": "2012-05-29",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Lyn Gardner"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/the-drama-s-outside-protests-target-israeli-take-on-shakespeare-7799885.html",
+			"date": "2012-05-12",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.thejc.com/life-and-culture/theatre/review-habimas-bravura-merchant-of-venice-yfvgzklo",
+			"date": "2012-06-01",
+			"publication": {
+				"name": "The Jewish Chronicle"
+			},
+			"critic": {
+				"name": "John Nathan"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/cba68df6-ab11-11e1-b675-00144feabdc0",
+			"date": "2012-06-02",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Eleanor Turney"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-merchant-of-venice-swan.json
+++ b/db-seeding/seeds/productions/the-merchant-of-venice-swan.json
@@ -201,5 +201,37 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.ft.com/content/f6d94472-dd4a-11db-8d42-000b5df10621",
+			"date": "2007-03-28",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2007/mar/29/theatre",
+			"date": "2007-03-29",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/the-rose-tattoo-nt-olivier-london-the-merchant-of-venice-swan-stratford-5332600.html",
+			"date": "2007-04-01",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-merry-wives-of-windsor-globe.json
+++ b/db-seeding/seeds/productions/the-merry-wives-of-windsor-globe.json
@@ -99,5 +99,27 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2012/apr/27/merry-wives-of-windsor-review",
+			"date": "2012-04-27",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Andrew Gilchrist"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2012/apr/29/merry-wives-windsor-globe-review",
+			"date": "2012-04-29",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Robert McCrum"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-mountaintop-theatre503.json
+++ b/db-seeding/seeds/productions/the-mountaintop-theatre503.json
@@ -102,5 +102,57 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.ft.com/content/59c4063e-59c3-11de-b687-00144feabdc0",
+			"date": "2009-06-15",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/the-mountaintop-theatre-503-london-1705910.html",
+			"date": "2009-06-16",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Nicola Christie"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2009/jun/17/mountaintop-theatre-review-london",
+			"date": "2009-06-17",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Lyn Gardner"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/been-so-long-young-vic-londonthe-mountaintop-theatre-503-battersea-londonthe-beautiful-journey-south-yard-naval-dockyard-plymouth-1711231.html",
+			"date": "2009-06-21",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/theatre-reviews/5601878/The-Mountaintop-Theatre503-review.html",
+			"date": "2009-06-22",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Dominic Cavendish"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-mountaintop-trafalgar-studio-1.json
+++ b/db-seeding/seeds/productions/the-mountaintop-trafalgar-studio-1.json
@@ -103,5 +103,27 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/the-mountaintop-trafalgar-studios-london-1757394.html",
+			"date": "2009-07-23",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Michael Coveney"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2009/jul/26/the-mountaintop-trafalgar-studios",
+			"date": "2009-07-26",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Vanessa Thorpe"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-pitmen-painters-nt-cottesloe.json
+++ b/db-seeding/seeds/productions/the-pitmen-painters-nt-cottesloe.json
@@ -127,5 +127,67 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2008/may/22/theatre",
+			"date": "2008-05-22",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/first-night-the-pitmen-painters-cottesloe-national-theatre-london-832252.html",
+			"date": "2008-05-22",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.dailymail.co.uk/tvshowbiz/reviews/article-1021309/The-Pitmen-Painters-A-minor-triumph-follow-Billy-Elliot.html",
+			"date": "2008-05-11",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Quentin Letts"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2008/may/25/theatre",
+			"date": "2008-05-25",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/marguerite-theatre-royal-haymarket-londonthe-long-road-soho-theatre-londonthe-pitman-painters-cottesloe-london-833849.html",
+			"date": "2008-05-25",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/the-pitmen-painters-0hrjwkjg3lz",
+			"date": "2008-06-01",
+			"publication": {
+				"name": "The Sunday Times"
+			},
+			"critic": {
+				"name": "Emma Smith"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-priory-royal-court-downstairs.json
+++ b/db-seeding/seeds/productions/the-priory-royal-court-downstairs.json
@@ -143,5 +143,47 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2009/nov/27/play-the-priory-review",
+			"date": "2009-11-27",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/nation-national-theatre-londonthe-line-arcola-londonthe-priory-royal-court-london-1830348.html",
+			"date": "2009-11-29",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://ft.com/content/924e70fe-db76-11de-9424-00144feabdc0",
+			"date": "2009-11-29",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/the-priory-royal-court-london-1831619.html",
+			"date": "2009-12-01",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-reporter-nt-cottesloe.json
+++ b/db-seeding/seeds/productions/the-reporter-nt-cottesloe.json
@@ -178,5 +178,37 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2007/feb/22/theatre1",
+			"date": "2007-02-22",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/b4d3d9cc-c2a4-11db-9e1c-000b5df10621",
+			"date": "2007-02-22",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/3663357/Haunting-portrait-of-a-mysterious-life.html",
+			"date": "2007-02-23",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-seagull-nuffield.json
+++ b/db-seeding/seeds/productions/the-seagull-nuffield.json
@@ -157,5 +157,47 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.ft.com/content/d60dd9ac-a746-11e2-9fbe-00144feabdc0",
+			"date": "2013-04-17",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2013/apr/21/seagull-blanche-mcintyre-review",
+			"date": "2013-04-21",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/theatre-reviews/10004140/The-Seagull-Nuffield-Theatre-Southamptontouring-review.html",
+			"date": "2013-04-18",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Matt Trueman"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2013/apr/21/the-seagull-review",
+			"date": "2013-04-21",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Lyn Gardner"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-seagull-royal-court-downstairs.json
+++ b/db-seeding/seeds/productions/the-seagull-royal-court-downstairs.json
@@ -176,5 +176,87 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/first-night-the-seagull-royal-court-theatre-london-433747.html",
+			"date": "2007-01-26",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/3662753/Leaving-Court-free-as-a-bird.html",
+			"date": "2007-01-26",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2007/jan/26/theatre1",
+			"date": "2007-01-26",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.express.co.uk/entertainment/theatre/637/Seagull-soars-to-success",
+			"date": "2007-01-26",
+			"publication": {
+				"name": "Daily Express"
+			},
+			"critic": {
+				"name": "Paul Callan"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/the-seagull-royal-court-londoncomfort-me-with-apples-hampstead-london-and-touring-happy-days-nt-lyttelton-london-434029.html",
+			"date": "2007-01-28",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2007/jan/28/theatre2",
+			"date": "2007-01-28",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/a-bird-thats-on-song-gn53d2ddfg8",
+			"date": "2007-01-28",
+			"publication": {
+				"name": "The Sunday Times"
+			},
+			"critic": {
+				"name": "Christopher Hart"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/198864ca-afac-11db-94ab-0000779e2340",
+			"date": "2007-01-29",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alastair Macauley"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-taming-of-the-shrew-globe.json
+++ b/db-seeding/seeds/productions/the-taming-of-the-shrew-globe.json
@@ -163,5 +163,27 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2012/may/30/taming-of-the-shrew-review",
+			"date": "2012-05-30",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Nosheen Iqbal"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/cba68df6-ab11-11e1-b675-00144feabdc0",
+			"date": "2012-06-02",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alexander Gilmour"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-tempest-globe.json
+++ b/db-seeding/seeds/productions/the-tempest-globe.json
@@ -155,5 +155,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2012/may/08/the-tempest-review",
+			"date": "2012-05-08",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Imogen Tilden"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-tempest-rst.json
+++ b/db-seeding/seeds/productions/the-tempest-rst.json
@@ -274,5 +274,47 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/first-night-the-tempest-royal-shakespeare-theatre-stratforduponavon-411147.html",
+			"date": "2006-08-09",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/293eef2c-27c3-11db-b25c-0000779e2340",
+			"date": "2006-08-09",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alastair Macauley"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2006/aug/10/theatre.rsc",
+			"date": "2006-08-10",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/the-tempest-royal-shakespeare-theatre-stratford-henry-vi-parts-13-courtyard-stratford-411700.html",
+			"date": "2006-08-13",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-two-gentlemen-of-verona-globe.json
+++ b/db-seeding/seeds/productions/the-two-gentlemen-of-verona-globe.json
@@ -39,5 +39,27 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.ft.com/content/b4c19792-9a96-11e1-83bf-00144feabdc0",
+			"date": "2012-05-10",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alexander Gilmour"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2012/may/14/the-two-gentlemen-of-verona-review",
+			"date": "2012-05-14",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Alex Needham"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-winters-tale-globe.json
+++ b/db-seeding/seeds/productions/the-winters-tale-globe.json
@@ -172,5 +172,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2012/may/30/the-winters-tale-review",
+			"date": "2012-05-20",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Imogen Tilden"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/the-winters-tale-swan.json
+++ b/db-seeding/seeds/productions/the-winters-tale-swan.json
@@ -316,5 +316,47 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2006/nov/16/theatre.rsc",
+			"date": "2006-11-16",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/d5873c2e-758b-11db-aea1-0000779e2340",
+			"date": "2006-11-16",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/the-winters-talepericles-krg0frx0z6j",
+			"date": "2006-11-17",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Benedict Nightingale"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/the-winter-s-tale-pericles-swan-theatre-stratforduponavon-424690.html",
+			"date": "2006-11-17",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/three-days-of-rain-apollo.json
+++ b/db-seeding/seeds/productions/three-days-of-rain-apollo.json
@@ -149,5 +149,87 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.thetimes.co.uk/article/three-days-of-rain-at-the-apollo-vlnnqz5069c",
+			"date": "2009-02-11",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Benedict Nightingale"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2009/feb/11/theatre",
+			"date": "2009-02-11",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/three-days-of-rain-apollo-theatre-london-1607054.html",
+			"date": "2009-02-12",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Michael Coveney"
+			}
+		},
+		{
+			"url": "https://www.dailymail.co.uk/tvshowbiz/reviews/article-1144032/Three-Days-Of-Rain-I-wish-rain-stopped-dreary-play.html",
+			"date": "2009-02-12",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Quentin Letts"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/69ef67be-f925-11dd-ab7f-000077b07658",
+			"date": "2009-02-12",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2009/feb/15/theatre",
+			"date": "2009-02-15",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/three-days-of-rain-at-the-apollo-w1-jjg6nlnptk6",
+			"date": "2009-02-15",
+			"publication": {
+				"name": "The Sunday Times"
+			},
+			"critic": {
+				"name": "Christopher Hart"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/three-days-of-rain-apollo-theatre-londonthe-stone-royal-court-downstairs-londonengland-people-very-nice-nt-olivier-london-1622127.html",
+			"date": "2009-02-15",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/three-sisters-nt-lyttelton.json
+++ b/db-seeding/seeds/productions/three-sisters-nt-lyttelton.json
@@ -468,5 +468,57 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.telegraph.co.uk/theatre/what-to-see/three-sisters-national-theatre-review-proof-inua-ellams-one/",
+			"date": "2019-12-11",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Dominic Cavendish"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2019/dec/11/three-sisters-review-inua-ellams-chekhov-lyttelton-theatre-london",
+			"date": "2011-12-11",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.standard.co.uk/culture/theatre/three-sisters-review-chekhov-finds-compelling-home-in-nigeria-a4310426.html",
+			"date": "2011-12-11",
+			"publication": {
+				"name": "Evening Standard"
+			},
+			"critic": {
+				"name": "Nick Curtis"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/9c4515ea-1cde-11ea-97df-cc63de1d73f4",
+			"date": "2011-12-12",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/theatre-review-three-sisters-lyttelton-theatre-national-cyrano-de-bergerac-playhouse-8blm6bf37",
+			"date": "2011-12-15",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Quentin Letts"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/three-sisters-young-vic-main-house.json
+++ b/db-seeding/seeds/productions/three-sisters-young-vic-main-house.json
@@ -211,5 +211,127 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.standard.co.uk/culture/theatre/three-sisters-young-vic-review-8139513.html",
+			"date": "2012-09-14",
+			"publication": {
+				"name": "Evening Standard"
+			},
+			"critic": {
+				"name": "Henry Hitchings"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/three-sisters-at-the-young-vic-rtkcbwlb8tr",
+			"date": "2012-09-14",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Dominic Maxwell"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/three-sisters-young-vic-london-8139210.html",
+			"date": "2012-09-14",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2012/sep/14/three-sisters-review",
+			"date": "2012-09-14",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/theatre-reviews/9547946/Three-Sisters-Young-Vic-review.html",
+			"date": "2012-09-16",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Dominic Cavendish"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/afd9b7c6-fe70-11e1-8028-00144feabdc0",
+			"date": "2012-09-17",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		},
+		{
+			"url": "https://www.dailymail.co.uk/tvshowbiz/reviews/article-2206359/The-Chekhov-rulebook-ripped-apart-Three-Sisters.html",
+			"date": "2012-09-20",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Patrick Marmion"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/theatre-reviews/9570865/Three-Sisters-at-Young-Vic-Seven-magazine-review.html",
+			"date": "2012-09-23",
+			"publication": {
+				"name": "The Sunday Telegraph"
+			},
+			"critic": {
+				"name": "Tim Auld"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2012/sep/23/love-information-three-sisters-steptoe",
+			"date": "2012-09-23",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/also-showing-sept-23-kxq8pz8mln0",
+			"date": "2012-09-23",
+			"publication": {
+				"name": "The Sunday Times"
+			},
+			"critic": {
+				"name": "David Jays"
+			}
+		},
+		{
+			"url": "https://www.thejc.com/life-and-culture/theatre/review-three-sisters-its-a-russian-revolution-as-chekhov-is-modernised-pim6p7w8",
+			"date": "2012-09-27",
+			"publication": {
+				"name": "The Jewish Chronicle"
+			},
+			"critic": {
+				"name": "John Nathan"
+			}
+		},
+		{
+			"url": "https://www.express.co.uk/entertainment/theatre/349045/Theatre-review-The-Judas-Kiss-Three-Sisters-Jesus-Christ-Superstar-and-Let-It-Be",
+			"date": "2012-09-30",
+			"publication": {
+				"name": "Sunday Express"
+			},
+			"critic": {
+				"name": "Mark Shenton"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/timon-of-athens-globe.json
+++ b/db-seeding/seeds/productions/timon-of-athens-globe.json
@@ -90,5 +90,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2012/jun/06/timon-of-athens-review",
+			"date": "2012-06-12",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Peter Beech"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/timon-of-athens-shakespeare-centre.json
+++ b/db-seeding/seeds/productions/timon-of-athens-shakespeare-centre.json
@@ -223,5 +223,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2006/oct/28/theatre",
+			"date": "2006-10-28",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/titus-andronicus-globe-2006.json
+++ b/db-seeding/seeds/productions/titus-andronicus-globe-2006.json
@@ -295,5 +295,77 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/first-night-tutus-andronicus-shakespeare-s-globe-london-480477.html",
+			"date": "2006-05-31",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/049e5524-f0c1-11da-9338-0000779e2340",
+			"date": "2006-05-31",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alastair Macauley"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2006/jun/01/theatre2",
+			"date": "2006-06-01",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/titus-andronicus-0pvhbx7kg75",
+			"date": "2006-06-01",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Sam Marlowe"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/drama/3652794/The-horror-endures.html",
+			"date": "2006-06-01",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/titus-andronicus-globe-london-sit-and-shiver-new-end-london-hear-and-now-gate-london-8684776.html",
+			"date": "2006-06-04",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2006/jun/04/theatre",
+			"date": "2006-06-04",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/titus-andronicus-globe-2012.json
+++ b/db-seeding/seeds/productions/titus-andronicus-globe-2012.json
@@ -176,5 +176,27 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.ft.com/content/6930e45e-9514-11e1-ad72-00144feab49a",
+			"date": "2012-05-03",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alexander Gilmour"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2012/may/10/titus-andronicus-shakespeares-globe-review",
+			"date": "2012-05-10",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Andrew Dickson"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/titus-andronicus-rst.json
+++ b/db-seeding/seeds/productions/titus-andronicus-rst.json
@@ -511,5 +511,57 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/titus-andronicus-royal-shakespeare-theatre-stratforduponavon-6097503.html",
+			"date": "2006-06-22",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2006/jun/22/theatre.rsc",
+			"date": "2006-06-22",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/drama/3653287/The-good-taste-gorefest.html",
+			"date": "2006-06-22",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/titus-andronicus-rst-stratfordjeffrey-bernard-is-unwell-garrick-londonwoman-and-scarecrow-royal-court-upstairs-london-6097234.html",
+			"date": "2006-06-25",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/3653392/Tongueless-in-Stratford.html",
+			"date": "2006-06-25",
+			"publication": {
+				"name": "The Sunday Times"
+			},
+			"critic": {
+				"name": "Rebecca Tyrrel"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/tomorrow-ill-be-happy-nt-shed.json
+++ b/db-seeding/seeds/productions/tomorrow-ill-be-happy-nt-shed.json
@@ -151,5 +151,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.ft.com/content/7992caa6-e946-11e2-9f11-00144feabdc0",
+			"date": "2013-07-12",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alexander Gilmour"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/tonight-at-8-30-cft-minerva-9-collection.json
+++ b/db-seeding/seeds/productions/tonight-at-8-30-cft-minerva-9-collection.json
@@ -101,5 +101,27 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/nicholas-nickleby-festival-theatre-chichestertonight-at-8-30-minerva-chichesterthe-last-five-years-menier-chocolate-factory-london-409919.html",
+			"date": "2006-07-30",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/80159cec-20ac-11db-8b3e-0000779e2340",
+			"date": "2006-07-31",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Antony Thorncroft"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/tonight-at-8-30-nuffield-13-collection.json
+++ b/db-seeding/seeds/productions/tonight-at-8-30-nuffield-13-collection.json
@@ -190,5 +190,47 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/theatre-reviews/10822944/Tonight-at-8.30-review-a-major-theatrical-feast.html?onwardjourney=584162_c1",
+			"date": "2014-05-10",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Dominic Cavendish"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2014/may/11/tonight-at-830-review",
+			"date": "2014-05-11",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/90bbfaba-d9b7-11e3-b3e3-00144feabdc0",
+			"date": "2014-05-12",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/tonight-at-830-at-the-nuffield-southampton-st008ccchnf",
+			"date": "2014-05-14",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/troilus-and-cressida-globe.json
+++ b/db-seeding/seeds/productions/troilus-and-cressida-globe.json
@@ -195,5 +195,47 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.thetimes.co.uk/article/troilus-and-cressida-shakespeares-globe-se1-3t3dsxwctzv",
+			"date": "2012-04-24",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Dominic Maxwell"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2012/apr/24/troilus-cressida-review",
+			"date": "2012-04-24",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Andrew Dickson"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/theatre-reviews/9224440/Maori-Troilus-and-Cressida-Shakespeares-Globe-review.html",
+			"date": "2012-04-24",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Dominic Cavendish"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/globe-to-globe-shakespeare-s-globe-london-wild-swans-young-vic-london-what-country-friends-is-this-royal-shakespeare-theatre-stratforduponavon-7687280.html",
+			"date": "2012-04-28",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/troilus-and-cressida-rst.json
+++ b/db-seeding/seeds/productions/troilus-and-cressida-rst.json
@@ -373,5 +373,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.spectator.co.uk/article/wives-and-wooings",
+			"date": "2006-09-16",
+			"publication": {
+				"name": "The Spectator"
+			},
+			"critic": {
+				"name": "Patrick Carnegy"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/true-west-sheffield-theatres-crucible.json
+++ b/db-seeding/seeds/productions/true-west-sheffield-theatres-crucible.json
@@ -120,5 +120,47 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2010/may/19/true-west-michael-billington",
+			"date": "2010-05-19",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/theatre-reviews/7744490/True-West-at-the-Sheffield-Crucible-review.html?onwardjourney=584162_v1",
+			"date": "2010-05-20",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.dailymail.co.uk/tvshowbiz/reviews/article-1280064/True-West-An-American-lesson-brotherly-love.html",
+			"date": "2010-05-21",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Patrick Marmion"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/true-west-crucible-sheffield-1983798.html",
+			"date": "2010-05-27",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Lynne Walker"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/true-west-vaudeville.json
+++ b/db-seeding/seeds/productions/true-west-vaudeville.json
@@ -120,5 +120,77 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.telegraph.co.uk/theatre/what-to-see/true-west-review-vaudeville-theatre-kit-harington-proves-mettle/",
+			"date": "2018-12-04",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Dominic Cavendish"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2018/dec/04/true-west-review-harington-and-flynn-star-as-shepards-warring-siblings",
+			"date": "2018-12-04",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.standard.co.uk/culture/theatre/true-west-review-kit-harington-and-johnny-flynn-electrify-in-tale-of-brothers-grim-a4008696.html",
+			"date": "2018-12-05",
+			"publication": {
+				"name": "Evening Standard"
+			},
+			"critic": {
+				"name": "Henry Hitchings"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/true-west-vaudeville-theatre-london-review-kit-harington-johnny-flynn-game-of-thrones-a8668346.html",
+			"date": "2018-12-05",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/e7a39be0-f8a6-11e8-af46-2022a0b02a6c",
+			"date": "2018-12-06",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		},
+		{
+			"url": "https://www.dailymail.co.uk/home/event/article-6467009/True-West-review-Powerful-performances-Kit-Harington-Johnny-Flynn.html",
+			"date": "2018-12-08",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Robert Gore-Langton"
+			}
+		},
+		{
+			"url": "https://www.thetimes.co.uk/article/theatre-review-true-west-vaudeville-johnny-flynn-and-kit-harington-star-in-sam-shepards-play-n9662vzq8",
+			"date": "2018-12-09",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Christopher Hart"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/twelfth-night-globe.json
+++ b/db-seeding/seeds/productions/twelfth-night-globe.json
@@ -105,5 +105,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2012/apr/30/twelfth-night-shakespeares-globe-review",
+			"date": "2012-04-30",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Lyn Gardner"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/twelfth-night-swan.json
+++ b/db-seeding/seeds/productions/twelfth-night-swan.json
@@ -200,5 +200,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.thetimes.co.uk/article/twelfth-night-njpvvjhrmss",
+			"date": "2007-03-02",
+			"publication": {
+				"name": "The Times"
+			},
+			"critic": {
+				"name": "Benedict Nightingale"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/twelfth-night-wyndhams.json
+++ b/db-seeding/seeds/productions/twelfth-night-wyndhams.json
@@ -215,5 +215,67 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2008/dec/11/theatre",
+			"date": "2008-12-11",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/first-night-twelfth-night-wyndham-s-theatre-london-1061462.html",
+			"date": "2008-12-11",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Michael Coveney"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/bb2dbeea-c785-11dd-b611-000077b07658",
+			"date": "2008-12-11",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Ian Shuttleworth"
+			}
+		},
+		{
+			"url": "https://www.express.co.uk/entertainment/theatre/75469/Twelfth-Night",
+			"date": "2008-12-12",
+			"publication": {
+				"name": "Daily Express"
+			},
+			"critic": {
+				"name": "Paul Callan"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/3724509/Twelfth-Night-at-the-Donmar-at-Wyndhams-review.html",
+			"date": "2008-12-12",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2008/dec/14/twelfth-night-wyndhams-hamlet-novello",
+			"date": "2008-12-14",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/vernon-god-little-young-vic-main-house.json
+++ b/db-seeding/seeds/productions/vernon-god-little-young-vic-main-house.json
@@ -209,5 +209,37 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.theguardian.com/stage/2007/may/09/theatre1",
+			"date": "2007-05-09",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/drama/3664989/Black-comedy-is-top-of-the-class.html",
+			"date": "2007-05-09",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2007/may/13/theatre1",
+			"date": "2007-05-13",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/war-horse-nt-olivier.json
+++ b/db-seeding/seeds/productions/war-horse-nt-olivier.json
@@ -445,5 +445,67 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/drama/3668613/War-Horse-Horse-play-is-no-puppet-show.html",
+			"date": "2007-10-18",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Charles Spencer"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2007/oct/18/theatre.michaelmorpurgo",
+			"date": "2007-10-18",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/first-night-war-horse-olivier-national-theatre-london-397181.html",
+			"date": "2007-10-18",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/aacd8668-7de7-11dc-9f47-0000779fd2ac",
+			"date": "2007-10-19",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		},
+		{
+			"url": "https://www.dailymail.co.uk/tvshowbiz/reviews/article-488664/War-Horse-galloping-winner-pulls-heart-strings.html",
+			"date": "2007-10-19",
+			"publication": {
+				"name": "Daily Mail"
+			},
+			"critic": {
+				"name": "Quentin Letts"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2007/oct/21/theatre.michaelmorpurgo",
+			"date": "2007-10-21",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/we-lost-elijah-nt-shed.json
+++ b/db-seeding/seeds/productions/we-lost-elijah-nt-shed.json
@@ -173,5 +173,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.ft.com/content/7992caa6-e946-11e2-9f11-00144feabdc0",
+			"date": "2013-07-12",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alexander Gilmour"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/what-are-they-like?-nt-olivier.json
+++ b/db-seeding/seeds/productions/what-are-they-like?-nt-olivier.json
@@ -198,5 +198,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.ft.com/content/7992caa6-e946-11e2-9f11-00144feabdc0",
+			"date": "2013-07-12",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Alexander Gilmour"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/whipping-it-up-new-ambassadors.json
+++ b/db-seeding/seeds/productions/whipping-it-up-new-ambassadors.json
@@ -148,5 +148,17 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.ft.com/content/78b707ec-cb42-11db-b436-000b5df10621",
+			"date": "2007-03-05",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		}
 	]
 }

--- a/db-seeding/seeds/productions/women-power-and-politics-12-collection-tricycle.json
+++ b/db-seeding/seeds/productions/women-power-and-politics-12-collection-tricycle.json
@@ -76,5 +76,67 @@
 				}
 			]
 		}
+	],
+	"reviews": [
+		{
+			"url": "https://www.telegraph.co.uk/culture/theatre/theatre-reviews/7826387/Women-Power-and-Politics-at-the-Tricycle-Theatre-review.html",
+			"date": "2010-06-13",
+			"publication": {
+				"name": "The Telegraph"
+			},
+			"critic": {
+				"name": "Dominic Cavendish"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2010/jun/13/women-power-politics-tricycle-review",
+			"date": "2010-06-13",
+			"publication": {
+				"name": "The Guardian"
+			},
+			"critic": {
+				"name": "Michael Billington"
+			}
+		},
+		{
+			"url": "https://www.ft.com/content/fa3c17c6-77ce-11df-82c3-00144feabdc0",
+			"date": "2010-06-14",
+			"publication": {
+				"name": "Financial Times"
+			},
+			"critic": {
+				"name": "Sarah Hemming"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/women-power-and-politics-tricycle-theatre-london-2000466.html",
+			"date": "2010-06-15",
+			"publication": {
+				"name": "The Independent"
+			},
+			"critic": {
+				"name": "Paul Taylor"
+			}
+		},
+		{
+			"url": "https://www.independent.co.uk/arts-entertainment/theatre-dance/reviews/through-a-glass-darkly-almeida-londonlulu-gate-londonwomen-power-and-politics-tricycle-london-2005190.html",
+			"date": "2010-06-20",
+			"publication": {
+				"name": "The Independent on Sunday"
+			},
+			"critic": {
+				"name": "Kate Bassett"
+			}
+		},
+		{
+			"url": "https://www.theguardian.com/stage/2010/jun/20/women-power-politics-tricycle-susannah-clapp",
+			"date": "2010-06-20",
+			"publication": {
+				"name": "The Observer"
+			},
+			"critic": {
+				"name": "Susannah Clapp"
+			}
+		}
 	]
 }


### PR DESCRIPTION
This PR updates production database seeds to include their reviews, utilising functionality introduced by PR https://github.com/andygout/dramatis-api/pull/658.