### PR TITLE
Add getTrimmedOrEmptyString function

### DIFF
--- a/src/lib/strings.js
+++ b/src/lib/strings.js
@@ -1,0 +1,5 @@
+export const getTrimmedOrEmptyString = value => {
+
+	return value?.trim() || '';
+
+};

--- a/src/models/Base.js
+++ b/src/models/Base.js
@@ -1,3 +1,4 @@
+import { getTrimmedOrEmptyString } from '../lib/strings';
 import { validateString } from '../lib/validate-string';
 import { MODELS } from '../utils/constants';
 
@@ -11,7 +12,7 @@ export default class Base {
 
 	constructor (props = {}) {
 
-		if (!NAME_EXEMPT_MODELS.has(this.model)) this.name = props.name?.trim() || '';
+		if (!NAME_EXEMPT_MODELS.has(this.model)) this.name = getTrimmedOrEmptyString(props.name);
 
 		this.errors = {};
 

--- a/src/models/CharacterDepiction.js
+++ b/src/models/CharacterDepiction.js
@@ -1,3 +1,4 @@
+import { getTrimmedOrEmptyString } from '../lib/strings';
 import Character from './Character';
 
 export default class CharacterDepiction extends Character {
@@ -8,8 +9,9 @@ export default class CharacterDepiction extends Character {
 
 		const { underlyingName, qualifier } = props;
 
-		this.underlyingName = underlyingName?.trim() || '';
-		this.qualifier = qualifier?.trim() || '';
+		this.underlyingName = getTrimmedOrEmptyString(underlyingName);
+
+		this.qualifier = getTrimmedOrEmptyString(qualifier);
 
 	}
 

--- a/src/models/Entity.js
+++ b/src/models/Entity.js
@@ -1,5 +1,6 @@
 import { hasErrors } from '../lib/has-errors';
 import { prepareAsParams } from '../lib/prepare-as-params';
+import { getTrimmedOrEmptyString } from '../lib/strings';
 import Base from './Base';
 import {
 	getCreateQueries,
@@ -34,7 +35,11 @@ export default class Entity extends Base {
 
 		this.uuid = uuid;
 
-		if (!DIFFERENTIATOR_EXEMPT_MODELS.has(this.model)) this.differentiator = differentiator?.trim() || '';
+		if (!DIFFERENTIATOR_EXEMPT_MODELS.has(this.model)) {
+
+			this.differentiator = getTrimmedOrEmptyString(differentiator);
+
+		}
 
 	}
 

--- a/src/models/Material.js
+++ b/src/models/Material.js
@@ -1,5 +1,6 @@
 import { getDuplicateBaseInstanceIndices, getDuplicateNameIndices } from '../lib/get-duplicate-indices';
 import { isValidYear } from '../lib/is-valid-year';
+import { getTrimmedOrEmptyString } from '../lib/strings';
 import MaterialBase from './MaterialBase';
 import { CharacterGroup, OriginalVersionMaterial, SubMaterial, WritingCredit } from '.';
 
@@ -19,11 +20,11 @@ export default class Material extends MaterialBase {
 			characterGroups
 		} = props;
 
-		this.subtitle = subtitle?.trim() || '';
+		this.subtitle = getTrimmedOrEmptyString(subtitle);
 
-		this.format = format?.trim() || '';
+		this.format = getTrimmedOrEmptyString(format);
 
-		this.year = parseInt(year) || year?.trim() || '';
+		this.year = parseInt(year) || getTrimmedOrEmptyString(year);
 
 		this.originalVersionMaterial = new OriginalVersionMaterial(originalVersionMaterial);
 

--- a/src/models/Nomination.js
+++ b/src/models/Nomination.js
@@ -1,5 +1,6 @@
 import { getDuplicateEntities, isEntityInArray } from '../lib/get-duplicate-entity-info';
 import { getDuplicateBaseInstanceIndices, getDuplicateUuidIndices } from '../lib/get-duplicate-indices';
+import { getTrimmedOrEmptyString } from '../lib/strings';
 import Base from './Base';
 import { CompanyWithMembers, MaterialBase, NominatedProductionIdentifier, Person } from '.';
 import { MODELS } from '../utils/constants';
@@ -14,7 +15,7 @@ export default class Nomination extends Base {
 
 		this.isWinner = Boolean(isWinner);
 
-		this.customType = customType?.trim() || '';
+		this.customType = getTrimmedOrEmptyString(customType);
 
 		this.entities = entities
 			? entities.map(entity => {

--- a/src/models/Production.js
+++ b/src/models/Production.js
@@ -5,6 +5,7 @@ import {
 	getDuplicateUrlIndices
 } from '../lib/get-duplicate-indices';
 import { isValidDate } from '../lib/is-valid-date';
+import { getTrimmedOrEmptyString } from '../lib/strings';
 import Entity from './Entity';
 import {
 	CastMember,
@@ -43,13 +44,13 @@ export default class Production extends Entity {
 			reviews
 		} = props;
 
-		this.subtitle = subtitle?.trim() || '';
+		this.subtitle = getTrimmedOrEmptyString(subtitle);
 
-		this.startDate = startDate?.trim() || '';
+		this.startDate = getTrimmedOrEmptyString(startDate);
 
-		this.pressDate = pressDate?.trim() || '';
+		this.pressDate = getTrimmedOrEmptyString(pressDate);
 
-		this.endDate = endDate?.trim() || '';
+		this.endDate = getTrimmedOrEmptyString(endDate);
 
 		this.material = new MaterialBase(material);
 

--- a/src/models/ProductionIdentifier.js
+++ b/src/models/ProductionIdentifier.js
@@ -1,3 +1,4 @@
+import { getTrimmedOrEmptyString } from '../lib/strings';
 import Entity from './Entity';
 import { MODELS } from '../utils/constants';
 
@@ -7,7 +8,7 @@ export default class ProductionIdentifier extends Entity {
 
 		super(props);
 
-		this.uuid = props.uuid?.trim() || '';
+		this.uuid = getTrimmedOrEmptyString(props.uuid);
 
 	}
 

--- a/src/models/Review.js
+++ b/src/models/Review.js
@@ -1,4 +1,5 @@
 import { isValidDate } from '../lib/is-valid-date';
+import { getTrimmedOrEmptyString } from '../lib/strings';
 import Base from './Base';
 import { Company, Person } from '.';
 import { MODELS } from '../utils/constants';
@@ -11,9 +12,9 @@ export default class Review extends Base {
 
 		const { url, date, publication, critic } = props;
 
-		this.url = url?.trim() || '';
+		this.url = getTrimmedOrEmptyString(url);
 
-		this.date = date?.trim() || '';
+		this.date = getTrimmedOrEmptyString(date);
 
 		this.publication = new Company(publication);
 

--- a/src/models/Role.js
+++ b/src/models/Role.js
@@ -1,3 +1,4 @@
+import { getTrimmedOrEmptyString } from '../lib/strings';
 import Base from './Base';
 import { MODELS } from '../utils/constants';
 
@@ -9,9 +10,12 @@ export default class Role extends Base {
 
 		const { characterName, characterDifferentiator, qualifier, isAlternate } = props;
 
-		this.characterName = characterName?.trim() || '';
-		this.characterDifferentiator = characterDifferentiator?.trim() || '';
-		this.qualifier = qualifier?.trim() || '';
+		this.characterName = getTrimmedOrEmptyString(characterName);
+
+		this.characterDifferentiator = getTrimmedOrEmptyString(characterDifferentiator);
+
+		this.qualifier = getTrimmedOrEmptyString(qualifier);
+
 		this.isAlternate = Boolean(isAlternate);
 
 	}

--- a/test-unit/src/lib/strings.test.js
+++ b/test-unit/src/lib/strings.test.js
@@ -1,0 +1,41 @@
+import { expect } from 'chai';
+
+import { getTrimmedOrEmptyString } from '../../../src/lib/strings';
+
+describe('Strings module', () => {
+
+	describe('getTrimmedOrEmptyString function', () => {
+
+		it('assigns empty string if value is undefined', () => {
+
+			expect(getTrimmedOrEmptyString(undefined)).to.equal('');
+
+		});
+
+		it('assigns empty string if value is empty string', () => {
+
+			expect(getTrimmedOrEmptyString('')).to.equal('');
+
+		});
+
+		it('assigns empty string if value is whitespace-only string', () => {
+
+			expect(getTrimmedOrEmptyString(' ')).to.equal('');
+
+		});
+
+		it('assigns value if value is string with length', () => {
+
+			expect(getTrimmedOrEmptyString('foobar')).to.equal('foobar');
+
+		});
+
+		it('assigns trimmed value if value is string with leading and trailing whitespace', () => {
+
+			expect(getTrimmedOrEmptyString(' foobar ')).to.equal('foobar');
+
+		});
+
+	});
+
+});

--- a/test-unit/src/models/Base.test.js
+++ b/test-unit/src/models/Base.test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { assert, createSandbox, spy } from 'sinon';
 
+import * as stringsModule from '../../../src/lib/strings';
 import * as validateStringModule from '../../../src/lib/validate-string';
 import Base from '../../../src/models/Base';
 import { Nomination, ProductionIdentifier, Review } from '../../../src/models';
@@ -18,6 +19,8 @@ describe('Base model', () => {
 	beforeEach(() => {
 
 		stubs = {
+			getTrimmedOrEmptyString:
+				sandbox.stub(stringsModule, 'getTrimmedOrEmptyString').callsFake(arg => arg?.trim() || ''),
 			validateString: sandbox.stub(validateStringModule, 'validateString').returns(undefined)
 		};
 
@@ -40,38 +43,11 @@ describe('Base model', () => {
 
 			context('model is not exempt', () => {
 
-				it('assigns empty string if absent from props', () => {
+				it('assigns return value from getTrimmedOrEmptyString called with props value', () => {
 
-					const instance = new Base({});
-					expect(instance.name).to.equal('');
-
-				});
-
-				it('assigns empty string if included in props but value is empty string', () => {
-
-					const instance = new Base({ name: '' });
-					expect(instance.name).to.equal('');
-
-				});
-
-				it('assigns empty string if included in props but value is whitespace-only string', () => {
-
-					const instance = new Base({ name: ' ' });
-					expect(instance.name).to.equal('');
-
-				});
-
-				it('assigns value if included in props and is string with length', () => {
-
-					const instance = new Base({ name: 'Barfoo' });
-					expect(instance.name).to.equal('Barfoo');
-
-				});
-
-				it('trims value before assigning', () => {
-
-					const instance = new Base({ name: ' Barfoo ' });
-					expect(instance.name).to.equal('Barfoo');
+					assert.calledOnce(stubs.getTrimmedOrEmptyString);
+					assert.calledWithExactly(stubs.getTrimmedOrEmptyString, 'Foobar');
+					expect(instance.name).to.equal('Foobar');
 
 				});
 

--- a/test-unit/src/models/CharacterDepiction.test.js
+++ b/test-unit/src/models/CharacterDepiction.test.js
@@ -1,45 +1,45 @@
 import { expect } from 'chai';
-import { assert, spy } from 'sinon';
+import { assert, createSandbox, spy } from 'sinon';
 
+import * as stringsModule from '../../../src/lib/strings';
 import CharacterDepiction from '../../../src/models/CharacterDepiction';
 
 describe('CharacterDepiction model', () => {
 
+	let stubs;
+
+	const sandbox = createSandbox();
+
+	beforeEach(() => {
+
+		stubs = {
+			getTrimmedOrEmptyString:
+				sandbox.stub(stringsModule, 'getTrimmedOrEmptyString').callsFake(arg => arg?.trim() || '')
+		};
+
+	});
+
+	afterEach(() => {
+
+		sandbox.restore();
+
+	});
+
 	describe('constructor method', () => {
+
+		it('calls getTrimmedOrEmptyString to get values to assign to properties', () => {
+
+			new CharacterDepiction();
+			expect(stubs.getTrimmedOrEmptyString.callCount).to.equal(4);
+
+		});
 
 		describe('underlyingName property', () => {
 
-			it('assigns empty string if absent from props', () => {
+			it('assigns return value from getTrimmedOrEmptyString called with props value', () => {
 
-				const instance = new CharacterDepiction({ name: 'Prince Hal' });
-				expect(instance.underlyingName).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is empty string', () => {
-
-				const instance = new CharacterDepiction({ name: 'Prince Hal', underlyingName: '' });
-				expect(instance.underlyingName).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is whitespace-only string', () => {
-
-				const instance = new CharacterDepiction({ name: 'Prince Hal', underlyingName: ' ' });
-				expect(instance.underlyingName).to.equal('');
-
-			});
-
-			it('assigns value if included in props and is string with length', () => {
-
-				const instance = new CharacterDepiction({ name: 'Prince Hal', underlyingName: 'King Henry V' });
-				expect(instance.underlyingName).to.equal('King Henry V');
-
-			});
-
-			it('trims value before assigning', () => {
-
-				const instance = new CharacterDepiction({ name: 'Prince Hal', underlyingName: ' King Henry V ' });
+				const instance = new CharacterDepiction({ underlyingName: 'King Henry V' });
+				assert.calledWithExactly(stubs.getTrimmedOrEmptyString.thirdCall, 'King Henry V');
 				expect(instance.underlyingName).to.equal('King Henry V');
 
 			});
@@ -48,37 +48,10 @@ describe('CharacterDepiction model', () => {
 
 		describe('qualifier property', () => {
 
-			it('assigns empty string if absent from props', () => {
+			it('assigns return value from getTrimmedOrEmptyString called with props value', () => {
 
-				const instance = new CharacterDepiction({ name: 'Esme' });
-				expect(instance.qualifier).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is empty string', () => {
-
-				const instance = new CharacterDepiction({ name: 'Esme', qualifier: '' });
-				expect(instance.qualifier).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is whitespace-only string', () => {
-
-				const instance = new CharacterDepiction({ name: 'Esme', qualifier: ' ' });
-				expect(instance.qualifier).to.equal('');
-
-			});
-
-			it('assigns value if included in props and is string with length', () => {
-
-				const instance = new CharacterDepiction({ name: 'Esme', qualifier: 'older' });
-				expect(instance.qualifier).to.equal('older');
-
-			});
-
-			it('trims value before assigning', () => {
-
-				const instance = new CharacterDepiction({ name: 'Esme', qualifier: ' older ' });
+				const instance = new CharacterDepiction({ qualifier: 'older' });
+				assert.calledWithExactly(stubs.getTrimmedOrEmptyString.getCall(3), 'older');
 				expect(instance.qualifier).to.equal('older');
 
 			});

--- a/test-unit/src/models/Material.test.js
+++ b/test-unit/src/models/Material.test.js
@@ -42,6 +42,9 @@ describe('Material model', () => {
 			isValidYearModule: {
 				isValidYear: stub().returns(false)
 			},
+			stringsModule: {
+				getTrimmedOrEmptyString: stub().callsFake(arg => arg?.trim() || '')
+			},
 			models: {
 				CharacterGroup: CharacterGroupStub,
 				OriginalVersionMaterial: OriginalVersionMaterialStub,
@@ -58,6 +61,7 @@ describe('Material model', () => {
 		proxyquire('../../../src/models/Material', {
 			'../lib/get-duplicate-indices': stubs.getDuplicateIndicesModule,
 			'../lib/is-valid-year': stubs.isValidYearModule,
+			'../lib/strings': stubs.stringsModule,
 			'.': stubs.models
 		}).default;
 
@@ -71,39 +75,19 @@ describe('Material model', () => {
 
 	describe('constructor method', () => {
 
+		it('calls getTrimmedOrEmptyString to get values to assign to properties', () => {
+
+			createInstance();
+			expect(stubs.stringsModule.getTrimmedOrEmptyString.callCount).to.equal(3);
+
+		});
+
 		describe('subtitle property', () => {
 
-			it('assigns empty string if absent from props', () => {
+			it('assigns return value from getTrimmedOrEmptyString called with props value', () => {
 
-				const instance = createInstance({ name: 'The Tragedy of Hamlet' });
-				expect(instance.subtitle).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is empty string', () => {
-
-				const instance = createInstance({ name: 'The Tragedy of Hamlet', subtitle: '' });
-				expect(instance.subtitle).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is whitespace-only string', () => {
-
-				const instance = createInstance({ name: 'The Tragedy of Hamlet', subtitle: ' ' });
-				expect(instance.subtitle).to.equal('');
-
-			});
-
-			it('assigns value if included in props and is string with length', () => {
-
-				const instance = createInstance({ name: 'The Tragedy of Hamlet', subtitle: 'Prince of Denmark' });
-				expect(instance.subtitle).to.equal('Prince of Denmark');
-
-			});
-
-			it('trims value before assigning', () => {
-
-				const instance = createInstance({ name: 'The Tragedy of Hamlet', subtitle: ' Prince of Denmark ' });
+				const instance = createInstance({ subtitle: 'Prince of Denmark' });
+				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.firstCall, 'Prince of Denmark');
 				expect(instance.subtitle).to.equal('Prince of Denmark');
 
 			});
@@ -112,37 +96,10 @@ describe('Material model', () => {
 
 		describe('format property', () => {
 
-			it('assigns empty string if absent from props', () => {
+			it('assigns return value from getTrimmedOrEmptyString called with props value', () => {
 
-				const instance = createInstance({ name: 'The Tragedy of Hamlet' });
-				expect(instance.format).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is empty string', () => {
-
-				const instance = createInstance({ name: 'The Tragedy of Hamlet', format: '' });
-				expect(instance.format).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is whitespace-only string', () => {
-
-				const instance = createInstance({ name: 'The Tragedy of Hamlet', format: ' ' });
-				expect(instance.format).to.equal('');
-
-			});
-
-			it('assigns value if included in props and is string with length', () => {
-
-				const instance = createInstance({ name: 'The Tragedy of Hamlet', format: 'play' });
-				expect(instance.format).to.equal('play');
-
-			});
-
-			it('trims value before assigning', () => {
-
-				const instance = createInstance({ name: 'The Tragedy of Hamlet', format: ' play ' });
+				const instance = createInstance({ format: 'play' });
+				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.secondCall, 'play');
 				expect(instance.format).to.equal('play');
 
 			});
@@ -151,59 +108,40 @@ describe('Material model', () => {
 
 		describe('year property', () => {
 
-			it('assigns empty string if absent from props', () => {
+			context('value cannot be parsed as integer', () => {
 
-				const instance = createInstance({ name: 'The Caretaker' });
-				expect(instance.year).to.equal('');
+				it('assigns return value from getTrimmedOrEmptyString called with props value', () => {
 
-			});
+					const instance = createInstance({ year: 'Nineteen Fifty-Nine' });
+					assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.thirdCall, 'Nineteen Fifty-Nine');
+					expect(instance.year).to.equal('Nineteen Fifty-Nine');
 
-			it('assigns empty string if included in props but value is empty string', () => {
-
-				const instance = createInstance({ name: 'The Caretaker', year: '' });
-				expect(instance.year).to.equal('');
+				});
 
 			});
 
-			it('assigns empty string if included in props but value is whitespace-only string', () => {
+			context('value can be parsed as integer', () => {
 
-				const instance = createInstance({ name: 'The Caretaker', year: ' ' });
-				expect(instance.year).to.equal('');
+				it('assigns value converted to integer if included in props and value can be parsed as integer', () => {
 
-			});
+					const instance = createInstance({ year: '1959' });
+					expect(instance.year).to.equal(1959);
 
-			it('assigns value if included in props and cannot be parsed as integer', () => {
+				});
 
-				const instance = createInstance({ name: 'The Caretaker', year: 'Nineteen Fifty-Nine' });
-				expect(instance.year).to.equal('Nineteen Fifty-Nine');
+				it('assigns value with flanking whitespace converted to integer if included in props and value can be parsed as integer', () => {
 
-			});
+					const instance = createInstance({ year: ' 1959 ' });
+					expect(instance.year).to.equal(1959);
 
-			it('assigns whitespace-trimmed value if included in props and value cannot be parsed as integer', () => {
+				});
 
-				const instance = createInstance({ name: 'The Caretaker', year: ' Nineteen Fifty-Nine ' });
-				expect(instance.year).to.equal('Nineteen Fifty-Nine');
+				it('assigns value if included in props and is an integer', () => {
 
-			});
+					const instance = createInstance({ year: 1959 });
+					expect(instance.year).to.equal(1959);
 
-			it('assigns value converted to integer if included in props and value can be parsed as integer', () => {
-
-				const instance = createInstance({ name: 'The Caretaker', year: '1959' });
-				expect(instance.year).to.equal(1959);
-
-			});
-
-			it('assigns value with flanking whitespace converted to integer if included in props and value can be parsed as integer', () => {
-
-				const instance = createInstance({ name: 'The Caretaker', year: ' 1959 ' });
-				expect(instance.year).to.equal(1959);
-
-			});
-
-			it('assigns value if included in props and is an integer', () => {
-
-				const instance = createInstance({ name: 'The Caretaker', year: 1959 });
-				expect(instance.year).to.equal(1959);
+				});
 
 			});
 

--- a/test-unit/src/models/Nomination.test.js
+++ b/test-unit/src/models/Nomination.test.js
@@ -43,6 +43,9 @@ describe('Nomination model', () => {
 				getDuplicateBaseInstanceIndices: stub().returns([]),
 				getDuplicateUuidIndices: stub().returns([])
 			},
+			stringsModule: {
+				getTrimmedOrEmptyString: stub().callsFake(arg => arg?.trim() || '')
+			},
 			models: {
 				CompanyWithMembers: CompanyWithMembersStub,
 				MaterialBase: MaterialBaseStub,
@@ -57,6 +60,7 @@ describe('Nomination model', () => {
 		proxyquire('../../../src/models/Nomination', {
 			'../lib/get-duplicate-entity-info': stubs.getDuplicateEntityInfoModule,
 			'../lib/get-duplicate-indices': stubs.getDuplicateIndicesModule,
+			'../lib/strings': stubs.stringsModule,
 			'.': stubs.models
 		}).default;
 
@@ -109,39 +113,19 @@ describe('Nomination model', () => {
 
 		});
 
+		it('calls getTrimmedOrEmptyString to get values to assign to properties', () => {
+
+			createInstance();
+			expect(stubs.stringsModule.getTrimmedOrEmptyString.callCount).to.equal(1);
+
+		});
+
 		describe('customType property', () => {
 
-			it('assigns empty string if absent from props', () => {
-
-				const instance = createInstance({});
-				expect(instance.customType).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is empty string', () => {
-
-				const instance = createInstance({ customType: '' });
-				expect(instance.customType).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is whitespace-only string', () => {
-
-				const instance = createInstance({ customType: ' ' });
-				expect(instance.customType).to.equal('');
-
-			});
-
-			it('assigns value if included in props and is string with length', () => {
+			it('assigns return value from getTrimmedOrEmptyString called with props value', () => {
 
 				const instance = createInstance({ customType: 'Shortlisted' });
-				expect(instance.customType).to.equal('Shortlisted');
-
-			});
-
-			it('trims value before assigning', () => {
-
-				const instance = createInstance({ customType: ' Shortlisted ' });
+				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.firstCall, 'Shortlisted');
 				expect(instance.customType).to.equal('Shortlisted');
 
 			});

--- a/test-unit/src/models/Production.test.js
+++ b/test-unit/src/models/Production.test.js
@@ -91,6 +91,9 @@ describe('Production model', () => {
 			isValidDateModule: {
 				isValidDate: stub().returns(false)
 			},
+			stringsModule: {
+				getTrimmedOrEmptyString: stub().callsFake(arg => arg?.trim() || '')
+			},
 			models: {
 				CastMember: CastMemberStub,
 				CreativeCredit: CreativeCreditStub,
@@ -111,6 +114,7 @@ describe('Production model', () => {
 		proxyquire('../../../src/models/Production', {
 			'../lib/get-duplicate-indices': stubs.getDuplicateIndicesModule,
 			'../lib/is-valid-date': stubs.isValidDateModule,
+			'../lib/strings': stubs.stringsModule,
 			'.': stubs.models
 		}).default;
 
@@ -124,39 +128,19 @@ describe('Production model', () => {
 
 	describe('constructor method', () => {
 
+		it('calls getTrimmedOrEmptyString to get values to assign to properties', () => {
+
+			createInstance();
+			expect(stubs.stringsModule.getTrimmedOrEmptyString.callCount).to.equal(4);
+
+		});
+
 		describe('subtitle property', () => {
 
-			it('assigns empty string if absent from props', () => {
+			it('assigns return value from getTrimmedOrEmptyString called with props value', () => {
 
-				const instance = createInstance({ name: 'The Tragedy of Hamlet' });
-				expect(instance.subtitle).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is empty string', () => {
-
-				const instance = createInstance({ name: 'The Tragedy of Hamlet', subtitle: '' });
-				expect(instance.subtitle).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is whitespace-only string', () => {
-
-				const instance = createInstance({ name: 'The Tragedy of Hamlet', subtitle: ' ' });
-				expect(instance.subtitle).to.equal('');
-
-			});
-
-			it('assigns value if included in props and is string with length', () => {
-
-				const instance = createInstance({ name: 'The Tragedy of Hamlet', subtitle: 'Prince of Denmark' });
-				expect(instance.subtitle).to.equal('Prince of Denmark');
-
-			});
-
-			it('trims value before assigning', () => {
-
-				const instance = createInstance({ name: 'The Tragedy of Hamlet', subtitle: ' Prince of Denmark ' });
+				const instance = createInstance({ subtitle: 'Prince of Denmark' });
+				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.firstCall, 'Prince of Denmark');
 				expect(instance.subtitle).to.equal('Prince of Denmark');
 
 			});
@@ -165,37 +149,10 @@ describe('Production model', () => {
 
 		describe('startDate property', () => {
 
-			it('assigns empty string if absent from props', () => {
+			it('assigns return value from getTrimmedOrEmptyString called with props value', () => {
 
-				const instance = createInstance({ name: 'Hamlet' });
-				expect(instance.startDate).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is empty string', () => {
-
-				const instance = createInstance({ name: 'Hamlet', startDate: '' });
-				expect(instance.startDate).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is whitespace-only string', () => {
-
-				const instance = createInstance({ name: 'Hamlet', startDate: ' ' });
-				expect(instance.startDate).to.equal('');
-
-			});
-
-			it('assigns value if included in props and is string with length', () => {
-
-				const instance = createInstance({ name: 'Hamlet', startDate: '2010-09-30' });
-				expect(instance.startDate).to.equal('2010-09-30');
-
-			});
-
-			it('trims value before assigning', () => {
-
-				const instance = createInstance({ name: 'Hamlet', startDate: ' 2010-09-30 ' });
+				const instance = createInstance({ startDate: '2010-09-30' });
+				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.secondCall, '2010-09-30');
 				expect(instance.startDate).to.equal('2010-09-30');
 
 			});
@@ -204,37 +161,10 @@ describe('Production model', () => {
 
 		describe('pressDate property', () => {
 
-			it('assigns empty string if absent from props', () => {
+			it('assigns return value from getTrimmedOrEmptyString called with props value', () => {
 
-				const instance = createInstance({ name: 'Hamlet' });
-				expect(instance.pressDate).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is empty string', () => {
-
-				const instance = createInstance({ name: 'Hamlet', pressDate: '' });
-				expect(instance.pressDate).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is whitespace-only string', () => {
-
-				const instance = createInstance({ name: 'Hamlet', pressDate: ' ' });
-				expect(instance.pressDate).to.equal('');
-
-			});
-
-			it('assigns value if included in props and is string with length', () => {
-
-				const instance = createInstance({ name: 'Hamlet', pressDate: '2010-10-07' });
-				expect(instance.pressDate).to.equal('2010-10-07');
-
-			});
-
-			it('trims value before assigning', () => {
-
-				const instance = createInstance({ name: 'Hamlet', pressDate: ' 2010-10-07 ' });
+				const instance = createInstance({ pressDate: '2010-10-07' });
+				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.thirdCall, '2010-10-07');
 				expect(instance.pressDate).to.equal('2010-10-07');
 
 			});
@@ -243,37 +173,10 @@ describe('Production model', () => {
 
 		describe('endDate property', () => {
 
-			it('assigns empty string if absent from props', () => {
+			it('assigns return value from getTrimmedOrEmptyString called with props value', () => {
 
-				const instance = createInstance({ name: 'Hamlet' });
-				expect(instance.endDate).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is empty string', () => {
-
-				const instance = createInstance({ name: 'Hamlet', endDate: '' });
-				expect(instance.endDate).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is whitespace-only string', () => {
-
-				const instance = createInstance({ name: 'Hamlet', endDate: ' ' });
-				expect(instance.endDate).to.equal('');
-
-			});
-
-			it('assigns value if included in props and is string with length', () => {
-
-				const instance = createInstance({ name: 'Hamlet', endDate: '2011-01-26' });
-				expect(instance.endDate).to.equal('2011-01-26');
-
-			});
-
-			it('trims value before assigning', () => {
-
-				const instance = createInstance({ name: 'Hamlet', endDate: ' 2011-01-26 ' });
+				const instance = createInstance({ endDate: '2011-01-26' });
+				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.getCall(3), '2011-01-26');
 				expect(instance.endDate).to.equal('2011-01-26');
 
 			});

--- a/test-unit/src/models/ProductionIdentifier.test.js
+++ b/test-unit/src/models/ProductionIdentifier.test.js
@@ -1,45 +1,45 @@
 import { expect } from 'chai';
-import { assert, spy } from 'sinon';
+import { assert, createSandbox, spy } from 'sinon';
 
+import * as stringsModule from '../../../src/lib/strings';
 import { ProductionIdentifier } from '../../../src/models';
 
 describe('ProductionIdentifier model', () => {
 
+	let stubs;
+
+	const sandbox = createSandbox();
+
+	beforeEach(() => {
+
+		stubs = {
+			getTrimmedOrEmptyString:
+				sandbox.stub(stringsModule, 'getTrimmedOrEmptyString').callsFake(arg => arg?.trim() || '')
+		};
+
+	});
+
+	afterEach(() => {
+
+		sandbox.restore();
+
+	});
+
 	describe('constructor method', () => {
+
+		it('calls getTrimmedOrEmptyString to get values to assign to properties', () => {
+
+			new ProductionIdentifier();
+			expect(stubs.getTrimmedOrEmptyString.callCount).to.equal(1);
+
+		});
 
 		describe('uuid property', () => {
 
-			it('assigns empty string if absent from props', () => {
-
-				const instance = new ProductionIdentifier({});
-				expect(instance.uuid).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is empty string', () => {
-
-				const instance = new ProductionIdentifier({ uuid: '' });
-				expect(instance.uuid).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is whitespace-only string', () => {
-
-				const instance = new ProductionIdentifier({ uuid: ' ' });
-				expect(instance.uuid).to.equal('');
-
-			});
-
-			it('assigns value if included in props and is string with length', () => {
+			it('assigns return value from getTrimmedOrEmptyString called with props value', () => {
 
 				const instance = new ProductionIdentifier({ uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' });
-				expect(instance.uuid).to.equal('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
-
-			});
-
-			it('trims value before assigning', () => {
-
-				const instance = new ProductionIdentifier({ uuid: ' xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx ' });
+				assert.calledWithExactly(stubs.getTrimmedOrEmptyString, 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
 				expect(instance.uuid).to.equal('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
 
 			});

--- a/test-unit/src/models/Review.test.js
+++ b/test-unit/src/models/Review.test.js
@@ -26,6 +26,9 @@ describe('Review model', () => {
 			isValidDateModule: {
 				isValidDate: stub().returns(true)
 			},
+			stringsModule: {
+				getTrimmedOrEmptyString: stub().callsFake(arg => arg?.trim() || '')
+			},
 			models: {
 				Company: CompanyStub,
 				Person: PersonStub
@@ -37,6 +40,7 @@ describe('Review model', () => {
 	const createSubject = () =>
 		proxyquire('../../../src/models/Review', {
 			'../lib/is-valid-date': stubs.isValidDateModule,
+			'../lib/strings': stubs.stringsModule,
 			'.': stubs.models
 		}).default;
 
@@ -50,39 +54,19 @@ describe('Review model', () => {
 
 	describe('constructor method', () => {
 
+		it('calls getTrimmedOrEmptyString to get values to assign to properties', () => {
+
+			createInstance();
+			expect(stubs.stringsModule.getTrimmedOrEmptyString.callCount).to.equal(2);
+
+		});
+
 		describe('url property', () => {
 
-			it('assigns empty string if absent from props', () => {
-
-				const instance = createInstance({});
-				expect(instance.url).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is empty string', () => {
-
-				const instance = createInstance({ url: '' });
-				expect(instance.url).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is whitespace-only string', () => {
-
-				const instance = createInstance({ url: ' ' });
-				expect(instance.url).to.equal('');
-
-			});
-
-			it('assigns value if included in props and is string with length', () => {
+			it('assigns return value from getTrimmedOrEmptyString called with props value', () => {
 
 				const instance = createInstance({ url: 'https://www.foo.com' });
-				expect(instance.url).to.equal('https://www.foo.com');
-
-			});
-
-			it('trims value before assigning', () => {
-
-				const instance = createInstance({ url: ' https://www.foo.com ' });
+				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.firstCall, 'https://www.foo.com');
 				expect(instance.url).to.equal('https://www.foo.com');
 
 			});
@@ -91,37 +75,10 @@ describe('Review model', () => {
 
 		describe('date property', () => {
 
-			it('assigns empty string if absent from props', () => {
-
-				const instance = createInstance({});
-				expect(instance.date).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is empty string', () => {
-
-				const instance = createInstance({ date: '' });
-				expect(instance.date).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is whitespace-only string', () => {
-
-				const instance = createInstance({ date: ' ' });
-				expect(instance.date).to.equal('');
-
-			});
-
-			it('assigns value if included in props and is string with length', () => {
+			it('assigns return value from getTrimmedOrEmptyString called with props value', () => {
 
 				const instance = createInstance({ date: '2024-04-03' });
-				expect(instance.date).to.equal('2024-04-03');
-
-			});
-
-			it('trims value before assigning', () => {
-
-				const instance = createInstance({ date: ' 2024-04-03 ' });
+				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.secondCall, '2024-04-03');
 				expect(instance.date).to.equal('2024-04-03');
 
 			});

--- a/test-unit/src/models/Role.test.js
+++ b/test-unit/src/models/Role.test.js
@@ -1,45 +1,45 @@
 import { expect } from 'chai';
-import { assert, spy } from 'sinon';
+import { assert, createSandbox, spy } from 'sinon';
 
+import * as stringsModule from '../../../src/lib/strings';
 import Role from '../../../src/models/Role';
 
 describe('Role model', () => {
 
+	let stubs;
+
+	const sandbox = createSandbox();
+
+	beforeEach(() => {
+
+		stubs = {
+			getTrimmedOrEmptyString:
+				sandbox.stub(stringsModule, 'getTrimmedOrEmptyString').callsFake(arg => arg?.trim() || '')
+		};
+
+	});
+
+	afterEach(() => {
+
+		sandbox.restore();
+
+	});
+
 	describe('constructor method', () => {
+
+		it('calls getTrimmedOrEmptyString to get values to assign to properties', () => {
+
+			new Role();
+			expect(stubs.getTrimmedOrEmptyString.callCount).to.equal(4);
+
+		});
 
 		describe('characterName property', () => {
 
-			it('assigns empty string if absent from props', () => {
+			it('assigns return value from getTrimmedOrEmptyString called with props value', () => {
 
-				const instance = new Role({ name: 'Hamlet, Prince of Denmark' });
-				expect(instance.characterName).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is empty string', () => {
-
-				const instance = new Role({ name: 'Hamlet, Prince of Denmark', characterName: '' });
-				expect(instance.characterName).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is whitespace-only string', () => {
-
-				const instance = new Role({ name: 'Hamlet, Prince of Denmark', characterName: ' ' });
-				expect(instance.characterName).to.equal('');
-
-			});
-
-			it('assigns value if included in props and is string with length', () => {
-
-				const instance = new Role({ name: 'Hamlet, Prince of Denmark', characterName: 'Hamlet' });
-				expect(instance.characterName).to.equal('Hamlet');
-
-			});
-
-			it('trims value before assigning', () => {
-
-				const instance = new Role({ name: 'Hamlet, Prince of Denmark', characterName: ' Hamlet ' });
+				const instance = new Role({ characterName: 'Hamlet' });
+				assert.calledWithExactly(stubs.getTrimmedOrEmptyString.secondCall, 'Hamlet');
 				expect(instance.characterName).to.equal('Hamlet');
 
 			});
@@ -48,37 +48,10 @@ describe('Role model', () => {
 
 		describe('characterDifferentiator property', () => {
 
-			it('assigns empty string if absent from props', () => {
+			it('assigns return value from getTrimmedOrEmptyString called with props value', () => {
 
-				const instance = new Role({ name: 'Cinna' });
-				expect(instance.characterDifferentiator).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is empty string', () => {
-
-				const instance = new Role({ name: 'Cinna', characterDifferentiator: '' });
-				expect(instance.characterDifferentiator).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is whitespace-only string', () => {
-
-				const instance = new Role({ name: 'Cinna', characterDifferentiator: ' ' });
-				expect(instance.characterDifferentiator).to.equal('');
-
-			});
-
-			it('assigns value if included in props and is string with length', () => {
-
-				const instance = new Role({ name: 'Cinna', characterDifferentiator: '1' });
-				expect(instance.characterDifferentiator).to.equal('1');
-
-			});
-
-			it('trims value before assigning', () => {
-
-				const instance = new Role({ name: 'Cinna', characterDifferentiator: ' 1 ' });
+				const instance = new Role({ characterDifferentiator: '1' });
+				assert.calledWithExactly(stubs.getTrimmedOrEmptyString.thirdCall, '1');
 				expect(instance.characterDifferentiator).to.equal('1');
 
 			});
@@ -87,37 +60,10 @@ describe('Role model', () => {
 
 		describe('qualifier property', () => {
 
-			it('assigns empty string if absent from props', () => {
+			it('assigns return value from getTrimmedOrEmptyString called with props value', () => {
 
-				const instance = new Role({ name: 'Esme' });
-				expect(instance.qualifier).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is empty string', () => {
-
-				const instance = new Role({ name: 'Esme', qualifier: '' });
-				expect(instance.qualifier).to.equal('');
-
-			});
-
-			it('assigns empty string if included in props but value is whitespace-only string', () => {
-
-				const instance = new Role({ name: 'Esme', qualifier: ' ' });
-				expect(instance.qualifier).to.equal('');
-
-			});
-
-			it('assigns value if included in props and is string with length', () => {
-
-				const instance = new Role({ name: 'Esme', qualifier: 'younger' });
-				expect(instance.qualifier).to.equal('younger');
-
-			});
-
-			it('trims value before assigning', () => {
-
-				const instance = new Role({ name: 'Esme', qualifier: ' younger ' });
+				const instance = new Role({ qualifier: 'younger' });
+				assert.calledWithExactly(stubs.getTrimmedOrEmptyString.getCall(3), 'younger');
 				expect(instance.qualifier).to.equal('younger');
 
 			});


### PR DESCRIPTION
This PR extracts the repeated logic used in model constructors when assigning string values to properties to a separate module, which also reduces the number of required unit tests (currently repeated each time the logic was used in a constructor; now run once for the shared module).