### PR TITLE
Use Node.js-native watch

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,6 +1,0 @@
-{
-  "watch": [
-    "built"
-  ],
-  "ext": "js"
-}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "webpack",
     "watch": "webpack --watch",
     "setup": "node --require source-map-support/register built/setup.js",
-    "start": "npm run setup && npm run watch & nodemon --require source-map-support/register built/app.js"
+    "start": "npm run setup && npm run watch & node --watch --require source-map-support/register built/app.js"
   },
   "pre-commit": [
     "lint-check",
@@ -54,7 +54,6 @@
     "lintspaces-cli": "0.7.1",
     "mocha": "10.0.0",
     "node-mocks-http": "1.11.0",
-    "nodemon": "2.0.20",
     "pre-commit": "1.2.2",
     "proxyquire": "2.1.3",
     "sinon": "14.0.0",


### PR DESCRIPTION
This PR removes its dependency on Nodemon in favour of the Node.js-native `--watch` option

### References:
- [Node.js v22.2.0 | Command-line API: `--watch-path`](https://nodejs.org/docs/v22.2.0/api/cli.html#--watch-path)