### PR TITLE
Fix The Mountaintop material database seed (Dr Martin Luther King Jr character)

### DIFF
--- a/db-seeding/seeds/materials/the-mountaintop.json
+++ b/db-seeding/seeds/materials/the-mountaintop.json
@@ -16,7 +16,7 @@
 			"characters": [
 				{
 					"name": "King",
-					"underlyingName": "Dr Martin Luther King, Jr"
+					"underlyingName": "Dr Martin Luther King Jr"
 				},
 				{
 					"name": "Camae"


### PR DESCRIPTION
This PR removes the comma from Dr Martin Luther King Jr, who appears as a character in the material The Mountaintop, to ensure that the portrayals in corresponding productions can link up.