### PR TITLE
Modify production review ordering

### DIFF
--- a/src/neo4j/cypher-queries/production/show/show.js
+++ b/src/neo4j/cypher-queries/production/show/show.js
@@ -684,7 +684,7 @@ export default () => `
 			publication,
 			publicationRel,
 			critic
-			ORDER BY publicationRel.date
+			ORDER BY publicationRel.date, publication.name
 
 		WITH
 			production,


### PR DESCRIPTION
This PR modifies the ordering of production reviews to include a secondary ordering clause of the publication name.

There will regularly be multiple reviews on a single day, so this clause will provide some consistency of ordering when the same publications publish reviews on the same day for multiple productions.

#### Before
<img width="384" alt="before" src="https://github.com/andygout/dramatis-api/assets/10484515/4885fa98-86cb-4b61-a717-6f5dc4b11366">

---

#### After

(Evening Standard now precedes Financial Times)

<img width="376" alt="after" src="https://github.com/andygout/dramatis-api/assets/10484515/8b2642dd-6d84-47f5-8f23-abb437b97a54">