### PR TITLE
Use Sinon calledOnceWithExactly()

### DIFF
--- a/test-unit/src/controllers/award-ceremonies.test.js
+++ b/test-unit/src/controllers/award-ceremonies.test.js
@@ -54,8 +54,7 @@ describe('Award ceremonies controller', () => {
 		it('calls sendJsonResponse module', () => {
 
 			const result = callFunction('newRoute');
-			assert.calledOnce(stubs.sendJsonResponseModule.sendJsonResponse);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.sendJsonResponseModule.sendJsonResponse,
 				stubs.response, stubs.models.AwardCeremony() // eslint-disable-line new-cap
 			);
@@ -70,8 +69,7 @@ describe('Award ceremonies controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('createRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.AwardCeremony(), 'CREATE' // eslint-disable-line new-cap
 			);
@@ -86,8 +84,7 @@ describe('Award ceremonies controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('editRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.AwardCeremony(), 'EDIT' // eslint-disable-line new-cap
 			);
@@ -102,8 +99,7 @@ describe('Award ceremonies controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('updateRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.AwardCeremony(), 'UPDATE' // eslint-disable-line new-cap
 			);
@@ -118,8 +114,7 @@ describe('Award ceremonies controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('deleteRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.AwardCeremony(), 'DELETE' // eslint-disable-line new-cap
 			);
@@ -134,8 +129,7 @@ describe('Award ceremonies controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('showRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.AwardCeremony(), 'SHOW' // eslint-disable-line new-cap
 			);
@@ -150,8 +144,7 @@ describe('Award ceremonies controller', () => {
 		it('calls callStaticListMethod module', async () => {
 
 			const result = await callFunction('listRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callStaticListMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callStaticListMethod,
 				stubs.response, stubs.next, stubs.models.AwardCeremony, 'AWARD_CEREMONY'
 			);

--- a/test-unit/src/controllers/awards.test.js
+++ b/test-unit/src/controllers/awards.test.js
@@ -54,8 +54,7 @@ describe('Awards controller', () => {
 		it('calls sendJsonResponse module', () => {
 
 			const result = callFunction('newRoute');
-			assert.calledOnce(stubs.sendJsonResponseModule.sendJsonResponse);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.sendJsonResponseModule.sendJsonResponse,
 				stubs.response, stubs.models.Award() // eslint-disable-line new-cap
 			);
@@ -70,8 +69,7 @@ describe('Awards controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('createRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Award(), 'CREATE' // eslint-disable-line new-cap
 			);
@@ -86,8 +84,7 @@ describe('Awards controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('editRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Award(), 'EDIT' // eslint-disable-line new-cap
 			);
@@ -102,8 +99,7 @@ describe('Awards controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('updateRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Award(), 'UPDATE' // eslint-disable-line new-cap
 			);
@@ -118,8 +114,7 @@ describe('Awards controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('deleteRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Award(), 'DELETE' // eslint-disable-line new-cap
 			);
@@ -134,8 +129,7 @@ describe('Awards controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('showRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Award(), 'SHOW' // eslint-disable-line new-cap
 			);
@@ -150,8 +144,7 @@ describe('Awards controller', () => {
 		it('calls callStaticListMethod module', async () => {
 
 			const result = await callFunction('listRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callStaticListMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callStaticListMethod,
 				stubs.response, stubs.next, stubs.models.Award, 'AWARD'
 			);

--- a/test-unit/src/controllers/characters.test.js
+++ b/test-unit/src/controllers/characters.test.js
@@ -54,8 +54,7 @@ describe('Characters controller', () => {
 		it('calls sendJsonResponse module', () => {
 
 			const result = callFunction('newRoute');
-			assert.calledOnce(stubs.sendJsonResponseModule.sendJsonResponse);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.sendJsonResponseModule.sendJsonResponse,
 				stubs.response, stubs.models.Character() // eslint-disable-line new-cap
 			);
@@ -70,8 +69,7 @@ describe('Characters controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('createRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Character(), 'CREATE' // eslint-disable-line new-cap
 			);
@@ -86,8 +84,7 @@ describe('Characters controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('editRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Character(), 'EDIT' // eslint-disable-line new-cap
 			);
@@ -102,8 +99,7 @@ describe('Characters controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('updateRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Character(), 'UPDATE' // eslint-disable-line new-cap
 			);
@@ -118,8 +114,7 @@ describe('Characters controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('deleteRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Character(), 'DELETE' // eslint-disable-line new-cap
 			);
@@ -134,8 +129,7 @@ describe('Characters controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('showRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Character(), 'SHOW' // eslint-disable-line new-cap
 			);
@@ -150,8 +144,7 @@ describe('Characters controller', () => {
 		it('calls callStaticListMethod module', async () => {
 
 			const result = await callFunction('listRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callStaticListMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callStaticListMethod,
 				stubs.response, stubs.next, stubs.models.Character, 'CHARACTER'
 			);

--- a/test-unit/src/controllers/companies.test.js
+++ b/test-unit/src/controllers/companies.test.js
@@ -54,8 +54,7 @@ describe('Companies controller', () => {
 		it('calls sendJsonResponse module', () => {
 
 			const result = callFunction('newRoute');
-			assert.calledOnce(stubs.sendJsonResponseModule.sendJsonResponse);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.sendJsonResponseModule.sendJsonResponse,
 				stubs.response, stubs.models.Company() // eslint-disable-line new-cap
 			);
@@ -70,8 +69,7 @@ describe('Companies controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('createRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Company(), 'CREATE' // eslint-disable-line new-cap
 			);
@@ -86,8 +84,7 @@ describe('Companies controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('editRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Company(), 'EDIT' // eslint-disable-line new-cap
 			);
@@ -102,8 +99,7 @@ describe('Companies controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('updateRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Company(), 'UPDATE' // eslint-disable-line new-cap
 			);
@@ -118,8 +114,7 @@ describe('Companies controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('deleteRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Company(), 'DELETE' // eslint-disable-line new-cap
 			);
@@ -134,8 +129,7 @@ describe('Companies controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('showRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Company(), 'SHOW' // eslint-disable-line new-cap
 			);
@@ -150,8 +144,7 @@ describe('Companies controller', () => {
 		it('calls callStaticListMethod module', async () => {
 
 			const result = await callFunction('listRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callStaticListMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callStaticListMethod,
 				stubs.response, stubs.next, stubs.models.Company, 'COMPANY'
 			);

--- a/test-unit/src/controllers/festival-serieses.test.js
+++ b/test-unit/src/controllers/festival-serieses.test.js
@@ -54,8 +54,7 @@ describe('Festival Serieses controller', () => {
 		it('calls sendJsonResponse module', () => {
 
 			const result = callFunction('newRoute');
-			assert.calledOnce(stubs.sendJsonResponseModule.sendJsonResponse);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.sendJsonResponseModule.sendJsonResponse,
 				stubs.response, stubs.models.FestivalSeries() // eslint-disable-line new-cap
 			);
@@ -70,8 +69,7 @@ describe('Festival Serieses controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('createRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.FestivalSeries(), 'CREATE' // eslint-disable-line new-cap
 			);
@@ -86,8 +84,7 @@ describe('Festival Serieses controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('editRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.FestivalSeries(), 'EDIT' // eslint-disable-line new-cap
 			);
@@ -102,8 +99,7 @@ describe('Festival Serieses controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('updateRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.FestivalSeries(), 'UPDATE' // eslint-disable-line new-cap
 			);
@@ -118,8 +114,7 @@ describe('Festival Serieses controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('deleteRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.FestivalSeries(), 'DELETE' // eslint-disable-line new-cap
 			);
@@ -134,8 +129,7 @@ describe('Festival Serieses controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('showRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.FestivalSeries(), 'SHOW' // eslint-disable-line new-cap
 			);
@@ -150,8 +144,7 @@ describe('Festival Serieses controller', () => {
 		it('calls callStaticListMethod module', async () => {
 
 			const result = await callFunction('listRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callStaticListMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callStaticListMethod,
 				stubs.response, stubs.next, stubs.models.FestivalSeries, 'FESTIVAL_SERIES'
 			);

--- a/test-unit/src/controllers/festivals.test.js
+++ b/test-unit/src/controllers/festivals.test.js
@@ -54,8 +54,7 @@ describe('Festivals controller', () => {
 		it('calls sendJsonResponse module', () => {
 
 			const result = callFunction('newRoute');
-			assert.calledOnce(stubs.sendJsonResponseModule.sendJsonResponse);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.sendJsonResponseModule.sendJsonResponse,
 				stubs.response, stubs.models.Festival() // eslint-disable-line new-cap
 			);
@@ -70,8 +69,7 @@ describe('Festivals controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('createRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Festival(), 'CREATE' // eslint-disable-line new-cap
 			);
@@ -86,8 +84,7 @@ describe('Festivals controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('editRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Festival(), 'EDIT' // eslint-disable-line new-cap
 			);
@@ -102,8 +99,7 @@ describe('Festivals controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('updateRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Festival(), 'UPDATE' // eslint-disable-line new-cap
 			);
@@ -118,8 +114,7 @@ describe('Festivals controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('deleteRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Festival(), 'DELETE' // eslint-disable-line new-cap
 			);
@@ -134,8 +129,7 @@ describe('Festivals controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('showRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Festival(), 'SHOW' // eslint-disable-line new-cap
 			);
@@ -150,8 +144,7 @@ describe('Festivals controller', () => {
 		it('calls callStaticListMethod module', async () => {
 
 			const result = await callFunction('listRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callStaticListMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callStaticListMethod,
 				stubs.response, stubs.next, stubs.models.Festival, 'FESTIVAL'
 			);

--- a/test-unit/src/controllers/materials.test.js
+++ b/test-unit/src/controllers/materials.test.js
@@ -54,8 +54,7 @@ describe('Materials controller', () => {
 		it('calls sendJsonResponse module', () => {
 
 			const result = callFunction('newRoute');
-			assert.calledOnce(stubs.sendJsonResponseModule.sendJsonResponse);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.sendJsonResponseModule.sendJsonResponse,
 				stubs.response, stubs.models.Material() // eslint-disable-line new-cap
 			);
@@ -70,8 +69,7 @@ describe('Materials controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('createRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Material(), 'CREATE' // eslint-disable-line new-cap
 			);
@@ -86,8 +84,7 @@ describe('Materials controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('editRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Material(), 'EDIT' // eslint-disable-line new-cap
 			);
@@ -102,8 +99,7 @@ describe('Materials controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('updateRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Material(), 'UPDATE' // eslint-disable-line new-cap
 			);
@@ -118,8 +114,7 @@ describe('Materials controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('deleteRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Material(), 'DELETE' // eslint-disable-line new-cap
 			);
@@ -134,8 +129,7 @@ describe('Materials controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('showRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Material(), 'SHOW' // eslint-disable-line new-cap
 			);
@@ -150,8 +144,7 @@ describe('Materials controller', () => {
 		it('calls callStaticListMethod module', async () => {
 
 			const result = await callFunction('listRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callStaticListMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callStaticListMethod,
 				stubs.response, stubs.next, stubs.models.Material, 'MATERIAL'
 			);

--- a/test-unit/src/controllers/people.test.js
+++ b/test-unit/src/controllers/people.test.js
@@ -54,8 +54,7 @@ describe('People controller', () => {
 		it('calls sendJsonResponse module', () => {
 
 			const result = callFunction('newRoute');
-			assert.calledOnce(stubs.sendJsonResponseModule.sendJsonResponse);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.sendJsonResponseModule.sendJsonResponse,
 				stubs.response, stubs.models.Person() // eslint-disable-line new-cap
 			);
@@ -70,8 +69,7 @@ describe('People controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('createRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Person(), 'CREATE' // eslint-disable-line new-cap
 			);
@@ -86,8 +84,7 @@ describe('People controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('editRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Person(), 'EDIT' // eslint-disable-line new-cap
 			);
@@ -102,8 +99,7 @@ describe('People controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('updateRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Person(), 'UPDATE' // eslint-disable-line new-cap
 			);
@@ -118,8 +114,7 @@ describe('People controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('deleteRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Person(), 'DELETE' // eslint-disable-line new-cap
 			);
@@ -134,8 +129,7 @@ describe('People controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('showRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Person(), 'SHOW' // eslint-disable-line new-cap
 			);
@@ -150,8 +144,7 @@ describe('People controller', () => {
 		it('calls callStaticListMethod module', async () => {
 
 			const result = await callFunction('listRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callStaticListMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callStaticListMethod,
 				stubs.response, stubs.next, stubs.models.Person, 'PERSON'
 			);

--- a/test-unit/src/controllers/productions.test.js
+++ b/test-unit/src/controllers/productions.test.js
@@ -54,8 +54,7 @@ describe('Productions controller', () => {
 		it('calls sendJsonResponse module', () => {
 
 			const result = callFunction('newRoute');
-			assert.calledOnce(stubs.sendJsonResponseModule.sendJsonResponse);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.sendJsonResponseModule.sendJsonResponse,
 				stubs.response, stubs.models.Production() // eslint-disable-line new-cap
 			);
@@ -70,8 +69,7 @@ describe('Productions controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('createRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Production(), 'CREATE' // eslint-disable-line new-cap
 			);
@@ -86,8 +84,7 @@ describe('Productions controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('editRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Production(), 'EDIT' // eslint-disable-line new-cap
 			);
@@ -102,8 +99,7 @@ describe('Productions controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('updateRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Production(), 'UPDATE' // eslint-disable-line new-cap
 			);
@@ -118,8 +114,7 @@ describe('Productions controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('deleteRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Production(), 'DELETE' // eslint-disable-line new-cap
 			);
@@ -134,8 +129,7 @@ describe('Productions controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('showRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Production(), 'SHOW' // eslint-disable-line new-cap
 			);
@@ -150,8 +144,7 @@ describe('Productions controller', () => {
 		it('calls callStaticListMethod module', async () => {
 
 			const result = await callFunction('listRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callStaticListMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callStaticListMethod,
 				stubs.response, stubs.next, stubs.models.Production, 'PRODUCTION'
 			);

--- a/test-unit/src/controllers/search.test.js
+++ b/test-unit/src/controllers/search.test.js
@@ -40,8 +40,7 @@ describe('Search controller', () => {
 
 			const request = httpMocks.createRequest();
 			const result = await searchController(request, stubs.response, stubs.next);
-			assert.calledOnce(stubs.sendJsonResponse);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.sendJsonResponse,
 				stubs.response, []
 			);
@@ -60,8 +59,7 @@ describe('Search controller', () => {
 
 			const request = httpMocks.createRequest({ query: { searchTerm: '' } });
 			const result = await searchController(request, stubs.response, stubs.next);
-			assert.calledOnce(stubs.sendJsonResponse);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.sendJsonResponse,
 				stubs.response, []
 			);
@@ -81,10 +79,8 @@ describe('Search controller', () => {
 			it('calls getSearchQuery, neo4jQuery, then sendJsonResponse with the response object and the neo4jQuery response', async () => {
 
 				const result = await searchController(stubs.request, stubs.response, stubs.next);
-				assert.calledOnce(stubs.getSearchQuery);
-				assert.calledWithExactly(stubs.getSearchQuery);
-				assert.calledOnce(stubs.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(stubs.getSearchQuery);
+				assert.calledOnceWithExactly(
 					stubs.neo4jQuery,
 					{
 						query: 'getSearchQuery response',
@@ -97,8 +93,7 @@ describe('Search controller', () => {
 						isArrayResult: true
 					}
 				);
-				assert.calledOnce(stubs.sendJsonResponse);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(
 					stubs.sendJsonResponse,
 					stubs.response, ['foo bar']
 				);
@@ -117,10 +112,8 @@ describe('Search controller', () => {
 				stubs.neo4jQuery.rejects(neo4jQueryError);
 				
 				await searchController(stubs.request, stubs.response, stubs.next);
-				assert.calledOnce(stubs.getSearchQuery);
-				assert.calledWithExactly(stubs.getSearchQuery);
-				assert.calledOnce(stubs.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(stubs.getSearchQuery);
+				assert.calledOnceWithExactly(
 					stubs.neo4jQuery,
 					{
 						query: 'getSearchQuery response',
@@ -134,8 +127,7 @@ describe('Search controller', () => {
 					}
 				);
 				assert.notCalled(stubs.sendJsonResponse);
-				assert.calledOnce(stubs.next);
-				assert.calledWithExactly(stubs.next, neo4jQueryError);
+				assert.calledOnceWithExactly(stubs.next, neo4jQueryError);
 
 			});
 

--- a/test-unit/src/controllers/seasons.test.js
+++ b/test-unit/src/controllers/seasons.test.js
@@ -54,8 +54,7 @@ describe('Seasons controller', () => {
 		it('calls sendJsonResponse module', () => {
 
 			const result = callFunction('newRoute');
-			assert.calledOnce(stubs.sendJsonResponseModule.sendJsonResponse);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.sendJsonResponseModule.sendJsonResponse,
 				stubs.response, stubs.models.Season() // eslint-disable-line new-cap
 			);
@@ -70,8 +69,7 @@ describe('Seasons controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('createRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Season(), 'CREATE' // eslint-disable-line new-cap
 			);
@@ -86,8 +84,7 @@ describe('Seasons controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('editRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Season(), 'EDIT' // eslint-disable-line new-cap
 			);
@@ -102,8 +99,7 @@ describe('Seasons controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('updateRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Season(), 'UPDATE' // eslint-disable-line new-cap
 			);
@@ -118,8 +114,7 @@ describe('Seasons controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('deleteRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Season(), 'DELETE' // eslint-disable-line new-cap
 			);
@@ -134,8 +129,7 @@ describe('Seasons controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('showRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Season(), 'SHOW' // eslint-disable-line new-cap
 			);
@@ -150,8 +144,7 @@ describe('Seasons controller', () => {
 		it('calls callStaticListMethod module', async () => {
 
 			const result = await callFunction('listRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callStaticListMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callStaticListMethod,
 				stubs.response, stubs.next, stubs.models.Season, 'SEASON'
 			);

--- a/test-unit/src/controllers/venues.test.js
+++ b/test-unit/src/controllers/venues.test.js
@@ -54,8 +54,7 @@ describe('Venues controller', () => {
 		it('calls sendJsonResponse module', () => {
 
 			const result = callFunction('newRoute');
-			assert.calledOnce(stubs.sendJsonResponseModule.sendJsonResponse);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.sendJsonResponseModule.sendJsonResponse,
 				stubs.response, stubs.models.Venue() // eslint-disable-line new-cap
 			);
@@ -70,8 +69,7 @@ describe('Venues controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('createRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Venue(), 'CREATE' // eslint-disable-line new-cap
 			);
@@ -86,8 +84,7 @@ describe('Venues controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('editRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Venue(), 'EDIT' // eslint-disable-line new-cap
 			);
@@ -102,8 +99,7 @@ describe('Venues controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('updateRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Venue(), 'UPDATE' // eslint-disable-line new-cap
 			);
@@ -118,8 +114,7 @@ describe('Venues controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('deleteRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Venue(), 'DELETE' // eslint-disable-line new-cap
 			);
@@ -134,8 +129,7 @@ describe('Venues controller', () => {
 		it('calls callInstanceMethod module', async () => {
 
 			const result = await callFunction('showRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callInstanceMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callInstanceMethod,
 				stubs.response, stubs.next, stubs.models.Venue(), 'SHOW' // eslint-disable-line new-cap
 			);
@@ -150,8 +144,7 @@ describe('Venues controller', () => {
 		it('calls callStaticListMethod module', async () => {
 
 			const result = await callFunction('listRoute');
-			assert.calledOnce(stubs.callClassMethodsModule.callStaticListMethod);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.callClassMethodsModule.callStaticListMethod,
 				stubs.response, stubs.next, stubs.models.Venue, 'VENUE'
 			);

--- a/test-unit/src/lib/call-class-methods.test.js
+++ b/test-unit/src/lib/call-class-methods.test.js
@@ -50,8 +50,7 @@ describe('Call Class Methods module', () => {
 				const instanceMethodResponse = { property: 'value' };
 				sandbox.stub(character, method).callsFake(() => { return Promise.resolve(instanceMethodResponse); });
 				const result = await callClassMethods.callInstanceMethod(stubs.response, stubs.next, character, method);
-				assert.calledOnce(stubs.sendJsonResponse);
-				assert.calledWithExactly(stubs.sendJsonResponse, stubs.response, instanceMethodResponse);
+				assert.calledOnceWithExactly(stubs.sendJsonResponse, stubs.response, instanceMethodResponse);
 				assert.notCalled(stubs.next);
 				expect(result).to.equal('sendJsonResponse response');
 
@@ -65,8 +64,7 @@ describe('Call Class Methods module', () => {
 
 				sandbox.stub(character, method).callsFake(() => { return Promise.reject(error); });
 				await callClassMethods.callInstanceMethod(stubs.response, stubs.next, character, method);
-				assert.calledOnce(stubs.next);
-				assert.calledWithExactly(stubs.next, error);
+				assert.calledOnceWithExactly(stubs.next, error);
 				assert.notCalled(stubs.sendJsonResponse);
 
 			});
@@ -108,8 +106,7 @@ describe('Call Class Methods module', () => {
 				sandbox.stub(Character, method).callsFake(() => { return Promise.resolve(staticListMethodResponse); });
 				const result =
 					await callClassMethods.callStaticListMethod(stubs.response, stubs.next, Character, 'character');
-				assert.calledOnce(stubs.sendJsonResponse);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(
 					stubs.sendJsonResponse,
 					stubs.response, staticListMethodResponse
 				);
@@ -126,8 +123,7 @@ describe('Call Class Methods module', () => {
 
 				sandbox.stub(Character, method).callsFake(() => { return Promise.reject(error); });
 				await callClassMethods.callStaticListMethod(stubs.response, stubs.next, Character, 'character');
-				assert.calledOnce(stubs.next);
-				assert.calledWithExactly(stubs.next, error);
+				assert.calledOnceWithExactly(stubs.next, error);
 				assert.notCalled(stubs.sendJsonResponse);
 
 			});

--- a/test-unit/src/models/AwardCeremony.test.js
+++ b/test-unit/src/models/AwardCeremony.test.js
@@ -154,19 +154,14 @@ describe('AwardCeremony model', () => {
 				stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices,
 				instance.categories[0].runInputValidations
 			);
-			assert.calledOnce(instance.validateName);
-			assert.calledWithExactly(instance.validateName, { isRequired: true });
-			assert.calledOnce(instance.award.validateName);
-			assert.calledWithExactly(instance.award.validateName, { isRequired: false });
-			assert.calledOnce(instance.award.validateDifferentiator);
-			assert.calledWithExactly(instance.award.validateDifferentiator);
-			assert.calledOnce(stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(instance.validateName, { isRequired: true });
+			assert.calledOnceWithExactly(instance.award.validateName, { isRequired: false });
+			assert.calledOnceWithExactly(instance.award.validateDifferentiator);
+			assert.calledOnceWithExactly(
 				stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices,
 				instance.categories
 			);
-			assert.calledOnce(instance.categories[0].runInputValidations);
-			assert.calledWithExactly(instance.categories[0].runInputValidations, { isDuplicate: false });
+			assert.calledOnceWithExactly(instance.categories[0].runInputValidations, { isDuplicate: false });
 
 		});
 
@@ -187,10 +182,8 @@ describe('AwardCeremony model', () => {
 			const instance = createInstance(props);
 			spy(instance, 'validateAwardContextualUniquenessInDatabase');
 			await instance.runDatabaseValidations();
-			assert.calledOnce(instance.validateAwardContextualUniquenessInDatabase);
-			assert.calledWithExactly(instance.validateAwardContextualUniquenessInDatabase);
-			assert.calledOnce(instance.categories[0].runDatabaseValidations);
-			assert.calledWithExactly(instance.categories[0].runDatabaseValidations);
+			assert.calledOnceWithExactly(instance.validateAwardContextualUniquenessInDatabase);
+			assert.calledOnceWithExactly(instance.categories[0].runDatabaseValidations);
 
 		});
 
@@ -211,16 +204,11 @@ describe('AwardCeremony model', () => {
 					stubs.cypherQueriesModule.validationQueries.getAwardContextualDuplicateRecordCheckQuery,
 					stubs.neo4jQueryModule.neo4jQuery
 				);
-				assert.calledOnce(stubs.prepareAsParamsModule.prepareAsParams);
-				assert.calledWithExactly(stubs.prepareAsParamsModule.prepareAsParams, instance);
-				assert.calledOnce(
+				assert.calledOnceWithExactly(stubs.prepareAsParamsModule.prepareAsParams, instance);
+				assert.calledOnceWithExactly(
 					stubs.cypherQueriesModule.validationQueries.getAwardContextualDuplicateRecordCheckQuery
 				);
-				assert.calledWithExactly(
-					stubs.cypherQueriesModule.validationQueries.getAwardContextualDuplicateRecordCheckQuery
-				);
-				assert.calledOnce(stubs.neo4jQueryModule.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(
 					stubs.neo4jQueryModule.neo4jQuery,
 					{
 						query: 'getAwardContextualDuplicateRecordCheckQuery response',
@@ -255,16 +243,11 @@ describe('AwardCeremony model', () => {
 					stubs.neo4jQueryModule.neo4jQuery,
 					instance.addPropertyError
 				);
-				assert.calledOnce(stubs.prepareAsParamsModule.prepareAsParams);
-				assert.calledWithExactly(stubs.prepareAsParamsModule.prepareAsParams, instance);
-				assert.calledOnce(
+				assert.calledOnceWithExactly(stubs.prepareAsParamsModule.prepareAsParams, instance);
+				assert.calledOnceWithExactly(
 					stubs.cypherQueriesModule.validationQueries.getAwardContextualDuplicateRecordCheckQuery
 				);
-				assert.calledWithExactly(
-					stubs.cypherQueriesModule.validationQueries.getAwardContextualDuplicateRecordCheckQuery
-				);
-				assert.calledOnce(stubs.neo4jQueryModule.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(
 					stubs.neo4jQueryModule.neo4jQuery,
 					{
 						query: 'getAwardContextualDuplicateRecordCheckQuery response',
@@ -278,8 +261,7 @@ describe('AwardCeremony model', () => {
 						}
 					}
 				);
-				assert.calledOnce(instance.addPropertyError);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(
 					instance.addPropertyError,
 					'name', 'Award ceremony already exists for given award'
 				);

--- a/test-unit/src/models/AwardCeremonyCategory.test.js
+++ b/test-unit/src/models/AwardCeremonyCategory.test.js
@@ -57,14 +57,10 @@ describe('AwardCeremonyCategory model', () => {
 				instance.validateNamePresenceIfNamedChildren,
 				instance.nominations[0].runInputValidations
 			);
-			assert.calledOnce(instance.validateName);
-			assert.calledWithExactly(instance.validateName, { isRequired: false });
-			assert.calledOnce(instance.validateUniquenessInGroup);
-			assert.calledWithExactly(instance.validateUniquenessInGroup, { isDuplicate: false });
-			assert.calledOnce(instance.validateNamePresenceIfNamedChildren);
-			assert.calledWithExactly(instance.validateNamePresenceIfNamedChildren, []);
-			assert.calledOnce(instance.nominations[0].runInputValidations);
-			assert.calledWithExactly(instance.nominations[0].runInputValidations);
+			assert.calledOnceWithExactly(instance.validateName, { isRequired: false });
+			assert.calledOnceWithExactly(instance.validateUniquenessInGroup, { isDuplicate: false });
+			assert.calledOnceWithExactly(instance.validateNamePresenceIfNamedChildren, []);
+			assert.calledOnceWithExactly(instance.nominations[0].runInputValidations);
 
 		});
 
@@ -80,8 +76,7 @@ describe('AwardCeremonyCategory model', () => {
 			const instance = new AwardCeremonyCategory(props);
 			spy(instance.nominations[0], 'runDatabaseValidations');
 			await instance.runDatabaseValidations();
-			assert.calledOnce(instance.nominations[0].runDatabaseValidations);
-			assert.calledWithExactly(instance.nominations[0].runDatabaseValidations);
+			assert.calledOnceWithExactly(instance.nominations[0].runDatabaseValidations);
 
 		});
 

--- a/test-unit/src/models/Base.test.js
+++ b/test-unit/src/models/Base.test.js
@@ -45,8 +45,7 @@ describe('Base model', () => {
 
 				it('assigns return value from getTrimmedOrEmptyString called with props value', () => {
 
-					assert.calledOnce(stubs.getTrimmedOrEmptyString);
-					assert.calledWithExactly(stubs.getTrimmedOrEmptyString, 'Foobar');
+					assert.calledOnceWithExactly(stubs.getTrimmedOrEmptyString, 'Foobar');
 					expect(instance.name).to.equal('Foobar');
 
 				});
@@ -106,8 +105,7 @@ describe('Base model', () => {
 
 			spy(instance, 'validateStringForProperty');
 			instance.validateName({ isRequired: false });
-			assert.calledOnce(instance.validateStringForProperty);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				instance.validateStringForProperty,
 				'name', { isRequired: false }
 			);
@@ -122,8 +120,7 @@ describe('Base model', () => {
 
 			spy(instance, 'validateStringForProperty');
 			instance.validateQualifier();
-			assert.calledOnce(instance.validateStringForProperty);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				instance.validateStringForProperty,
 				'qualifier', { isRequired: false }
 			);
@@ -140,8 +137,7 @@ describe('Base model', () => {
 
 				spy(instance, 'addPropertyError');
 				instance.validateStringForProperty('name', { isRequired: false });
-				assert.calledOnce(stubs.validateString);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(
 					stubs.validateString,
 					instance.name, { isRequired: false }
 				);
@@ -162,13 +158,11 @@ describe('Base model', () => {
 					stubs.validateString,
 					instance.addPropertyError
 				);
-				assert.calledOnce(stubs.validateString);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(
 					stubs.validateString,
 					instance.name, { isRequired: true }
 				);
-				assert.calledOnce(instance.addPropertyError);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(
 					instance.addPropertyError,
 					'name', 'Value is too short'
 				);
@@ -203,8 +197,7 @@ describe('Base model', () => {
 					spy(instance, 'addPropertyError');
 					const opts = { isDuplicate: true };
 					instance.validateUniquenessInGroup(opts);
-					assert.calledOnce(instance.addPropertyError);
-					assert.calledWithExactly(
+					assert.calledOnceWithExactly(
 						instance.addPropertyError,
 						'name', 'This item has been duplicated within the group'
 					);
@@ -330,8 +323,7 @@ describe('Base model', () => {
 					spy(instance, 'addPropertyError');
 					const opts = { isDuplicate: true };
 					instance.validateUniquenessInGroup(opts);
-					assert.calledOnce(instance.addPropertyError);
-					assert.calledWithExactly(
+					assert.calledOnceWithExactly(
 						instance.addPropertyError,
 						'name', 'This item has been duplicated within the group'
 					);
@@ -380,8 +372,7 @@ describe('Base model', () => {
 					spy(instance, 'addPropertyError');
 					const opts = { isDuplicate: true, properties: new Set(['uuid']) };
 					instance.validateUniquenessInGroup(opts);
-					assert.calledOnce(instance.addPropertyError);
-					assert.calledWithExactly(
+					assert.calledOnceWithExactly(
 						instance.addPropertyError,
 						'uuid', 'This item has been duplicated within the group'
 					);
@@ -400,8 +391,7 @@ describe('Base model', () => {
 
 			spy(instance, 'validatePropertyPresenceIfNamedChildren');
 			instance.validateNamePresenceIfNamedChildren([{ name: 'Foo' }, { name: 'Bar' }]);
-			assert.calledOnce(instance.validatePropertyPresenceIfNamedChildren);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				instance.validatePropertyPresenceIfNamedChildren,
 				'name', [{ name: 'Foo' }, { name: 'Bar' }]
 			);
@@ -459,8 +449,7 @@ describe('Base model', () => {
 				instance.name = '';
 				spy(instance, 'addPropertyError');
 				instance.validatePropertyPresenceIfNamedChildren('name', [{ name: 'Bar' }]);
-				assert.calledOnce(instance.addPropertyError);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(
 					instance.addPropertyError,
 					'name', 'Value is required if named children exist'
 				);

--- a/test-unit/src/models/CastMember.test.js
+++ b/test-unit/src/models/CastMember.test.js
@@ -110,29 +110,19 @@ describe('CastMember model', () => {
 				instance.roles[0].validateRoleNameCharacterNameDisparity,
 				instance.roles[0].validateUniquenessInGroup
 			);
-			assert.calledOnce(instance.validateName);
-			assert.calledWithExactly(instance.validateName, { isRequired: false });
-			assert.calledOnce(instance.validateDifferentiator);
-			assert.calledWithExactly(instance.validateDifferentiator);
-			assert.calledOnce(instance.validateUniquenessInGroup);
-			assert.calledWithExactly(instance.validateUniquenessInGroup, { isDuplicate: false });
-			assert.calledOnce(instance.validateNamePresenceIfNamedChildren);
-			assert.calledWithExactly(instance.validateNamePresenceIfNamedChildren, instance.roles);
-			assert.calledOnce(stubs.getDuplicateIndicesModule.getDuplicateRoleIndices);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(instance.validateName, { isRequired: false });
+			assert.calledOnceWithExactly(instance.validateDifferentiator);
+			assert.calledOnceWithExactly(instance.validateUniquenessInGroup, { isDuplicate: false });
+			assert.calledOnceWithExactly(instance.validateNamePresenceIfNamedChildren, instance.roles);
+			assert.calledOnceWithExactly(
 				stubs.getDuplicateIndicesModule.getDuplicateRoleIndices,
 				instance.roles
 			);
-			assert.calledOnce(instance.roles[0].validateName);
-			assert.calledWithExactly(instance.roles[0].validateName, { isRequired: false });
-			assert.calledOnce(instance.roles[0].validateCharacterName);
-			assert.calledWithExactly(instance.roles[0].validateCharacterName);
-			assert.calledOnce(instance.roles[0].validateQualifier);
-			assert.calledWithExactly(instance.roles[0].validateQualifier);
-			assert.calledOnce(instance.roles[0].validateRoleNameCharacterNameDisparity);
-			assert.calledWithExactly(instance.roles[0].validateRoleNameCharacterNameDisparity);
-			assert.calledOnce(instance.roles[0].validateUniquenessInGroup);
-			assert.calledWithExactly(instance.roles[0].validateUniquenessInGroup, { isDuplicate: false });
+			assert.calledOnceWithExactly(instance.roles[0].validateName, { isRequired: false });
+			assert.calledOnceWithExactly(instance.roles[0].validateCharacterName);
+			assert.calledOnceWithExactly(instance.roles[0].validateQualifier);
+			assert.calledOnceWithExactly(instance.roles[0].validateRoleNameCharacterNameDisparity);
+			assert.calledOnceWithExactly(instance.roles[0].validateUniquenessInGroup, { isDuplicate: false });
 
 		});
 

--- a/test-unit/src/models/CharacterDepiction.test.js
+++ b/test-unit/src/models/CharacterDepiction.test.js
@@ -67,8 +67,7 @@ describe('CharacterDepiction model', () => {
 			const instance = new CharacterDepiction({ name: 'Prince Hal', underlyingName: 'King Henry V' });
 			spy(instance, 'validateStringForProperty');
 			instance.validateUnderlyingName();
-			assert.calledOnce(instance.validateStringForProperty);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				instance.validateStringForProperty,
 				'underlyingName', { isRequired: false }
 			);
@@ -129,8 +128,7 @@ describe('CharacterDepiction model', () => {
 				const instance = new CharacterDepiction({ name: 'King Henry V', underlyingName: 'King Henry V' });
 				spy(instance, 'addPropertyError');
 				instance.validateCharacterNameUnderlyingNameDisparity();
-				assert.calledOnce(instance.addPropertyError);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(
 					instance.addPropertyError,
 					'underlyingName', 'Underlying name is only required if different from character name'
 				);

--- a/test-unit/src/models/CharacterGroup.test.js
+++ b/test-unit/src/models/CharacterGroup.test.js
@@ -105,25 +105,17 @@ describe('CharacterGroup model', () => {
 				instance.characters[0].validateCharacterNameUnderlyingNameDisparity,
 				instance.characters[0].validateUniquenessInGroup
 			);
-			assert.calledOnce(instance.validateName);
-			assert.calledWithExactly(instance.validateName, { isRequired: false });
-			assert.calledOnce(stubs.getDuplicateIndicesModule.getDuplicateCharacterIndices);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(instance.validateName, { isRequired: false });
+			assert.calledOnceWithExactly(
 				stubs.getDuplicateIndicesModule.getDuplicateCharacterIndices,
 				instance.characters
 			);
-			assert.calledOnce(instance.characters[0].validateName);
-			assert.calledWithExactly(instance.characters[0].validateName, { isRequired: false });
-			assert.calledOnce(instance.characters[0].validateUnderlyingName);
-			assert.calledWithExactly(instance.characters[0].validateUnderlyingName);
-			assert.calledOnce(instance.characters[0].validateDifferentiator);
-			assert.calledWithExactly(instance.characters[0].validateDifferentiator);
-			assert.calledOnce(instance.characters[0].validateQualifier);
-			assert.calledWithExactly(instance.characters[0].validateQualifier);
-			assert.calledOnce(instance.characters[0].validateCharacterNameUnderlyingNameDisparity);
-			assert.calledWithExactly(instance.characters[0].validateCharacterNameUnderlyingNameDisparity);
-			assert.calledOnce(instance.characters[0].validateUniquenessInGroup);
-			assert.calledWithExactly(instance.characters[0].validateUniquenessInGroup, { isDuplicate: false });
+			assert.calledOnceWithExactly(instance.characters[0].validateName, { isRequired: false });
+			assert.calledOnceWithExactly(instance.characters[0].validateUnderlyingName);
+			assert.calledOnceWithExactly(instance.characters[0].validateDifferentiator);
+			assert.calledOnceWithExactly(instance.characters[0].validateQualifier);
+			assert.calledOnceWithExactly(instance.characters[0].validateCharacterNameUnderlyingNameDisparity);
+			assert.calledOnceWithExactly(instance.characters[0].validateUniquenessInGroup, { isDuplicate: false });
 
 		});
 

--- a/test-unit/src/models/CompanyWithMembers.test.js
+++ b/test-unit/src/models/CompanyWithMembers.test.js
@@ -102,18 +102,14 @@ describe('CompanyWithMembers model', () => {
 				stubs.getDuplicateEntityInfoModule.isEntityInArray,
 				instance.members[0].validateUniquenessInGroup
 			);
-			assert.calledOnce(instance.validateNamePresenceIfNamedChildren);
-			assert.calledOnce(instance.members[0].validateName);
-			assert.calledWithExactly(instance.members[0].validateName, { isRequired: false });
-			assert.calledOnce(instance.members[0].validateDifferentiator);
-			assert.calledWithExactly(instance.members[0].validateDifferentiator);
-			assert.calledOnce(stubs.getDuplicateEntityInfoModule.isEntityInArray);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(instance.validateNamePresenceIfNamedChildren, instance.members);
+			assert.calledOnceWithExactly(instance.members[0].validateName, { isRequired: false });
+			assert.calledOnceWithExactly(instance.members[0].validateDifferentiator);
+			assert.calledOnceWithExactly(
 				stubs.getDuplicateEntityInfoModule.isEntityInArray,
 				instance.members[0], []
 			);
-			assert.calledOnce(instance.members[0].validateUniquenessInGroup);
-			assert.calledWithExactly(instance.members[0].validateUniquenessInGroup, { isDuplicate: false });
+			assert.calledOnceWithExactly(instance.members[0].validateUniquenessInGroup, { isDuplicate: false });
 
 		});
 

--- a/test-unit/src/models/Entity.test.js
+++ b/test-unit/src/models/Entity.test.js
@@ -189,10 +189,8 @@ describe('Entity model', () => {
 			spy(instance, 'validateName');
 			spy(instance, 'validateDifferentiator');
 			instance.runInputValidations();
-			assert.calledOnce(instance.validateName);
-			assert.calledWithExactly(instance.validateName, { isRequired: true });
-			assert.calledOnce(instance.validateDifferentiator);
-			assert.calledWithExactly(instance.validateDifferentiator);
+			assert.calledOnceWithExactly(instance.validateName, { isRequired: true });
+			assert.calledOnceWithExactly(instance.validateDifferentiator);
 
 		});
 
@@ -204,8 +202,7 @@ describe('Entity model', () => {
 
 			spy(instance, 'validateStringForProperty');
 			instance.validateDifferentiator();
-			assert.calledOnce(instance.validateStringForProperty);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				instance.validateStringForProperty,
 				'differentiator', { isRequired: false }
 			);
@@ -220,8 +217,7 @@ describe('Entity model', () => {
 
 			spy(instance, 'validateStringForProperty');
 			instance.validateSubtitle();
-			assert.calledOnce(instance.validateStringForProperty);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				instance.validateStringForProperty,
 				'subtitle', { isRequired: false }
 			);
@@ -357,8 +353,7 @@ describe('Entity model', () => {
 					const instance = new ProductionIdentifier({ uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' });
 					spy(instance, 'addPropertyError');
 					instance.validateNoAssociationWithSelf({ uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' });
-					assert.calledOnce(instance.addPropertyError);
-					assert.calledWithExactly(
+					assert.calledOnceWithExactly(
 						instance.addPropertyError,
 						'uuid', 'Instance cannot form association with itself'
 					);
@@ -379,8 +374,7 @@ describe('Entity model', () => {
 
 				spy(instance, 'validateUniquenessInDatabase');
 				await instance.runDatabaseValidations();
-				assert.calledOnce(instance.validateUniquenessInDatabase);
-				assert.calledWithExactly(instance.validateUniquenessInDatabase);
+				assert.calledOnceWithExactly(instance.validateUniquenessInDatabase);
 
 			});
 
@@ -420,12 +414,9 @@ describe('Entity model', () => {
 					stubs.validationQueries.getDuplicateRecordCheckQuery,
 					stubs.neo4jQuery
 				);
-				assert.calledOnce(stubs.prepareAsParams);
-				assert.calledWithExactly(stubs.prepareAsParams, instance);
-				assert.calledOnce(stubs.validationQueries.getDuplicateRecordCheckQuery);
-				assert.calledWithExactly(stubs.validationQueries.getDuplicateRecordCheckQuery, instance.model);
-				assert.calledOnce(stubs.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(stubs.prepareAsParams, instance);
+				assert.calledOnceWithExactly(stubs.validationQueries.getDuplicateRecordCheckQuery, instance.model);
+				assert.calledOnceWithExactly(
 					stubs.neo4jQuery,
 					{
 						query: 'getDuplicateRecordCheckQuery response',
@@ -460,12 +451,9 @@ describe('Entity model', () => {
 					stubs.neo4jQuery,
 					instance.addPropertyError
 				);
-				assert.calledOnce(stubs.prepareAsParams);
-				assert.calledWithExactly(stubs.prepareAsParams, instance);
-				assert.calledOnce(stubs.validationQueries.getDuplicateRecordCheckQuery);
-				assert.calledWithExactly(stubs.validationQueries.getDuplicateRecordCheckQuery, instance.model);
-				assert.calledOnce(stubs.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(stubs.prepareAsParams, instance);
+				assert.calledOnceWithExactly(stubs.validationQueries.getDuplicateRecordCheckQuery, instance.model);
+				assert.calledOnceWithExactly(
 					stubs.neo4jQuery,
 					{
 						query: 'getDuplicateRecordCheckQuery response',
@@ -497,8 +485,7 @@ describe('Entity model', () => {
 		it('will call hasErrors function and assign its return value to the instance\'s hasErrors property', () => {
 
 			instance.setErrorStatus();
-			assert.calledOnce(stubs.hasErrors);
-			assert.calledWithExactly(stubs.hasErrors, instance);
+			assert.calledOnceWithExactly(stubs.hasErrors, instance);
 			expect(instance.hasErrors).to.be.false;
 
 		});
@@ -518,10 +505,8 @@ describe('Entity model', () => {
 					stubs.validationQueries.getExistenceCheckQuery,
 					stubs.neo4jQuery
 				);
-				assert.calledOnce(stubs.validationQueries.getExistenceCheckQuery);
-				assert.calledWithExactly(stubs.validationQueries.getExistenceCheckQuery, instance.model);
-				assert.calledOnce(stubs.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(stubs.validationQueries.getExistenceCheckQuery, instance.model);
+				assert.calledOnceWithExactly(
 					stubs.neo4jQuery,
 					{ query: 'getExistenceCheckQuery response', params: { uuid: instance.uuid } }
 				);
@@ -541,10 +526,8 @@ describe('Entity model', () => {
 					stubs.validationQueries.getExistenceCheckQuery,
 					stubs.neo4jQuery
 				);
-				assert.calledOnce(stubs.validationQueries.getExistenceCheckQuery);
-				assert.calledWithExactly(stubs.validationQueries.getExistenceCheckQuery, model);
-				assert.calledOnce(stubs.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(stubs.validationQueries.getExistenceCheckQuery, model);
+				assert.calledOnceWithExactly(
 					stubs.neo4jQuery,
 					{ query: 'getExistenceCheckQuery response', params: { uuid: instance.uuid } }
 				);
@@ -607,14 +590,10 @@ describe('Entity model', () => {
 					stubs.prepareAsParams,
 					stubs.neo4jQuery
 				);
-				assert.calledOnce(instance.runInputValidations);
-				assert.calledWithExactly(instance.runInputValidations);
-				assert.calledOnce(instance.runDatabaseValidations);
-				assert.calledWithExactly(instance.runDatabaseValidations);
-				assert.calledOnce(instance.setErrorStatus);
-				assert.calledWithExactly(instance.setErrorStatus);
-				assert.calledOnce(stubs.sharedQueries.getCreateQuery);
-				assert.calledWithExactly(stubs.sharedQueries.getCreateQuery, instance.model);
+				assert.calledOnceWithExactly(instance.runInputValidations);
+				assert.calledOnceWithExactly(instance.runDatabaseValidations);
+				assert.calledOnceWithExactly(instance.setErrorStatus);
+				assert.calledOnceWithExactly(stubs.sharedQueries.getCreateQuery, instance.model);
 				assert.calledTwice(stubs.prepareAsParams);
 				assert.calledWithExactly(stubs.prepareAsParams.firstCall, instance);
 				assert.calledWithExactly(stubs.prepareAsParams.secondCall, instance);
@@ -634,8 +613,7 @@ describe('Entity model', () => {
 					stubs.neo4jQuery.secondCall,
 					{ query: 'getCreateQuery response', params: 'prepareAsParams response' }
 				);
-				assert.calledOnce(instance.constructor);
-				assert.calledWithExactly(instance.constructor, neo4jQueryMockResponse);
+				assert.calledOnceWithExactly(instance.constructor, neo4jQueryMockResponse);
 				expect(result instanceof Entity).to.be.true;
 
 			});
@@ -662,14 +640,10 @@ describe('Entity model', () => {
 					stubs.prepareAsParams,
 					stubs.neo4jQuery
 				);
-				assert.calledOnce(instance.runInputValidations);
-				assert.calledWithExactly(instance.runInputValidations);
-				assert.calledOnce(instance.runDatabaseValidations);
-				assert.calledWithExactly(instance.runDatabaseValidations);
-				assert.calledOnce(instance.setErrorStatus);
-				assert.calledWithExactly(instance.setErrorStatus);
-				assert.calledOnce(stubs.sharedQueries.getUpdateQuery);
-				assert.calledWithExactly(stubs.sharedQueries.getUpdateQuery, instance.model);
+				assert.calledOnceWithExactly(instance.runInputValidations);
+				assert.calledOnceWithExactly(instance.runDatabaseValidations);
+				assert.calledOnceWithExactly(instance.setErrorStatus);
+				assert.calledOnceWithExactly(stubs.sharedQueries.getUpdateQuery, instance.model);
 				assert.calledTwice(stubs.prepareAsParams);
 				assert.calledWithExactly(stubs.prepareAsParams.firstCall, instance);
 				assert.calledWithExactly(stubs.prepareAsParams.secondCall, instance);
@@ -689,8 +663,7 @@ describe('Entity model', () => {
 					stubs.neo4jQuery.secondCall,
 					{ query: 'getUpdateQuery response', params: 'prepareAsParams response' }
 				);
-				assert.calledOnce(instance.constructor);
-				assert.calledWithExactly(instance.constructor, neo4jQueryMockResponse);
+				assert.calledOnceWithExactly(instance.constructor, neo4jQueryMockResponse);
 				expect(result instanceof Entity).to.be.true;
 
 			});
@@ -720,17 +693,12 @@ describe('Entity model', () => {
 					instance.runDatabaseValidations,
 					instance.setErrorStatus
 				);
-				assert.calledOnce(instance.runInputValidations);
-				assert.calledWithExactly(instance.runInputValidations);
-				assert.calledOnce(instance.runDatabaseValidations);
-				assert.calledWithExactly(instance.runDatabaseValidations);
-				assert.calledOnce(instance.setErrorStatus);
-				assert.calledWithExactly(instance.setErrorStatus);
+				assert.calledOnceWithExactly(instance.runInputValidations);
+				assert.calledOnceWithExactly(instance.runDatabaseValidations);
+				assert.calledOnceWithExactly(instance.setErrorStatus);
 				assert.notCalled(getCreateUpdateQueryStub);
-				assert.calledOnce(stubs.prepareAsParams);
-				assert.calledWithExactly(stubs.prepareAsParams, instance);
-				assert.calledOnce(stubs.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(stubs.prepareAsParams, instance);
+				assert.calledOnceWithExactly(
 					stubs.neo4jQuery,
 					{
 						query: 'getDuplicateRecordCheckQuery response',
@@ -767,8 +735,7 @@ describe('Entity model', () => {
 				instance.model = 'PRODUCTION';
 				spy(instance, 'createUpdate');
 				await instance.create();
-				assert.calledOnce(instance.createUpdate);
-				assert.calledWithExactly(instance.createUpdate, stubs.getCreateQueries[instance.model]);
+				assert.calledOnceWithExactly(instance.createUpdate, stubs.getCreateQueries[instance.model]);
 
 			});
 
@@ -780,8 +747,7 @@ describe('Entity model', () => {
 
 				spy(instance, 'createUpdate');
 				await instance.create();
-				assert.calledOnce(instance.createUpdate);
-				assert.calledWithExactly(instance.createUpdate, stubs.sharedQueries.getCreateQuery);
+				assert.calledOnceWithExactly(instance.createUpdate, stubs.sharedQueries.getCreateQuery);
 
 			});
 
@@ -798,16 +764,13 @@ describe('Entity model', () => {
 				instance.model = 'PRODUCTION';
 				spy(instance, 'constructor');
 				const result = await instance.edit();
-				assert.calledOnce(stubs.getEditQueries[instance.model]);
-				assert.calledWithExactly(stubs.getEditQueries[instance.model]);
+				assert.calledOnceWithExactly(stubs.getEditQueries[instance.model]);
 				assert.notCalled(stubs.sharedQueries.getEditQuery);
-				assert.calledOnce(stubs.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(
 					stubs.neo4jQuery,
 					{ query: 'getEditProductionQuery response', params: { uuid: instance.uuid } }
 				);
-				assert.calledOnce(instance.constructor);
-				assert.calledWithExactly(instance.constructor, neo4jQueryMockResponse);
+				assert.calledOnceWithExactly(instance.constructor, neo4jQueryMockResponse);
 				expect(result instanceof Entity).to.be.true;
 
 			});
@@ -820,16 +783,13 @@ describe('Entity model', () => {
 
 				spy(instance, 'constructor');
 				const result = await instance.edit();
-				assert.calledOnce(stubs.sharedQueries.getEditQuery);
-				assert.calledWithExactly(stubs.sharedQueries.getEditQuery, instance.model);
+				assert.calledOnceWithExactly(stubs.sharedQueries.getEditQuery, instance.model);
 				assert.notCalled(stubs.getEditQueries.PRODUCTION);
-				assert.calledOnce(stubs.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(
 					stubs.neo4jQuery,
 					{ query: 'getEditQuery response', params: { uuid: instance.uuid } }
 				);
-				assert.calledOnce(instance.constructor);
-				assert.calledWithExactly(instance.constructor, neo4jQueryMockResponse);
+				assert.calledOnceWithExactly(instance.constructor, neo4jQueryMockResponse);
 				expect(result instanceof Entity).to.be.true;
 
 			});
@@ -851,8 +811,7 @@ describe('Entity model', () => {
 					await instance.update();
 				} catch (error) {
 					expect(error.message).to.equal('Not Found');
-					assert.calledOnce(instance.confirmExistenceInDatabase);
-					assert.calledWithExactly(instance.confirmExistenceInDatabase);
+					assert.calledOnceWithExactly(instance.confirmExistenceInDatabase);
 					assert.notCalled(instance.createUpdate);
 				}
 
@@ -870,10 +829,8 @@ describe('Entity model', () => {
 					stub(instance, 'confirmExistenceInDatabase').returns(true);
 					spy(instance, 'createUpdate');
 					await instance.update();
-					assert.calledOnce(instance.confirmExistenceInDatabase);
-					assert.calledWithExactly(instance.confirmExistenceInDatabase);
-					assert.calledOnce(instance.createUpdate);
-					assert.calledWithExactly(instance.createUpdate, stubs.getUpdateQueries[instance.model]);
+					assert.calledOnceWithExactly(instance.confirmExistenceInDatabase);
+					assert.calledOnceWithExactly(instance.createUpdate, stubs.getUpdateQueries[instance.model]);
 
 				});
 
@@ -886,10 +843,8 @@ describe('Entity model', () => {
 					stub(instance, 'confirmExistenceInDatabase').returns(true);
 					spy(instance, 'createUpdate');
 					await instance.update();
-					assert.calledOnce(instance.confirmExistenceInDatabase);
-					assert.calledWithExactly(instance.confirmExistenceInDatabase);
-					assert.calledOnce(instance.createUpdate);
-					assert.calledWithExactly(instance.createUpdate, stubs.sharedQueries.getUpdateQuery);
+					assert.calledOnceWithExactly(instance.confirmExistenceInDatabase);
+					assert.calledOnceWithExactly(instance.createUpdate, stubs.sharedQueries.getUpdateQuery);
 
 				});
 
@@ -923,15 +878,12 @@ describe('Entity model', () => {
 						stubs.sharedQueries.getDeleteQuery,
 						stubs.neo4jQuery
 					);
-					assert.calledOnce(stubs.sharedQueries.getDeleteQuery);
-					assert.calledWithExactly(stubs.sharedQueries.getDeleteQuery, instance.model);
-					assert.calledOnce(stubs.neo4jQuery);
-					assert.calledWithExactly(
+					assert.calledOnceWithExactly(stubs.sharedQueries.getDeleteQuery, instance.model);
+					assert.calledOnceWithExactly(
 						stubs.neo4jQuery,
 						{ query: 'getDeleteQuery response', params: { uuid: instance.uuid } }
 					);
-					assert.calledOnce(instance.constructor);
-					assert.calledWithExactly(
+					assert.calledOnceWithExactly(
 						instance.constructor,
 						{ name: 'Almeida Theatre', differentiator: null }
 					);
@@ -969,15 +921,12 @@ describe('Entity model', () => {
 						stubs.sharedQueries.getDeleteQuery,
 						stubs.neo4jQuery
 					);
-					assert.calledOnce(stubs.sharedQueries.getDeleteQuery);
-					assert.calledWithExactly(stubs.sharedQueries.getDeleteQuery, instance.model);
-					assert.calledOnce(stubs.neo4jQuery);
-					assert.calledWithExactly(
+					assert.calledOnceWithExactly(stubs.sharedQueries.getDeleteQuery, instance.model);
+					assert.calledOnceWithExactly(
 						stubs.neo4jQuery,
 						{ query: 'getDeleteQuery response', params: { uuid: instance.uuid } }
 					);
-					assert.calledOnce(instance.constructor);
-					assert.calledWithExactly(instance.constructor, { name: 'Hamlet' });
+					assert.calledOnceWithExactly(instance.constructor, { name: 'Hamlet' });
 					assert.notCalled(instance.addPropertyError);
 					assert.notCalled(instance.setErrorStatus);
 					expect(result instanceof Production).to.be.true;
@@ -1050,21 +999,17 @@ describe('Entity model', () => {
 						stubs.sharedQueries.getDeleteQuery,
 						stubs.neo4jQuery
 					);
-					assert.calledOnce(stubs.sharedQueries.getDeleteQuery);
-					assert.calledWithExactly(stubs.sharedQueries.getDeleteQuery, instance.model);
-					assert.calledOnce(stubs.neo4jQuery);
-					assert.calledWithExactly(
+					assert.calledOnceWithExactly(stubs.sharedQueries.getDeleteQuery, instance.model);
+					assert.calledOnceWithExactly(
 						stubs.neo4jQuery,
 						{ query: 'getDeleteQuery response', params: { uuid: instance.uuid } }
 					);
 					assert.notCalled(instance.constructor);
-					assert.calledOnce(instance.addPropertyError);
-					assert.calledWithExactly(
+					assert.calledOnceWithExactly(
 						instance.addPropertyError,
 						'associations', 'Production'
 					);
-					assert.calledOnce(instance.setErrorStatus);
-					assert.calledWithExactly(instance.setErrorStatus);
+					assert.calledOnceWithExactly(instance.setErrorStatus);
 					expect(result).to.deep.equal(instance);
 					expect(result).to.deep.equal({
 						uuid: undefined,
@@ -1103,21 +1048,17 @@ describe('Entity model', () => {
 						stubs.sharedQueries.getDeleteQuery,
 						stubs.neo4jQuery
 					);
-					assert.calledOnce(stubs.sharedQueries.getDeleteQuery);
-					assert.calledWithExactly(stubs.sharedQueries.getDeleteQuery, instance.model);
-					assert.calledOnce(stubs.neo4jQuery);
-					assert.calledWithExactly(
+					assert.calledOnceWithExactly(stubs.sharedQueries.getDeleteQuery, instance.model);
+					assert.calledOnceWithExactly(
 						stubs.neo4jQuery,
 						{ query: 'getDeleteQuery response', params: { uuid: instance.uuid } }
 					);
 					assert.notCalled(instance.constructor);
-					assert.calledOnce(instance.addPropertyError);
-					assert.calledWithExactly(
+					assert.calledOnceWithExactly(
 						instance.addPropertyError,
 						'associations', 'Venue'
 					);
-					assert.calledOnce(instance.setErrorStatus);
-					assert.calledWithExactly(instance.setErrorStatus);
+					assert.calledOnceWithExactly(instance.setErrorStatus);
 					expect(result).to.deep.equal(instance);
 					expect(result).to.deep.equal({
 						uuid: undefined,
@@ -1180,10 +1121,8 @@ describe('Entity model', () => {
 
 				instance.model = 'VENUE';
 				const result = await instance.show();
-				assert.calledOnce(stubs.getShowQueries.VENUE);
-				assert.calledWithExactly(stubs.getShowQueries.VENUE);
-				assert.calledOnce(stubs.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(stubs.getShowQueries.VENUE);
+				assert.calledOnceWithExactly(
 					stubs.neo4jQuery,
 					{ query: 'showVenueQuery', params: { uuid: instance.uuid } }
 				);
@@ -1199,8 +1138,7 @@ describe('Entity model', () => {
 
 				instance.model = 'PRODUCTION';
 				const result = await instance.show();
-				assert.calledOnce(stubs.getShowQueries.PRODUCTION);
-				assert.calledWithExactly(stubs.getShowQueries.PRODUCTION);
+				assert.calledOnceWithExactly(stubs.getShowQueries.PRODUCTION);
 				assert.calledTwice(stubs.neo4jQuery);
 				assert.calledWithExactly(
 					stubs.neo4jQuery.getCall(0),
@@ -1223,10 +1161,8 @@ describe('Entity model', () => {
 		it('gets list data', async () => {
 
 			const result = await Entity.list('model');
-			assert.calledOnce(stubs.sharedQueries.getListQuery);
-			assert.calledWithExactly(stubs.sharedQueries.getListQuery, 'model');
-			assert.calledOnce(stubs.neo4jQuery);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(stubs.sharedQueries.getListQuery, 'model');
+			assert.calledOnceWithExactly(
 				stubs.neo4jQuery,
 				{ query: 'getListQuery response' }, { isOptionalResult: true, isArrayResult: true }
 			);

--- a/test-unit/src/models/Festival.test.js
+++ b/test-unit/src/models/Festival.test.js
@@ -87,14 +87,10 @@ describe('Festival model', () => {
 				instance.festivalSeries.validateName,
 				instance.festivalSeries.validateDifferentiator
 			);
-			assert.calledOnce(instance.validateName);
-			assert.calledWithExactly(instance.validateName, { isRequired: true });
-			assert.calledOnce(instance.validateDifferentiator);
-			assert.calledWithExactly(instance.validateDifferentiator);
-			assert.calledOnce(instance.festivalSeries.validateName);
-			assert.calledWithExactly(instance.festivalSeries.validateName, { isRequired: false });
-			assert.calledOnce(instance.festivalSeries.validateDifferentiator);
-			assert.calledWithExactly(instance.festivalSeries.validateDifferentiator);
+			assert.calledOnceWithExactly(instance.validateName, { isRequired: true });
+			assert.calledOnceWithExactly(instance.validateDifferentiator);
+			assert.calledOnceWithExactly(instance.festivalSeries.validateName, { isRequired: false });
+			assert.calledOnceWithExactly(instance.festivalSeries.validateDifferentiator);
 
 		});
 

--- a/test-unit/src/models/Material.test.js
+++ b/test-unit/src/models/Material.test.js
@@ -330,27 +330,18 @@ describe('Material model', () => {
 				instance.subMaterials[0].validateUniquenessInGroup,
 				instance.characterGroups[0].runInputValidations
 			);
-			assert.calledOnce(instance.validateName);
-			assert.calledWithExactly(instance.validateName, { isRequired: true });
-			assert.calledOnce(instance.validateDifferentiator);
-			assert.calledWithExactly(instance.validateDifferentiator);
-			assert.calledOnce(instance.validateSubtitle);
-			assert.calledWithExactly(instance.validateSubtitle);
-			assert.calledOnce(instance.validateFormat);
-			assert.calledWithExactly(instance.validateFormat, { isRequired: false });
-			assert.calledOnce(instance.validateYear);
-			assert.calledWithExactly(instance.validateYear, { isRequired: false });
-			assert.calledOnce(instance.originalVersionMaterial.validateName);
-			assert.calledWithExactly(instance.originalVersionMaterial.validateName, { isRequired: false });
-			assert.calledOnce(instance.originalVersionMaterial.validateDifferentiator);
-			assert.calledWithExactly(instance.originalVersionMaterial.validateDifferentiator);
-			assert.calledOnce(stubs.getDuplicateIndicesModule.getDuplicateNameIndices);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(instance.validateName, { isRequired: true });
+			assert.calledOnceWithExactly(instance.validateDifferentiator);
+			assert.calledOnceWithExactly(instance.validateSubtitle);
+			assert.calledOnceWithExactly(instance.validateFormat, { isRequired: false });
+			assert.calledOnceWithExactly(instance.validateYear, { isRequired: false });
+			assert.calledOnceWithExactly(instance.originalVersionMaterial.validateName, { isRequired: false });
+			assert.calledOnceWithExactly(instance.originalVersionMaterial.validateDifferentiator);
+			assert.calledOnceWithExactly(
 				stubs.getDuplicateIndicesModule.getDuplicateNameIndices,
 				instance.writingCredits
 			);
-			assert.calledOnce(instance.writingCredits[0].runInputValidations);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				instance.writingCredits[0].runInputValidations,
 				{
 					isDuplicate: false,
@@ -360,27 +351,21 @@ describe('Material model', () => {
 					}
 				}
 			);
-			assert.calledOnce(stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices,
 				instance.subMaterials
 			);
-			assert.calledOnce(instance.subMaterials[0].validateName);
-			assert.calledWithExactly(instance.subMaterials[0].validateName, { isRequired: false });
-			assert.calledOnce(instance.subMaterials[0].validateDifferentiator);
-			assert.calledWithExactly(instance.subMaterials[0].validateDifferentiator);
-			assert.calledOnce(instance.subMaterials[0].validateNoAssociationWithSelf);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(instance.subMaterials[0].validateName, { isRequired: false });
+			assert.calledOnceWithExactly(instance.subMaterials[0].validateDifferentiator);
+			assert.calledOnceWithExactly(
 				instance.subMaterials[0].validateNoAssociationWithSelf,
 				{ name: 'The Tragedy of Hamlet', differentiator: '1' }
 			);
-			assert.calledOnce(instance.subMaterials[0].validateUniquenessInGroup);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				instance.subMaterials[0].validateUniquenessInGroup,
 				{ isDuplicate: false }
 			);
-			assert.calledOnce(instance.characterGroups[0].runInputValidations);
-			assert.calledWithExactly(instance.characterGroups[0].runInputValidations);
+			assert.calledOnceWithExactly(instance.characterGroups[0].runInputValidations);
 
 		});
 
@@ -393,8 +378,7 @@ describe('Material model', () => {
 			const instance = createInstance({ name: 'The Tragedy of Hamlet', format: 'play' });
 			spy(instance, 'validateStringForProperty');
 			instance.validateFormat({ isRequired: false });
-			assert.calledOnce(instance.validateStringForProperty);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				instance.validateStringForProperty,
 				'format', { isRequired: false }
 			);
@@ -426,10 +410,8 @@ describe('Material model', () => {
 				const instance = createInstance({ name: 'The Caretaker', year: 'Nineteen Fifty-Nine' });
 				spy(instance, 'addPropertyError');
 				instance.validateYear();
-				assert.calledOnce(stubs.isValidYearModule.isValidYear);
-				assert.calledWithExactly(stubs.isValidYearModule.isValidYear, 'Nineteen Fifty-Nine');
-				assert.calledOnce(instance.addPropertyError);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(stubs.isValidYearModule.isValidYear, 'Nineteen Fifty-Nine');
+				assert.calledOnceWithExactly(
 					instance.addPropertyError,
 					'year', 'Value must be a valid year'
 				);
@@ -445,8 +427,7 @@ describe('Material model', () => {
 				const instance = createInstance({ name: 'The Caretaker', year: 1959 });
 				spy(instance, 'addPropertyError');
 				instance.validateYear();
-				assert.calledOnce(stubs.isValidYearModule.isValidYear);
-				assert.calledWithExactly(stubs.isValidYearModule.isValidYear, 1959);
+				assert.calledOnceWithExactly(stubs.isValidYearModule.isValidYear, 1959);
 				assert.notCalled(instance.addPropertyError);
 
 			});
@@ -480,20 +461,16 @@ describe('Material model', () => {
 			const instance = createInstance(props);
 			stub(instance, 'validateUniquenessInDatabase');
 			await instance.runDatabaseValidations();
-			assert.calledOnce(instance.validateUniquenessInDatabase);
-			assert.calledWithExactly(instance.validateUniquenessInDatabase);
-			assert.calledOnce(instance.originalVersionMaterial.runDatabaseValidations);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(instance.validateUniquenessInDatabase);
+			assert.calledOnceWithExactly(
 				instance.originalVersionMaterial.runDatabaseValidations,
 				{ subjectMaterialUuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' }
 			);
-			assert.calledOnce(instance.writingCredits[0].runDatabaseValidations);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				instance.writingCredits[0].runDatabaseValidations,
 				{ subjectMaterialUuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' }
 			);
-			assert.calledOnce(instance.subMaterials[0].runDatabaseValidations);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				instance.subMaterials[0].runDatabaseValidations,
 				{ subjectMaterialUuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' }
 			);

--- a/test-unit/src/models/NominatedProductionIdentifier.test.js
+++ b/test-unit/src/models/NominatedProductionIdentifier.test.js
@@ -14,8 +14,7 @@ describe('NominatedProductionIdentifier model', () => {
 				stub(instance, 'confirmExistenceInDatabase').resolves(true);
 				spy(instance, 'addPropertyError');
 				await instance.runDatabaseValidations();
-				assert.calledOnce(instance.confirmExistenceInDatabase);
-				assert.calledWithExactly(instance.confirmExistenceInDatabase, { model: 'PRODUCTION' });
+				assert.calledOnceWithExactly(instance.confirmExistenceInDatabase, { model: 'PRODUCTION' });
 				assert.notCalled(instance.addPropertyError);
 
 			});
@@ -30,10 +29,8 @@ describe('NominatedProductionIdentifier model', () => {
 				stub(instance, 'confirmExistenceInDatabase').resolves(false);
 				spy(instance, 'addPropertyError');
 				await instance.runDatabaseValidations();
-				assert.calledOnce(instance.confirmExistenceInDatabase);
-				assert.calledWithExactly(instance.confirmExistenceInDatabase, { model: 'PRODUCTION' });
-				assert.calledOnce(instance.addPropertyError);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(instance.confirmExistenceInDatabase, { model: 'PRODUCTION' });
+				assert.calledOnceWithExactly(
 					instance.addPropertyError,
 					'uuid', 'Production with this UUID does not exist'
 				);

--- a/test-unit/src/models/Nomination.test.js
+++ b/test-unit/src/models/Nomination.test.js
@@ -300,59 +300,43 @@ describe('Nomination model', () => {
 				instance.materials[0].validateDifferentiator,
 				instance.materials[0].validateUniquenessInGroup
 			);
-			assert.calledOnce(instance.validateCustomType);
-			assert.calledWithExactly(instance.validateCustomType, { isRequired: false });
-			assert.calledOnce(stubs.getDuplicateEntityInfoModule.getDuplicateEntities);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(instance.validateCustomType, { isRequired: false });
+			assert.calledOnceWithExactly(
 				stubs.getDuplicateEntityInfoModule.getDuplicateEntities,
 				instance.entities
 			);
-			assert.calledOnce(instance.entities[0].validateName);
-			assert.calledWithExactly(instance.entities[0].validateName, { isRequired: false });
-			assert.calledOnce(instance.entities[0].validateDifferentiator);
-			assert.calledWithExactly(instance.entities[0].validateDifferentiator);
+			assert.calledOnceWithExactly(instance.entities[0].validateName, { isRequired: false });
+			assert.calledOnceWithExactly(instance.entities[0].validateDifferentiator);
 			assert.calledTwice(stubs.getDuplicateEntityInfoModule.isEntityInArray);
 			assert.calledWithExactly(
 				stubs.getDuplicateEntityInfoModule.isEntityInArray.getCall(0),
 				instance.entities[0], 'getDuplicateEntities response'
 			);
-			assert.calledOnce(instance.entities[0].validateUniquenessInGroup);
-			assert.calledWithExactly(instance.entities[0].validateUniquenessInGroup, { isDuplicate: false });
-			assert.calledOnce(instance.entities[1].validateName);
-			assert.calledWithExactly(instance.entities[1].validateName, { isRequired: false });
-			assert.calledOnce(instance.entities[1].validateDifferentiator);
-			assert.calledWithExactly(instance.entities[1].validateDifferentiator);
+			assert.calledOnceWithExactly(instance.entities[0].validateUniquenessInGroup, { isDuplicate: false });
+			assert.calledOnceWithExactly(instance.entities[1].validateName, { isRequired: false });
+			assert.calledOnceWithExactly(instance.entities[1].validateDifferentiator);
 			assert.calledWithExactly(
 				stubs.getDuplicateEntityInfoModule.isEntityInArray.getCall(1),
 				instance.entities[1], 'getDuplicateEntities response'
 			);
-			assert.calledOnce(instance.entities[1].validateUniquenessInGroup);
-			assert.calledWithExactly(instance.entities[1].validateUniquenessInGroup, { isDuplicate: false });
-			assert.calledOnce(instance.entities[1].runInputValidations);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(instance.entities[1].validateUniquenessInGroup, { isDuplicate: false });
+			assert.calledOnceWithExactly(
 				instance.entities[1].runInputValidations,
 				{ duplicateEntities: 'getDuplicateEntities response' }
 			);
-			assert.calledOnce(stubs.getDuplicateIndicesModule.getDuplicateUuidIndices);
-			assert.calledWithExactly(stubs.getDuplicateIndicesModule.getDuplicateUuidIndices, instance.productions);
-			assert.calledOnce(instance.productions[0].validateUuid);
-			assert.calledWithExactly(instance.productions[0].validateUuid);
-			assert.calledOnce(instance.productions[0].validateUniquenessInGroup);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(stubs.getDuplicateIndicesModule.getDuplicateUuidIndices, instance.productions);
+			assert.calledOnceWithExactly(instance.productions[0].validateUuid);
+			assert.calledOnceWithExactly(
 				instance.productions[0].validateUniquenessInGroup,
 				{ isDuplicate: false, properties: new Set(['uuid']) }
 			);
-			assert.calledOnce(stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices,
 				instance.materials
 			);
-			assert.calledOnce(instance.materials[0].validateName);
-			assert.calledWithExactly(instance.materials[0].validateName, { isRequired: false });
-			assert.calledOnce(instance.materials[0].validateDifferentiator);
-			assert.calledWithExactly(instance.materials[0].validateDifferentiator);
-			assert.calledOnce(instance.materials[0].validateUniquenessInGroup);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(instance.materials[0].validateName, { isRequired: false });
+			assert.calledOnceWithExactly(instance.materials[0].validateDifferentiator);
+			assert.calledOnceWithExactly(
 				instance.materials[0].validateUniquenessInGroup,
 				{ isDuplicate: false }
 			);
@@ -368,8 +352,7 @@ describe('Nomination model', () => {
 			const instance = createInstance({ customType: 'Shortlisted' });
 			spy(instance, 'validateStringForProperty');
 			instance.validateCustomType({ isRequired: false });
-			assert.calledOnce(instance.validateStringForProperty);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				instance.validateStringForProperty,
 				'customType', { isRequired: false }
 			);
@@ -391,8 +374,7 @@ describe('Nomination model', () => {
 			};
 			const instance = createInstance(props);
 			await instance.runDatabaseValidations();
-			assert.calledOnce(instance.productions[0].runDatabaseValidations);
-			assert.calledWithExactly(instance.productions[0].runDatabaseValidations);
+			assert.calledOnceWithExactly(instance.productions[0].runDatabaseValidations);
 
 		});
 

--- a/test-unit/src/models/OriginalVersionMaterial.test.js
+++ b/test-unit/src/models/OriginalVersionMaterial.test.js
@@ -57,12 +57,9 @@ describe('OriginalVersionMaterial model', () => {
 					stubs.validationQueries.getOriginalVersionMaterialChecksQuery,
 					stubs.neo4jQuery
 				);
-				assert.calledOnce(stubs.prepareAsParams);
-				assert.calledWithExactly(stubs.prepareAsParams, instance);
-				assert.calledOnce(stubs.validationQueries.getOriginalVersionMaterialChecksQuery);
-				assert.calledWithExactly(stubs.validationQueries.getOriginalVersionMaterialChecksQuery);
-				assert.calledOnce(stubs.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(stubs.prepareAsParams, instance);
+				assert.calledOnceWithExactly(stubs.validationQueries.getOriginalVersionMaterialChecksQuery);
+				assert.calledOnceWithExactly(
 					stubs.neo4jQuery,
 					{
 						query: 'getOriginalVersionMaterialChecksQuery response',
@@ -94,12 +91,9 @@ describe('OriginalVersionMaterial model', () => {
 					stubs.neo4jQuery,
 					instance.addPropertyError
 				);
-				assert.calledOnce(stubs.prepareAsParams);
-				assert.calledWithExactly(stubs.prepareAsParams, instance);
-				assert.calledOnce(stubs.validationQueries.getOriginalVersionMaterialChecksQuery);
-				assert.calledWithExactly(stubs.validationQueries.getOriginalVersionMaterialChecksQuery);
-				assert.calledOnce(stubs.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(stubs.prepareAsParams, instance);
+				assert.calledOnceWithExactly(stubs.validationQueries.getOriginalVersionMaterialChecksQuery);
+				assert.calledOnceWithExactly(
 					stubs.neo4jQuery,
 					{
 						query: 'getOriginalVersionMaterialChecksQuery response',

--- a/test-unit/src/models/ProducerCredit.test.js
+++ b/test-unit/src/models/ProducerCredit.test.js
@@ -137,38 +137,27 @@ describe('ProducerCredit model', () => {
 				instance.entities[1].validateUniquenessInGroup,
 				instance.entities[1].runInputValidations
 			);
-			assert.calledOnce(instance.validateName);
-			assert.calledWithExactly(instance.validateName, { isRequired: false });
-			assert.calledOnce(instance.validateUniquenessInGroup);
-			assert.calledWithExactly(instance.validateUniquenessInGroup, { isDuplicate: false });
-			assert.calledOnce(stubs.getDuplicateEntityInfoModule.getDuplicateEntities);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(instance.validateName, { isRequired: false });
+			assert.calledOnceWithExactly(instance.validateUniquenessInGroup, { isDuplicate: false });
+			assert.calledOnceWithExactly(
 				stubs.getDuplicateEntityInfoModule.getDuplicateEntities,
 				instance.entities
 			);
-			assert.calledOnce(instance.entities[0].validateName);
-			assert.calledWithExactly(instance.entities[0].validateName, { isRequired: false });
-			assert.calledOnce(instance.entities[0].validateDifferentiator);
-			assert.calledWithExactly(instance.entities[0].validateDifferentiator);
+			assert.calledOnceWithExactly(instance.entities[0].validateName, { isRequired: false });
+			assert.calledOnceWithExactly(instance.entities[0].validateDifferentiator);
 			assert.calledTwice(stubs.getDuplicateEntityInfoModule.isEntityInArray);
 			assert.calledWithExactly(
 				stubs.getDuplicateEntityInfoModule.isEntityInArray.getCall(0),
 				instance.entities[0], 'getDuplicateEntities response'
 			);
-			assert.calledOnce(instance.entities[0].validateUniquenessInGroup);
-			assert.calledWithExactly(instance.entities[0].validateUniquenessInGroup, { isDuplicate: false });
-			assert.calledOnce(instance.entities[1].validateName);
-			assert.calledWithExactly(instance.entities[1].validateName, { isRequired: false });
-			assert.calledOnce(instance.entities[1].validateDifferentiator);
-			assert.calledWithExactly(instance.entities[1].validateDifferentiator);
+			assert.calledOnceWithExactly(instance.entities[0].validateUniquenessInGroup, { isDuplicate: false });
+			assert.calledOnceWithExactly(instance.entities[1].validateName, { isRequired: false });
 			assert.calledWithExactly(
 				stubs.getDuplicateEntityInfoModule.isEntityInArray.getCall(1),
 				instance.entities[1], 'getDuplicateEntities response'
 			);
-			assert.calledOnce(instance.entities[1].validateUniquenessInGroup);
-			assert.calledWithExactly(instance.entities[1].validateUniquenessInGroup, { isDuplicate: false });
-			assert.calledOnce(instance.entities[1].runInputValidations);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(instance.entities[1].validateUniquenessInGroup, { isDuplicate: false });
+			assert.calledOnceWithExactly(
 				instance.entities[1].runInputValidations,
 				{ duplicateEntities: 'getDuplicateEntities response' }
 			);

--- a/test-unit/src/models/Production.test.js
+++ b/test-unit/src/models/Production.test.js
@@ -563,39 +563,26 @@ describe('Production model', () => {
 				stubs.getDuplicateIndicesModule.getDuplicateUrlIndices,
 				instance.reviews[0].runInputValidations
 			);
-			assert.calledOnce(instance.validateName);
-			assert.calledWithExactly(instance.validateName, { isRequired: true });
-			assert.calledOnce(instance.validateSubtitle);
-			assert.calledWithExactly(instance.validateSubtitle);
-			assert.calledOnce(instance.validateDates);
-			assert.calledWithExactly(instance.validateDates);
-			assert.calledOnce(instance.material.validateName);
-			assert.calledWithExactly(instance.material.validateName, { isRequired: false });
-			assert.calledOnce(instance.material.validateDifferentiator);
-			assert.calledWithExactly(instance.material.validateDifferentiator);
-			assert.calledOnce(instance.venue.validateName);
-			assert.calledWithExactly(instance.venue.validateName, { isRequired: false });
-			assert.calledOnce(instance.venue.validateDifferentiator);
-			assert.calledWithExactly(instance.venue.validateDifferentiator);
-			assert.calledOnce(instance.season.validateName);
-			assert.calledWithExactly(instance.season.validateName, { isRequired: false });
-			assert.calledOnce(instance.season.validateDifferentiator);
-			assert.calledWithExactly(instance.season.validateDifferentiator);
-			assert.calledOnce(instance.festival.validateName);
-			assert.calledWithExactly(instance.festival.validateName, { isRequired: false });
-			assert.calledOnce(instance.festival.validateDifferentiator);
-			assert.calledWithExactly(instance.festival.validateDifferentiator);
-			assert.calledOnce(stubs.getDuplicateIndicesModule.getDuplicateUuidIndices);
-			assert.calledWithExactly(stubs.getDuplicateIndicesModule.getDuplicateUuidIndices, instance.subProductions);
-			assert.calledOnce(instance.subProductions[0].validateUuid);
-			assert.calledWithExactly(instance.subProductions[0].validateUuid);
-			assert.calledOnce(instance.subProductions[0].validateNoAssociationWithSelf);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(instance.validateName, { isRequired: true });
+			assert.calledOnceWithExactly(instance.validateSubtitle);
+			assert.calledOnceWithExactly(instance.validateDates);
+			assert.calledOnceWithExactly(instance.material.validateName, { isRequired: false });
+			assert.calledOnceWithExactly(instance.material.validateDifferentiator);
+			assert.calledOnceWithExactly(instance.venue.validateName, { isRequired: false });
+			assert.calledOnceWithExactly(instance.venue.validateDifferentiator);
+			assert.calledOnceWithExactly(instance.season.validateName, { isRequired: false });
+			assert.calledOnceWithExactly(instance.season.validateDifferentiator);
+			assert.calledOnceWithExactly(instance.festival.validateName, { isRequired: false });
+			assert.calledOnceWithExactly(instance.festival.validateDifferentiator);
+			assert.calledOnceWithExactly(
+				stubs.getDuplicateIndicesModule.getDuplicateUuidIndices, instance.subProductions
+			);
+			assert.calledOnceWithExactly(instance.subProductions[0].validateUuid);
+			assert.calledOnceWithExactly(
 				instance.subProductions[0].validateNoAssociationWithSelf,
 				{ uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' }
 			);
-			assert.calledOnce(instance.subProductions[0].validateUniquenessInGroup);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				instance.subProductions[0].validateUniquenessInGroup,
 				{ isDuplicate: false, properties: new Set(['uuid']) }
 			);
@@ -604,18 +591,15 @@ describe('Production model', () => {
 				stubs.getDuplicateIndicesModule.getDuplicateNameIndices.getCall(0),
 				instance.producerCredits
 			);
-			assert.calledOnce(instance.producerCredits[0].runInputValidations);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				instance.producerCredits[0].runInputValidations,
 				{ isDuplicate: false }
 			);
-			assert.calledOnce(stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices);
-			assert.calledWithExactly(
-				stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices.getCall(0),
+			assert.calledOnceWithExactly(
+				stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices,
 				instance.cast
 			);
-			assert.calledOnce(instance.cast[0].runInputValidations);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				instance.cast[0].runInputValidations,
 				{ isDuplicate: false }
 			);
@@ -623,8 +607,7 @@ describe('Production model', () => {
 				stubs.getDuplicateIndicesModule.getDuplicateNameIndices.getCall(1),
 				instance.creativeCredits
 			);
-			assert.calledOnce(instance.creativeCredits[0].runInputValidations);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				instance.creativeCredits[0].runInputValidations,
 				{ isDuplicate: false }
 			);
@@ -632,18 +615,15 @@ describe('Production model', () => {
 				stubs.getDuplicateIndicesModule.getDuplicateNameIndices.getCall(2),
 				instance.crewCredits
 			);
-			assert.calledOnce(instance.crewCredits[0].runInputValidations);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				instance.crewCredits[0].runInputValidations,
 				{ isDuplicate: false }
 			);
-			assert.calledOnce(stubs.getDuplicateIndicesModule.getDuplicateUrlIndices);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				stubs.getDuplicateIndicesModule.getDuplicateUrlIndices,
 				instance.reviews
 			);
-			assert.calledOnce(instance.reviews[0].runInputValidations);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				instance.reviews[0].runInputValidations,
 				{ isDuplicate: false }
 			);
@@ -973,8 +953,7 @@ describe('Production model', () => {
 					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(0), 'foobar');
 					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(1), '');
 					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(2), '');
-					assert.calledOnce(instance.addPropertyError);
-					assert.calledWithExactly(
+					assert.calledOnceWithExactly(
 						instance.addPropertyError,
 						'startDate', 'Value must be in date format'
 					);
@@ -994,8 +973,7 @@ describe('Production model', () => {
 					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(0), '');
 					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(1), 'foobar');
 					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(2), '');
-					assert.calledOnce(instance.addPropertyError);
-					assert.calledWithExactly(
+					assert.calledOnceWithExactly(
 						instance.addPropertyError,
 						'pressDate', 'Value must be in date format'
 					);
@@ -1015,8 +993,7 @@ describe('Production model', () => {
 					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(0), '');
 					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(1), '');
 					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(2), 'foobar');
-					assert.calledOnce(instance.addPropertyError);
-					assert.calledWithExactly(
+					assert.calledOnceWithExactly(
 						instance.addPropertyError,
 						'endDate', 'Value must be in date format'
 					);
@@ -1181,8 +1158,7 @@ describe('Production model', () => {
 			};
 			const instance = createInstance(props);
 			await instance.runDatabaseValidations();
-			assert.calledOnce(instance.subProductions[0].runDatabaseValidations);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				instance.subProductions[0].runDatabaseValidations,
 				{ subjectProductionUuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' }
 			);

--- a/test-unit/src/models/ProductionIdentifier.test.js
+++ b/test-unit/src/models/ProductionIdentifier.test.js
@@ -55,8 +55,7 @@ describe('ProductionIdentifier model', () => {
 			const instance = new ProductionIdentifier({ uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' });
 			spy(instance, 'validateStringForProperty');
 			instance.validateUuid();
-			assert.calledOnce(instance.validateStringForProperty);
-			assert.calledWithExactly(instance.validateStringForProperty, 'uuid', { isRequired: false });
+			assert.calledOnceWithExactly(instance.validateStringForProperty, 'uuid', { isRequired: false });
 
 		});
 

--- a/test-unit/src/models/ProductionTeamCredit.test.js
+++ b/test-unit/src/models/ProductionTeamCredit.test.js
@@ -139,40 +139,29 @@ describe('ProductionTeamCredit model', () => {
 				instance.entities[1].validateUniquenessInGroup,
 				instance.entities[1].runInputValidations
 			);
-			assert.calledOnce(instance.validateName);
-			assert.calledWithExactly(instance.validateName, { isRequired: false });
-			assert.calledOnce(instance.validateUniquenessInGroup);
-			assert.calledWithExactly(instance.validateUniquenessInGroup, { isDuplicate: false });
-			assert.calledOnce(instance.validateNamePresenceIfNamedChildren);
-			assert.calledWithExactly(instance.validateNamePresenceIfNamedChildren, instance.entities);
-			assert.calledOnce(stubs.getDuplicateEntityInfoModule.getDuplicateEntities);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(instance.validateName, { isRequired: false });
+			assert.calledOnceWithExactly(instance.validateUniquenessInGroup, { isDuplicate: false });
+			assert.calledOnceWithExactly(instance.validateNamePresenceIfNamedChildren, instance.entities);
+			assert.calledOnceWithExactly(
 				stubs.getDuplicateEntityInfoModule.getDuplicateEntities,
 				instance.entities
 			);
-			assert.calledOnce(instance.entities[0].validateName);
-			assert.calledWithExactly(instance.entities[0].validateName, { isRequired: false });
-			assert.calledOnce(instance.entities[0].validateDifferentiator);
-			assert.calledWithExactly(instance.entities[0].validateDifferentiator);
+			assert.calledOnceWithExactly(instance.entities[0].validateName, { isRequired: false });
+			assert.calledOnceWithExactly(instance.entities[0].validateDifferentiator);
 			assert.calledTwice(stubs.getDuplicateEntityInfoModule.isEntityInArray);
 			assert.calledWithExactly(
 				stubs.getDuplicateEntityInfoModule.isEntityInArray.getCall(0),
 				instance.entities[0], 'getDuplicateEntities response'
 			);
-			assert.calledOnce(instance.entities[0].validateUniquenessInGroup);
-			assert.calledWithExactly(instance.entities[0].validateUniquenessInGroup, { isDuplicate: false });
-			assert.calledOnce(instance.entities[1].validateName);
-			assert.calledWithExactly(instance.entities[1].validateName, { isRequired: false });
-			assert.calledOnce(instance.entities[1].validateDifferentiator);
-			assert.calledWithExactly(instance.entities[1].validateDifferentiator);
+			assert.calledOnceWithExactly(instance.entities[0].validateUniquenessInGroup, { isDuplicate: false });
+			assert.calledOnceWithExactly(instance.entities[1].validateName, { isRequired: false });
+			assert.calledOnceWithExactly(instance.entities[1].validateDifferentiator);
 			assert.calledWithExactly(
 				stubs.getDuplicateEntityInfoModule.isEntityInArray.getCall(1),
 				instance.entities[1], 'getDuplicateEntities response'
 			);
-			assert.calledOnce(instance.entities[1].validateUniquenessInGroup);
-			assert.calledWithExactly(instance.entities[1].validateUniquenessInGroup, { isDuplicate: false });
-			assert.calledOnce(instance.entities[1].runInputValidations);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(instance.entities[1].validateUniquenessInGroup, { isDuplicate: false });
+			assert.calledOnceWithExactly(
 				instance.entities[1].runInputValidations,
 				{ duplicateEntities: 'getDuplicateEntities response' }
 			);

--- a/test-unit/src/models/Review.test.js
+++ b/test-unit/src/models/Review.test.js
@@ -164,28 +164,20 @@ describe('Review model', () => {
 					instance.critic.validateName,
 					instance.critic.validateDifferentiator
 				);
-				assert.calledOnce(instance.validateUrl);
-				assert.calledWithExactly(instance.validateUrl, { isRequired: false });
-				assert.calledOnce(instance.validateUniquenessInGroup);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(instance.validateUrl, { isRequired: false });
+				assert.calledOnceWithExactly(
 					instance.validateUniquenessInGroup,
 					{ isDuplicate: false, properties: new Set(['url']) }
 				);
-				assert.calledOnce(instance.validateUrlPresenceIfNamedChildren);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(
 					instance.validateUrlPresenceIfNamedChildren,
 					[instance.publication, instance.critic]
 				);
-				assert.calledOnce(instance.validateDate);
-				assert.calledWithExactly(instance.validateDate);
-				assert.calledOnce(instance.publication.validateName);
-				assert.calledWithExactly(instance.publication.validateName, { isRequired: true });
-				assert.calledOnce(instance.publication.validateDifferentiator);
-				assert.calledWithExactly(instance.publication.validateDifferentiator);
-				assert.calledOnce(instance.critic.validateName);
-				assert.calledWithExactly(instance.critic.validateName, { isRequired: true });
-				assert.calledOnce(instance.critic.validateDifferentiator);
-				assert.calledWithExactly(instance.critic.validateDifferentiator);
+				assert.calledOnceWithExactly(instance.validateDate);
+				assert.calledOnceWithExactly(instance.publication.validateName, { isRequired: true });
+				assert.calledOnceWithExactly(instance.publication.validateDifferentiator);
+				assert.calledOnceWithExactly(instance.critic.validateName, { isRequired: true });
+				assert.calledOnceWithExactly(instance.critic.validateDifferentiator);
 
 			});
 
@@ -206,10 +198,8 @@ describe('Review model', () => {
 				};
 				const instance = createInstance(props);
 				instance.runInputValidations({ isDuplicate: false });
-				assert.calledOnce(instance.publication.validateName);
-				assert.calledWithExactly(instance.publication.validateName, { isRequired: false });
-				assert.calledOnce(instance.critic.validateName);
-				assert.calledWithExactly(instance.critic.validateName, { isRequired: false });
+				assert.calledOnceWithExactly(instance.publication.validateName, { isRequired: false });
+				assert.calledOnceWithExactly(instance.critic.validateName, { isRequired: false });
 
 			});
 
@@ -224,8 +214,7 @@ describe('Review model', () => {
 			const instance = createInstance({ url: 'https://www.foo.com' });
 			spy(instance, 'validateStringForProperty');
 			instance.validateUrl({ isRequired: false });
-			assert.calledOnce(instance.validateStringForProperty);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				instance.validateStringForProperty,
 				'url', { isRequired: false }
 			);
@@ -265,8 +254,7 @@ describe('Review model', () => {
 				const instance = createInstance({ url: 'foobar' });
 				spy(instance, 'addPropertyError');
 				instance.validateUrl({ isRequired: false });
-				assert.calledOnce(instance.addPropertyError);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(
 					instance.addPropertyError,
 					'url', 'URL must be a valid URL'
 				);
@@ -284,8 +272,7 @@ describe('Review model', () => {
 			const instance = createInstance();
 			spy(instance, 'validatePropertyPresenceIfNamedChildren');
 			instance.validateUrlPresenceIfNamedChildren([{ name: 'Financial Times' }, { name: 'Sarah Hemming' }]);
-			assert.calledOnce(instance.validatePropertyPresenceIfNamedChildren);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				instance.validatePropertyPresenceIfNamedChildren,
 				'url', [{ name: 'Financial Times' }, { name: 'Sarah Hemming' }]
 			);
@@ -319,8 +306,7 @@ describe('Review model', () => {
 					const instance = createInstance({ date: '2024-04-03' });
 					spy(instance, 'addPropertyError');
 					instance.validateDate();
-					assert.calledOnce(stubs.isValidDateModule.isValidDate);
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate, instance.date);
+					assert.calledOnceWithExactly(stubs.isValidDateModule.isValidDate, instance.date);
 					assert.notCalled(instance.addPropertyError);
 
 				});
@@ -339,10 +325,8 @@ describe('Review model', () => {
 					const instance = createInstance({ date: 'foobar' });
 					spy(instance, 'addPropertyError');
 					instance.validateDate();
-					assert.calledOnce(stubs.isValidDateModule.isValidDate);
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate, instance.date);
-					assert.calledOnce(instance.addPropertyError);
-					assert.calledWithExactly(instance.addPropertyError, 'date', 'Value must be in date format');
+					assert.calledOnceWithExactly(stubs.isValidDateModule.isValidDate, instance.date);
+					assert.calledOnceWithExactly(instance.addPropertyError, 'date', 'Value must be in date format');
 
 				});
 

--- a/test-unit/src/models/Role.test.js
+++ b/test-unit/src/models/Role.test.js
@@ -118,8 +118,7 @@ describe('Role model', () => {
 			const instance = new Role({ name: 'Hamlet, Prince of Denmark', characterName: 'Hamlet' });
 			spy(instance, 'validateStringForProperty');
 			instance.validateCharacterName();
-			assert.calledOnce(instance.validateStringForProperty);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				instance.validateStringForProperty,
 				'characterName', { isRequired: false }
 			);
@@ -135,8 +134,7 @@ describe('Role model', () => {
 			const instance = new Role({ name: 'Cinna', characterDifferentiator: '1' });
 			spy(instance, 'validateStringForProperty');
 			instance.validateCharacterDifferentiator();
-			assert.calledOnce(instance.validateStringForProperty);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				instance.validateStringForProperty,
 				'characterDifferentiator', { isRequired: false }
 			);
@@ -197,8 +195,7 @@ describe('Role model', () => {
 				const instance = new Role({ name: 'Hamlet', characterName: 'Hamlet' });
 				spy(instance, 'addPropertyError');
 				instance.validateRoleNameCharacterNameDisparity();
-				assert.calledOnce(instance.addPropertyError);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(
 					instance.addPropertyError,
 					'characterName', 'Character name is only required if different from role name'
 				);

--- a/test-unit/src/models/SourceMaterial.test.js
+++ b/test-unit/src/models/SourceMaterial.test.js
@@ -57,12 +57,9 @@ describe('SourceMaterial model', () => {
 					stubs.validationQueries.getSourceMaterialChecksQuery,
 					stubs.neo4jQuery
 				);
-				assert.calledOnce(stubs.prepareAsParams);
-				assert.calledWithExactly(stubs.prepareAsParams, instance);
-				assert.calledOnce(stubs.validationQueries.getSourceMaterialChecksQuery);
-				assert.calledWithExactly(stubs.validationQueries.getSourceMaterialChecksQuery);
-				assert.calledOnce(stubs.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(stubs.prepareAsParams, instance);
+				assert.calledOnceWithExactly(stubs.validationQueries.getSourceMaterialChecksQuery);
+				assert.calledOnceWithExactly(
 					stubs.neo4jQuery,
 					{
 						query: 'getSourceMaterialChecksQuery response',
@@ -94,12 +91,9 @@ describe('SourceMaterial model', () => {
 					stubs.neo4jQuery,
 					instance.addPropertyError
 				);
-				assert.calledOnce(stubs.prepareAsParams);
-				assert.calledWithExactly(stubs.prepareAsParams, instance);
-				assert.calledOnce(stubs.validationQueries.getSourceMaterialChecksQuery);
-				assert.calledWithExactly(stubs.validationQueries.getSourceMaterialChecksQuery);
-				assert.calledOnce(stubs.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(stubs.prepareAsParams, instance);
+				assert.calledOnceWithExactly(stubs.validationQueries.getSourceMaterialChecksQuery);
+				assert.calledOnceWithExactly(
 					stubs.neo4jQuery,
 					{
 						query: 'getSourceMaterialChecksQuery response',

--- a/test-unit/src/models/SubMaterial.test.js
+++ b/test-unit/src/models/SubMaterial.test.js
@@ -60,12 +60,9 @@ describe('SubMaterial model', () => {
 					stubs.validationQueries.getSubMaterialChecksQuery,
 					stubs.neo4jQuery
 				);
-				assert.calledOnce(stubs.prepareAsParams);
-				assert.calledWithExactly(stubs.prepareAsParams, instance);
-				assert.calledOnce(stubs.validationQueries.getSubMaterialChecksQuery);
-				assert.calledWithExactly(stubs.validationQueries.getSubMaterialChecksQuery);
-				assert.calledOnce(stubs.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(stubs.prepareAsParams, instance);
+				assert.calledOnceWithExactly(stubs.validationQueries.getSubMaterialChecksQuery);
+				assert.calledOnceWithExactly(
 					stubs.neo4jQuery,
 					{
 						query: 'getSubMaterialChecksQuery response',
@@ -102,12 +99,9 @@ describe('SubMaterial model', () => {
 					stubs.neo4jQuery,
 					instance.addPropertyError
 				);
-				assert.calledOnce(stubs.prepareAsParams);
-				assert.calledWithExactly(stubs.prepareAsParams, instance);
-				assert.calledOnce(stubs.validationQueries.getSubMaterialChecksQuery);
-				assert.calledWithExactly(stubs.validationQueries.getSubMaterialChecksQuery);
-				assert.calledOnce(stubs.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(stubs.prepareAsParams, instance);
+				assert.calledOnceWithExactly(stubs.validationQueries.getSubMaterialChecksQuery);
+				assert.calledOnceWithExactly(
 					stubs.neo4jQuery,
 					{
 						query: 'getSubMaterialChecksQuery response',
@@ -152,12 +146,9 @@ describe('SubMaterial model', () => {
 					stubs.neo4jQuery,
 					instance.addPropertyError
 				);
-				assert.calledOnce(stubs.prepareAsParams);
-				assert.calledWithExactly(stubs.prepareAsParams, instance);
-				assert.calledOnce(stubs.validationQueries.getSubMaterialChecksQuery);
-				assert.calledWithExactly(stubs.validationQueries.getSubMaterialChecksQuery);
-				assert.calledOnce(stubs.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(stubs.prepareAsParams, instance);
+				assert.calledOnceWithExactly(stubs.validationQueries.getSubMaterialChecksQuery);
+				assert.calledOnceWithExactly(
 					stubs.neo4jQuery,
 					{
 						query: 'getSubMaterialChecksQuery response',
@@ -202,12 +193,9 @@ describe('SubMaterial model', () => {
 					stubs.neo4jQuery,
 					instance.addPropertyError
 				);
-				assert.calledOnce(stubs.prepareAsParams);
-				assert.calledWithExactly(stubs.prepareAsParams, instance);
-				assert.calledOnce(stubs.validationQueries.getSubMaterialChecksQuery);
-				assert.calledWithExactly(stubs.validationQueries.getSubMaterialChecksQuery);
-				assert.calledOnce(stubs.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(stubs.prepareAsParams, instance);
+				assert.calledOnceWithExactly(stubs.validationQueries.getSubMaterialChecksQuery);
+				assert.calledOnceWithExactly(
 					stubs.neo4jQuery,
 					{
 						query: 'getSubMaterialChecksQuery response',
@@ -252,12 +240,9 @@ describe('SubMaterial model', () => {
 					stubs.neo4jQuery,
 					instance.addPropertyError
 				);
-				assert.calledOnce(stubs.prepareAsParams);
-				assert.calledWithExactly(stubs.prepareAsParams, instance);
-				assert.calledOnce(stubs.validationQueries.getSubMaterialChecksQuery);
-				assert.calledWithExactly(stubs.validationQueries.getSubMaterialChecksQuery);
-				assert.calledOnce(stubs.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(stubs.prepareAsParams, instance);
+				assert.calledOnceWithExactly(stubs.validationQueries.getSubMaterialChecksQuery);
+				assert.calledOnceWithExactly(
 					stubs.neo4jQuery,
 					{
 						query: 'getSubMaterialChecksQuery response',

--- a/test-unit/src/models/SubProductionIdentifier.test.js
+++ b/test-unit/src/models/SubProductionIdentifier.test.js
@@ -55,10 +55,8 @@ describe('SubProductionIdentifier model', () => {
 					stubs.validationQueries.getSubProductionChecksQuery,
 					stubs.neo4jQuery
 				);
-				assert.calledOnce(stubs.validationQueries.getSubProductionChecksQuery);
-				assert.calledWithExactly(stubs.validationQueries.getSubProductionChecksQuery);
-				assert.calledOnce(stubs.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(stubs.validationQueries.getSubProductionChecksQuery);
+				assert.calledOnceWithExactly(
 					stubs.neo4jQuery,
 					{
 						query: 'getSubProductionChecksQuery response',
@@ -94,10 +92,8 @@ describe('SubProductionIdentifier model', () => {
 					stubs.neo4jQuery,
 					instance.addPropertyError
 				);
-				assert.calledOnce(stubs.validationQueries.getSubProductionChecksQuery);
-				assert.calledWithExactly(stubs.validationQueries.getSubProductionChecksQuery);
-				assert.calledOnce(stubs.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(stubs.validationQueries.getSubProductionChecksQuery);
+				assert.calledOnceWithExactly(
 					stubs.neo4jQuery,
 					{
 						query: 'getSubProductionChecksQuery response',
@@ -107,8 +103,7 @@ describe('SubProductionIdentifier model', () => {
 						}
 					}
 				);
-				assert.calledOnce(instance.addPropertyError);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(
 					instance.addPropertyError,
 					'uuid', 'Production with this UUID does not exist'
 				);
@@ -137,10 +132,8 @@ describe('SubProductionIdentifier model', () => {
 					stubs.neo4jQuery,
 					instance.addPropertyError
 				);
-				assert.calledOnce(stubs.validationQueries.getSubProductionChecksQuery);
-				assert.calledWithExactly(stubs.validationQueries.getSubProductionChecksQuery);
-				assert.calledOnce(stubs.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(stubs.validationQueries.getSubProductionChecksQuery);
+				assert.calledOnceWithExactly(
 					stubs.neo4jQuery,
 					{
 						query: 'getSubProductionChecksQuery response',
@@ -150,8 +143,7 @@ describe('SubProductionIdentifier model', () => {
 						}
 					}
 				);
-				assert.calledOnce(instance.addPropertyError);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(
 					instance.addPropertyError,
 					'uuid', 'Production with this UUID is already assigned to another sur-production'
 				);
@@ -180,10 +172,8 @@ describe('SubProductionIdentifier model', () => {
 					stubs.neo4jQuery,
 					instance.addPropertyError
 				);
-				assert.calledOnce(stubs.validationQueries.getSubProductionChecksQuery);
-				assert.calledWithExactly(stubs.validationQueries.getSubProductionChecksQuery);
-				assert.calledOnce(stubs.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(stubs.validationQueries.getSubProductionChecksQuery);
+				assert.calledOnceWithExactly(
 					stubs.neo4jQuery,
 					{
 						query: 'getSubProductionChecksQuery response',
@@ -193,8 +183,7 @@ describe('SubProductionIdentifier model', () => {
 						}
 					}
 				);
-				assert.calledOnce(instance.addPropertyError);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(
 					instance.addPropertyError,
 					'uuid', 'Production with this UUID is the sur-most production of a three-tiered production collection'
 				);
@@ -223,10 +212,8 @@ describe('SubProductionIdentifier model', () => {
 					stubs.neo4jQuery,
 					instance.addPropertyError
 				);
-				assert.calledOnce(stubs.validationQueries.getSubProductionChecksQuery);
-				assert.calledWithExactly(stubs.validationQueries.getSubProductionChecksQuery);
-				assert.calledOnce(stubs.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(stubs.validationQueries.getSubProductionChecksQuery);
+				assert.calledOnceWithExactly(
 					stubs.neo4jQuery,
 					{
 						query: 'getSubProductionChecksQuery response',
@@ -236,8 +223,7 @@ describe('SubProductionIdentifier model', () => {
 						}
 					}
 				);
-				assert.calledOnce(instance.addPropertyError);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(
 					instance.addPropertyError,
 					'uuid', 'Production with this UUID is this production\'s sur-production'
 				);
@@ -266,10 +252,8 @@ describe('SubProductionIdentifier model', () => {
 					stubs.neo4jQuery,
 					instance.addPropertyError
 				);
-				assert.calledOnce(stubs.validationQueries.getSubProductionChecksQuery);
-				assert.calledWithExactly(stubs.validationQueries.getSubProductionChecksQuery);
-				assert.calledOnce(stubs.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(stubs.validationQueries.getSubProductionChecksQuery);
+				assert.calledOnceWithExactly(
 					stubs.neo4jQuery,
 					{
 						query: 'getSubProductionChecksQuery response',
@@ -279,8 +263,7 @@ describe('SubProductionIdentifier model', () => {
 						}
 					}
 				);
-				assert.calledOnce(instance.addPropertyError);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(
 					instance.addPropertyError,
 					'uuid', 'Sub-production cannot be assigned to a three-tiered production collection'
 				);

--- a/test-unit/src/models/SubVenue.test.js
+++ b/test-unit/src/models/SubVenue.test.js
@@ -59,12 +59,9 @@ describe('SubVenue model', () => {
 					stubs.validationQueries.getSubVenueChecksQuery,
 					stubs.neo4jQuery
 				);
-				assert.calledOnce(stubs.prepareAsParams);
-				assert.calledWithExactly(stubs.prepareAsParams, instance);
-				assert.calledOnce(stubs.validationQueries.getSubVenueChecksQuery);
-				assert.calledWithExactly(stubs.validationQueries.getSubVenueChecksQuery);
-				assert.calledOnce(stubs.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(stubs.prepareAsParams, instance);
+				assert.calledOnceWithExactly(stubs.validationQueries.getSubVenueChecksQuery);
+				assert.calledOnceWithExactly(
 					stubs.neo4jQuery,
 					{
 						query: 'getSubVenueChecksQuery response',
@@ -100,12 +97,9 @@ describe('SubVenue model', () => {
 					stubs.neo4jQuery,
 					instance.addPropertyError
 				);
-				assert.calledOnce(stubs.prepareAsParams);
-				assert.calledWithExactly(stubs.prepareAsParams, instance);
-				assert.calledOnce(stubs.validationQueries.getSubVenueChecksQuery);
-				assert.calledWithExactly(stubs.validationQueries.getSubVenueChecksQuery);
-				assert.calledOnce(stubs.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(stubs.prepareAsParams, instance);
+				assert.calledOnceWithExactly(stubs.validationQueries.getSubVenueChecksQuery);
+				assert.calledOnceWithExactly(
 					stubs.neo4jQuery,
 					{
 						query: 'getSubVenueChecksQuery response',
@@ -149,12 +143,9 @@ describe('SubVenue model', () => {
 					stubs.neo4jQuery,
 					instance.addPropertyError
 				);
-				assert.calledOnce(stubs.prepareAsParams);
-				assert.calledWithExactly(stubs.prepareAsParams, instance);
-				assert.calledOnce(stubs.validationQueries.getSubVenueChecksQuery);
-				assert.calledWithExactly(stubs.validationQueries.getSubVenueChecksQuery);
-				assert.calledOnce(stubs.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(stubs.prepareAsParams, instance);
+				assert.calledOnceWithExactly(stubs.validationQueries.getSubVenueChecksQuery);
+				assert.calledOnceWithExactly(
 					stubs.neo4jQuery,
 					{
 						query: 'getSubVenueChecksQuery response',
@@ -198,12 +189,9 @@ describe('SubVenue model', () => {
 					stubs.neo4jQuery,
 					instance.addPropertyError
 				);
-				assert.calledOnce(stubs.prepareAsParams);
-				assert.calledWithExactly(stubs.prepareAsParams, instance);
-				assert.calledOnce(stubs.validationQueries.getSubVenueChecksQuery);
-				assert.calledWithExactly(stubs.validationQueries.getSubVenueChecksQuery);
-				assert.calledOnce(stubs.neo4jQuery);
-				assert.calledWithExactly(
+				assert.calledOnceWithExactly(stubs.prepareAsParams, instance);
+				assert.calledOnceWithExactly(stubs.validationQueries.getSubVenueChecksQuery);
+				assert.calledOnceWithExactly(
 					stubs.neo4jQuery,
 					{
 						query: 'getSubVenueChecksQuery response',

--- a/test-unit/src/models/Venue.test.js
+++ b/test-unit/src/models/Venue.test.js
@@ -108,26 +108,19 @@ describe('Venue model', () => {
 				instance.subVenues[0].validateNoAssociationWithSelf,
 				instance.subVenues[0].validateUniquenessInGroup
 			);
-			assert.calledOnce(instance.validateName);
-			assert.calledWithExactly(instance.validateName, { isRequired: true });
-			assert.calledOnce(instance.validateDifferentiator);
-			assert.calledWithExactly(instance.validateDifferentiator);
-			assert.calledOnce(stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(instance.validateName, { isRequired: true });
+			assert.calledOnceWithExactly(instance.validateDifferentiator);
+			assert.calledOnceWithExactly(
 				stubs.getDuplicateIndicesModule.getDuplicateBaseInstanceIndices,
 				instance.subVenues
 			);
-			assert.calledOnce(instance.subVenues[0].validateName);
-			assert.calledWithExactly(instance.subVenues[0].validateName, { isRequired: false });
-			assert.calledOnce(instance.subVenues[0].validateDifferentiator);
-			assert.calledWithExactly(instance.subVenues[0].validateDifferentiator);
-			assert.calledOnce(instance.subVenues[0].validateNoAssociationWithSelf);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(instance.subVenues[0].validateName, { isRequired: false });
+			assert.calledOnceWithExactly(instance.subVenues[0].validateDifferentiator);
+			assert.calledOnceWithExactly(
 				instance.subVenues[0].validateNoAssociationWithSelf,
 				{ name: 'National Theatre', differentiator: '' }
 			);
-			assert.calledOnce(instance.subVenues[0].validateUniquenessInGroup);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				instance.subVenues[0].validateUniquenessInGroup,
 				{ isDuplicate: false }
 			);
@@ -152,10 +145,8 @@ describe('Venue model', () => {
 			const instance = createInstance(props);
 			stub(instance, 'validateUniquenessInDatabase');
 			await instance.runDatabaseValidations();
-			assert.calledOnce(instance.validateUniquenessInDatabase);
-			assert.calledWithExactly(instance.validateUniquenessInDatabase);
-			assert.calledOnce(instance.subVenues[0].runDatabaseValidations);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(instance.validateUniquenessInDatabase);
+			assert.calledOnceWithExactly(
 				instance.subVenues[0].runDatabaseValidations,
 				{ subjectVenueUuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' }
 			);

--- a/test-unit/src/models/WritingCredit.test.js
+++ b/test-unit/src/models/WritingCredit.test.js
@@ -199,35 +199,23 @@ describe('WritingCredit model', () => {
 				instance.entities[2].validateUniquenessInGroup,
 				instance.entities[2].validateNoAssociationWithSelf
 			);
-			assert.calledOnce(instance.validateName);
-			assert.calledWithExactly(instance.validateName, { isRequired: false });
-			assert.calledOnce(stubs.getDuplicateIndicesModule.getDuplicateEntityIndices);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(instance.validateName, { isRequired: false });
+			assert.calledOnceWithExactly(
 				stubs.getDuplicateIndicesModule.getDuplicateEntityIndices,
 				instance.entities
 			);
-			assert.calledOnce(instance.entities[0].validateName);
-			assert.calledWithExactly(instance.entities[0].validateName, { isRequired: false });
-			assert.calledOnce(instance.entities[0].validateDifferentiator);
-			assert.calledWithExactly(instance.entities[0].validateDifferentiator);
-			assert.calledOnce(instance.entities[0].validateUniquenessInGroup);
-			assert.calledWithExactly(instance.entities[0].validateUniquenessInGroup, { isDuplicate: false });
+			assert.calledOnceWithExactly(instance.entities[0].validateName, { isRequired: false });
+			assert.calledOnceWithExactly(instance.entities[0].validateDifferentiator);
+			assert.calledOnceWithExactly(instance.entities[0].validateUniquenessInGroup, { isDuplicate: false });
 			assert.notCalled(instance.entities[0].validateNoAssociationWithSelf);
-			assert.calledOnce(instance.entities[1].validateName);
-			assert.calledWithExactly(instance.entities[1].validateName, { isRequired: false });
-			assert.calledOnce(instance.entities[1].validateDifferentiator);
-			assert.calledWithExactly(instance.entities[1].validateDifferentiator);
-			assert.calledOnce(instance.entities[1].validateUniquenessInGroup);
-			assert.calledWithExactly(instance.entities[1].validateUniquenessInGroup, { isDuplicate: false });
+			assert.calledOnceWithExactly(instance.entities[1].validateName, { isRequired: false });
+			assert.calledOnceWithExactly(instance.entities[1].validateDifferentiator);
+			assert.calledOnceWithExactly(instance.entities[1].validateUniquenessInGroup, { isDuplicate: false });
 			assert.notCalled(instance.entities[1].validateNoAssociationWithSelf);
-			assert.calledOnce(instance.entities[2].validateName);
-			assert.calledWithExactly(instance.entities[2].validateName, { isRequired: false });
-			assert.calledOnce(instance.entities[2].validateDifferentiator);
-			assert.calledWithExactly(instance.entities[2].validateDifferentiator);
-			assert.calledOnce(instance.entities[2].validateUniquenessInGroup);
-			assert.calledWithExactly(instance.entities[2].validateUniquenessInGroup, { isDuplicate: false });
-			assert.calledOnce(instance.entities[2].validateNoAssociationWithSelf);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(instance.entities[2].validateName, { isRequired: false });
+			assert.calledOnceWithExactly(instance.entities[2].validateDifferentiator);
+			assert.calledOnceWithExactly(instance.entities[2].validateUniquenessInGroup, { isDuplicate: false });
+			assert.calledOnceWithExactly(
 				instance.entities[2].validateNoAssociationWithSelf,
 				{ name: 'The Indian Boy', differentiator: '1' }
 			);
@@ -260,8 +248,7 @@ describe('WritingCredit model', () => {
 			await instance.runDatabaseValidations({ subjectMaterialUuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' });
 			assert.notCalled(instance.entities[0].runDatabaseValidations);
 			assert.notCalled(instance.entities[1].runDatabaseValidations);
-			assert.calledOnce(instance.entities[2].runDatabaseValidations);
-			assert.calledWithExactly(
+			assert.calledOnceWithExactly(
 				instance.entities[2].runDatabaseValidations,
 				{ subjectMaterialUuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' }
 			);


### PR DESCRIPTION
This PR consolidates separate `assert.calledOnce()` and `assert.calledWithExactly()` (where called once) calls into a single `assert.calledOnceWithExactly()` call to make the tests more succinct.

It loses the granularity of knowing if the error was because the given function was not called with the specific arguments or if the given function was called a number of times other than one, though the error message should make clear, and in either of those cases, debugging would be required to identify the cause as it would here as well.

### References:
- [Sinon.js: Assertions — `sinon.assert.calledOnceWithExactly(spyOrSpyCall, arg1, arg2, ...);`](https://sinonjs.org/releases/latest/assertions/#:~:text=sinon.assert.calledOnceWithExactly(spyOrSpyCall%2C%20arg1%2C%20arg2%2C%20...)%3B)