### PR TITLE
Run server.closeAllConnections() before server.close()

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -29,7 +29,10 @@ const server = http.createServer(app);
 
 server.listen(port, () => console.log(`Listening on port ${port}`)); // eslint-disable-line no-console
 
-const shutDown = () => server.close(() => neo4jDriver.close().then(() => process.exit(0)));
+const shutDown = () => {
+	server.closeAllConnections();
+	server.close(() => neo4jDriver.close().then(() => process.exit(0)));
+};
 
 process.on('SIGTERM', shutDown);
 process.on('SIGINT', shutDown);


### PR DESCRIPTION
This PR addresses an issue that was encountered on another Node.js app with a Neo4j database in which after a change was made to the code which triggered a Nodemon restart of the server, it would be impossible to close the server using `ctrl` + `c` and would require that the entire CLI shell was closed.

Upon the sixth attempt at `ctrl` + `c`, the following message would appear:

> (node:26548) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 close listeners added to [Server]. Use emitter.setMaxListeners() to increase limit
> (Use `node --trace-warnings ...` to show where the warning was created)

Each attempt of `ctrl` + `c` would call `server.close()` twice (but not invoke the callback), so the sixth attempt would reach the 11th call, indicating that each call would add a close listener.

I'm not sure of the exact cause, but the below references helped lead me to a solution.

### References:
- [Node.js: `server.closeAllConnections()`](https://nodejs.org/api/https.html#servercloseallconnections)
- [Stack Overflow: Why is server.close callback never invoked?](https://stackoverflow.com/questions/28053659/why-is-server-close-callback-never-invoked)
- [Stack Overflow: Force close all connections in a node.js http server](https://stackoverflow.com/questions/18874689/force-close-all-connections-in-a-node-js-http-server)
- [GitHub: nodejs/node — Issues: Add ability to force close persistent connections](https://github.com/nodejs/node/issues/41578)