### PR TITLE
Revise syntax for referencing specific stub calls

### DIFF
--- a/test-unit/src/lib/prepare-as-params.test.js
+++ b/test-unit/src/lib/prepare-as-params.test.js
@@ -476,8 +476,8 @@ describe('Prepare As Params module', () => {
 				const result = prepareAsParams(instance);
 				assert.calledTwice(stubs.cryptoRandomUUID);
 				assert.calledTwice(stubs.neo4jInt);
-				assert.calledWithExactly(stubs.neo4jInt.getCall(0), 0);
-				assert.calledWithExactly(stubs.neo4jInt.getCall(1), 1);
+				assert.calledWithExactly(stubs.neo4jInt.firstCall, 0);
+				assert.calledWithExactly(stubs.neo4jInt.secondCall, 1);
 				expect(result.cast[0]).to.have.property('position');
 				expect(result.cast[0].position).to.equal(0);
 				expect(result.cast[1]).to.have.property('position');
@@ -866,8 +866,8 @@ describe('Prepare As Params module', () => {
 				const result = prepareAsParams(instance);
 				assert.calledTwice(stubs.cryptoRandomUUID);
 				assert.calledTwice(stubs.neo4jInt);
-				assert.calledWithExactly(stubs.neo4jInt.getCall(0), 0);
-				assert.calledWithExactly(stubs.neo4jInt.getCall(1), 1);
+				assert.calledWithExactly(stubs.neo4jInt.firstCall, 0);
+				assert.calledWithExactly(stubs.neo4jInt.secondCall, 1);
 				expect(result.production.cast[0]).to.have.property('position');
 				expect(result.production.cast[0].position).to.equal(0);
 				expect(result.production.cast[1]).to.have.property('position');
@@ -1288,8 +1288,8 @@ describe('Prepare As Params module', () => {
 				const result = prepareAsParams(instance);
 				assert.calledTwice(stubs.cryptoRandomUUID);
 				assert.calledTwice(stubs.neo4jInt);
-				assert.calledWithExactly(stubs.neo4jInt.getCall(0), 0);
-				assert.calledWithExactly(stubs.neo4jInt.getCall(1), 1);
+				assert.calledWithExactly(stubs.neo4jInt.firstCall, 0);
+				assert.calledWithExactly(stubs.neo4jInt.secondCall, 1);
 				expect(result.cast[0]).to.not.have.property('position');
 				expect(result.cast[0].roles[0]).to.have.property('position');
 				expect(result.cast[0].roles[0].position).to.equal(0);

--- a/test-unit/src/models/Entity.test.js
+++ b/test-unit/src/models/Entity.test.js
@@ -1141,11 +1141,11 @@ describe('Entity model', () => {
 				assert.calledOnceWithExactly(stubs.getShowQueries.PRODUCTION);
 				assert.calledTwice(stubs.neo4jQuery);
 				assert.calledWithExactly(
-					stubs.neo4jQuery.getCall(0),
+					stubs.neo4jQuery.firstCall,
 					{ query: 'showProductionQuery', params: { uuid: instance.uuid } }
 				);
 				assert.calledWithExactly(
-					stubs.neo4jQuery.getCall(1),
+					stubs.neo4jQuery.secondCall,
 					{ query: 'showProductionAwardsQuery', params: { uuid: instance.uuid } }
 				);
 				expect(result).to.deep.equal(neo4jQueryMockResponse);

--- a/test-unit/src/models/Nomination.test.js
+++ b/test-unit/src/models/Nomination.test.js
@@ -309,14 +309,14 @@ describe('Nomination model', () => {
 			assert.calledOnceWithExactly(instance.entities[0].validateDifferentiator);
 			assert.calledTwice(stubs.getDuplicateEntityInfoModule.isEntityInArray);
 			assert.calledWithExactly(
-				stubs.getDuplicateEntityInfoModule.isEntityInArray.getCall(0),
+				stubs.getDuplicateEntityInfoModule.isEntityInArray.firstCall,
 				instance.entities[0], 'getDuplicateEntities response'
 			);
 			assert.calledOnceWithExactly(instance.entities[0].validateUniquenessInGroup, { isDuplicate: false });
 			assert.calledOnceWithExactly(instance.entities[1].validateName, { isRequired: false });
 			assert.calledOnceWithExactly(instance.entities[1].validateDifferentiator);
 			assert.calledWithExactly(
-				stubs.getDuplicateEntityInfoModule.isEntityInArray.getCall(1),
+				stubs.getDuplicateEntityInfoModule.isEntityInArray.secondCall,
 				instance.entities[1], 'getDuplicateEntities response'
 			);
 			assert.calledOnceWithExactly(instance.entities[1].validateUniquenessInGroup, { isDuplicate: false });

--- a/test-unit/src/models/ProducerCredit.test.js
+++ b/test-unit/src/models/ProducerCredit.test.js
@@ -147,13 +147,13 @@ describe('ProducerCredit model', () => {
 			assert.calledOnceWithExactly(instance.entities[0].validateDifferentiator);
 			assert.calledTwice(stubs.getDuplicateEntityInfoModule.isEntityInArray);
 			assert.calledWithExactly(
-				stubs.getDuplicateEntityInfoModule.isEntityInArray.getCall(0),
+				stubs.getDuplicateEntityInfoModule.isEntityInArray.firstCall,
 				instance.entities[0], 'getDuplicateEntities response'
 			);
 			assert.calledOnceWithExactly(instance.entities[0].validateUniquenessInGroup, { isDuplicate: false });
 			assert.calledOnceWithExactly(instance.entities[1].validateName, { isRequired: false });
 			assert.calledWithExactly(
-				stubs.getDuplicateEntityInfoModule.isEntityInArray.getCall(1),
+				stubs.getDuplicateEntityInfoModule.isEntityInArray.secondCall,
 				instance.entities[1], 'getDuplicateEntities response'
 			);
 			assert.calledOnceWithExactly(instance.entities[1].validateUniquenessInGroup, { isDuplicate: false });

--- a/test-unit/src/models/Production.test.js
+++ b/test-unit/src/models/Production.test.js
@@ -588,7 +588,7 @@ describe('Production model', () => {
 			);
 			assert.calledThrice(stubs.getDuplicateIndicesModule.getDuplicateNameIndices);
 			assert.calledWithExactly(
-				stubs.getDuplicateIndicesModule.getDuplicateNameIndices.getCall(0),
+				stubs.getDuplicateIndicesModule.getDuplicateNameIndices.firstCall,
 				instance.producerCredits
 			);
 			assert.calledOnceWithExactly(
@@ -604,7 +604,7 @@ describe('Production model', () => {
 				{ isDuplicate: false }
 			);
 			assert.calledWithExactly(
-				stubs.getDuplicateIndicesModule.getDuplicateNameIndices.getCall(1),
+				stubs.getDuplicateIndicesModule.getDuplicateNameIndices.secondCall,
 				instance.creativeCredits
 			);
 			assert.calledOnceWithExactly(
@@ -612,7 +612,7 @@ describe('Production model', () => {
 				{ isDuplicate: false }
 			);
 			assert.calledWithExactly(
-				stubs.getDuplicateIndicesModule.getDuplicateNameIndices.getCall(2),
+				stubs.getDuplicateIndicesModule.getDuplicateNameIndices.thirdCall,
 				instance.crewCredits
 			);
 			assert.calledOnceWithExactly(
@@ -644,9 +644,9 @@ describe('Production model', () => {
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
 					expect(stubs.isValidDateModule.isValidDate.callCount).to.equal(3);
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(0), '');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(1), '');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(2), '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.firstCall, '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.secondCall, '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.thirdCall, '');
 					assert.notCalled(instance.addPropertyError);
 
 				});
@@ -662,9 +662,9 @@ describe('Production model', () => {
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
 					expect(stubs.isValidDateModule.isValidDate.callCount).to.equal(3);
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(0), '2010-09-30');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(1), '');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(2), '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.firstCall, '2010-09-30');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.secondCall, '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.thirdCall, '');
 					assert.notCalled(instance.addPropertyError);
 
 				});
@@ -679,9 +679,9 @@ describe('Production model', () => {
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
 					expect(stubs.isValidDateModule.isValidDate.callCount).to.equal(3);
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(0), '');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(1), '');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(2), '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.firstCall, '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.secondCall, '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.thirdCall, '');
 					assert.notCalled(instance.addPropertyError);
 
 				});
@@ -697,9 +697,9 @@ describe('Production model', () => {
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
 					expect(stubs.isValidDateModule.isValidDate.callCount).to.equal(3);
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(0), '');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(1), '2010-10-07');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(2), '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.firstCall, '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.secondCall, '2010-10-07');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.thirdCall, '');
 					assert.notCalled(instance.addPropertyError);
 
 				});
@@ -714,9 +714,9 @@ describe('Production model', () => {
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
 					expect(stubs.isValidDateModule.isValidDate.callCount).to.equal(3);
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(0), '');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(1), '');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(2), '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.firstCall, '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.secondCall, '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.thirdCall, '');
 					assert.notCalled(instance.addPropertyError);
 
 				});
@@ -732,9 +732,9 @@ describe('Production model', () => {
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
 					expect(stubs.isValidDateModule.isValidDate.callCount).to.equal(3);
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(0), '');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(1), '');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(2), '2011-01-26');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.firstCall, '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.secondCall, '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.thirdCall, '2011-01-26');
 					assert.notCalled(instance.addPropertyError);
 
 				});
@@ -752,9 +752,9 @@ describe('Production model', () => {
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
 					expect(stubs.isValidDateModule.isValidDate.callCount).to.equal(3);
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(0), '2010-09-30');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(1), '');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(2), '2011-01-26');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.firstCall, '2010-09-30');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.secondCall, '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.thirdCall, '2011-01-26');
 					assert.notCalled(instance.addPropertyError);
 
 				});
@@ -772,9 +772,9 @@ describe('Production model', () => {
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
 					expect(stubs.isValidDateModule.isValidDate.callCount).to.equal(3);
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(0), '2010-09-30');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(1), '');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(2), '2010-09-30');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.firstCall, '2010-09-30');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.secondCall, '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.thirdCall, '2010-09-30');
 					assert.notCalled(instance.addPropertyError);
 
 				});
@@ -796,9 +796,9 @@ describe('Production model', () => {
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
 					expect(stubs.isValidDateModule.isValidDate.callCount).to.equal(3);
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(0), '2010-09-30');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(1), '2010-10-07');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(2), '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.firstCall, '2010-09-30');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.secondCall, '2010-10-07');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.thirdCall, '');
 					assert.notCalled(instance.addPropertyError);
 
 				});
@@ -820,9 +820,9 @@ describe('Production model', () => {
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
 					expect(stubs.isValidDateModule.isValidDate.callCount).to.equal(3);
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(0), '2010-09-30');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(1), '2010-09-30');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(2), '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.firstCall, '2010-09-30');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.secondCall, '2010-09-30');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.thirdCall, '');
 					assert.notCalled(instance.addPropertyError);
 
 				});
@@ -840,9 +840,9 @@ describe('Production model', () => {
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
 					expect(stubs.isValidDateModule.isValidDate.callCount).to.equal(3);
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(0), '');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(1), '2010-10-07');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(2), '2011-01-26');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.firstCall, '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.secondCall, '2010-10-07');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.thirdCall, '2011-01-26');
 					assert.notCalled(instance.addPropertyError);
 
 				});
@@ -860,9 +860,9 @@ describe('Production model', () => {
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
 					expect(stubs.isValidDateModule.isValidDate.callCount).to.equal(3);
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(0), '');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(1), '2010-09-30');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(2), '2010-09-30');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.firstCall, '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.secondCall, '2010-09-30');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.thirdCall, '2010-09-30');
 					assert.notCalled(instance.addPropertyError);
 
 				});
@@ -877,9 +877,9 @@ describe('Production model', () => {
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
 					expect(stubs.isValidDateModule.isValidDate.callCount).to.equal(3);
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(0), '');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(1), '');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(2), '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.firstCall, '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.secondCall, '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.thirdCall, '');
 					assert.notCalled(instance.addPropertyError);
 
 				});
@@ -903,9 +903,9 @@ describe('Production model', () => {
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
 					expect(stubs.isValidDateModule.isValidDate.callCount).to.equal(3);
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(0), '2010-09-30');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(1), '2010-10-07');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(2), '2011-01-26');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.firstCall, '2010-09-30');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.secondCall, '2010-10-07');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.thirdCall, '2011-01-26');
 					assert.notCalled(instance.addPropertyError);
 
 				});
@@ -929,9 +929,9 @@ describe('Production model', () => {
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
 					expect(stubs.isValidDateModule.isValidDate.callCount).to.equal(3);
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(0), '2010-09-30');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(1), '2010-09-30');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(2), '2010-09-30');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.firstCall, '2010-09-30');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.secondCall, '2010-09-30');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.thirdCall, '2010-09-30');
 					assert.notCalled(instance.addPropertyError);
 
 				});
@@ -950,9 +950,9 @@ describe('Production model', () => {
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
 					expect(stubs.isValidDateModule.isValidDate.callCount).to.equal(3);
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(0), 'foobar');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(1), '');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(2), '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.firstCall, 'foobar');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.secondCall, '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.thirdCall, '');
 					assert.calledOnceWithExactly(
 						instance.addPropertyError,
 						'startDate', 'Value must be in date format'
@@ -970,9 +970,9 @@ describe('Production model', () => {
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
 					expect(stubs.isValidDateModule.isValidDate.callCount).to.equal(3);
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(0), '');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(1), 'foobar');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(2), '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.firstCall, '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.secondCall, 'foobar');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.thirdCall, '');
 					assert.calledOnceWithExactly(
 						instance.addPropertyError,
 						'pressDate', 'Value must be in date format'
@@ -990,9 +990,9 @@ describe('Production model', () => {
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
 					expect(stubs.isValidDateModule.isValidDate.callCount).to.equal(3);
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(0), '');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(1), '');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(2), 'foobar');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.firstCall, '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.secondCall, '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.thirdCall, 'foobar');
 					assert.calledOnceWithExactly(
 						instance.addPropertyError,
 						'endDate', 'Value must be in date format'
@@ -1013,16 +1013,16 @@ describe('Production model', () => {
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
 					expect(stubs.isValidDateModule.isValidDate.callCount).to.equal(3);
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(0), '2011-01-26');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(1), '');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(2), '2010-09-30');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.firstCall, '2011-01-26');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.secondCall, '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.thirdCall, '2010-09-30');
 					assert.calledTwice(instance.addPropertyError);
 					assert.calledWithExactly(
-						instance.addPropertyError.getCall(0),
+						instance.addPropertyError.firstCall,
 						'startDate', 'Start date must not be after end date'
 					);
 					assert.calledWithExactly(
-						instance.addPropertyError.getCall(1),
+						instance.addPropertyError.secondCall,
 						'endDate', 'End date must not be before start date'
 					);
 
@@ -1045,16 +1045,16 @@ describe('Production model', () => {
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
 					expect(stubs.isValidDateModule.isValidDate.callCount).to.equal(3);
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(0), '2010-10-07');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(1), '2010-09-30');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(2), '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.firstCall, '2010-10-07');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.secondCall, '2010-09-30');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.thirdCall, '');
 					assert.calledTwice(instance.addPropertyError);
 					assert.calledWithExactly(
-						instance.addPropertyError.getCall(0),
+						instance.addPropertyError.firstCall,
 						'startDate', 'Start date must not be after press date'
 					);
 					assert.calledWithExactly(
-						instance.addPropertyError.getCall(1),
+						instance.addPropertyError.secondCall,
 						'pressDate', 'Press date must not be before start date'
 					);
 
@@ -1073,16 +1073,16 @@ describe('Production model', () => {
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
 					expect(stubs.isValidDateModule.isValidDate.callCount).to.equal(3);
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(0), '');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(1), '2011-01-26');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(2), '2010-10-07');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.firstCall, '');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.secondCall, '2011-01-26');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.thirdCall, '2010-10-07');
 					assert.calledTwice(instance.addPropertyError);
 					assert.calledWithExactly(
-						instance.addPropertyError.getCall(0),
+						instance.addPropertyError.firstCall,
 						'pressDate', 'Press date must not be after end date'
 					);
 					assert.calledWithExactly(
-						instance.addPropertyError.getCall(1),
+						instance.addPropertyError.secondCall,
 						'endDate', 'End date must not be before press date'
 					);
 
@@ -1107,20 +1107,20 @@ describe('Production model', () => {
 					spy(instance, 'addPropertyError');
 					instance.validateDates();
 					expect(stubs.isValidDateModule.isValidDate.callCount).to.equal(3);
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(0), '2011-01-26');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(1), '2010-10-07');
-					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.getCall(2), '2010-09-30');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.firstCall, '2011-01-26');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.secondCall, '2010-10-07');
+					assert.calledWithExactly(stubs.isValidDateModule.isValidDate.thirdCall, '2010-09-30');
 					expect(instance.addPropertyError.callCount).to.equal(6);
 					assert.calledWithExactly(
-						instance.addPropertyError.getCall(0),
+						instance.addPropertyError.firstCall,
 						'startDate', 'Start date must not be after end date'
 					);
 					assert.calledWithExactly(
-						instance.addPropertyError.getCall(1),
+						instance.addPropertyError.secondCall,
 						'endDate', 'End date must not be before start date'
 					);
 					assert.calledWithExactly(
-						instance.addPropertyError.getCall(2),
+						instance.addPropertyError.thirdCall,
 						'startDate', 'Start date must not be after press date'
 					);
 					assert.calledWithExactly(

--- a/test-unit/src/models/ProductionTeamCredit.test.js
+++ b/test-unit/src/models/ProductionTeamCredit.test.js
@@ -150,14 +150,14 @@ describe('ProductionTeamCredit model', () => {
 			assert.calledOnceWithExactly(instance.entities[0].validateDifferentiator);
 			assert.calledTwice(stubs.getDuplicateEntityInfoModule.isEntityInArray);
 			assert.calledWithExactly(
-				stubs.getDuplicateEntityInfoModule.isEntityInArray.getCall(0),
+				stubs.getDuplicateEntityInfoModule.isEntityInArray.firstCall,
 				instance.entities[0], 'getDuplicateEntities response'
 			);
 			assert.calledOnceWithExactly(instance.entities[0].validateUniquenessInGroup, { isDuplicate: false });
 			assert.calledOnceWithExactly(instance.entities[1].validateName, { isRequired: false });
 			assert.calledOnceWithExactly(instance.entities[1].validateDifferentiator);
 			assert.calledWithExactly(
-				stubs.getDuplicateEntityInfoModule.isEntityInArray.getCall(1),
+				stubs.getDuplicateEntityInfoModule.isEntityInArray.secondCall,
 				instance.entities[1], 'getDuplicateEntities response'
 			);
 			assert.calledOnceWithExactly(instance.entities[1].validateUniquenessInGroup, { isDuplicate: false });


### PR DESCRIPTION
This PR revises the syntax for referencing specific stub calls to the more readable option.