### PR TITLE
Use 'node:' prefix for Node.js-native modules

### DIFF
--- a/db-seeding/seed-db.js
+++ b/db-seeding/seed-db.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const directly = require('directly');
 const jsonlint = require('jsonlint');

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,6 @@
 import './dotenv';
 
-import http from 'http';
+import http from 'node:http';
 
 import express from 'express';
 import logger from 'morgan';

--- a/src/lib/get-random-uuid.js
+++ b/src/lib/get-random-uuid.js
@@ -1,3 +1,3 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 
 export const getRandomUuid = () => randomUUID({ disableEntropyCache: true });

--- a/transfer-env-dev.js
+++ b/transfer-env-dev.js
@@ -1,3 +1,3 @@
-const fs = require('fs');
+const fs = require('node:fs');
 
 fs.createReadStream('.env-dev').pipe(fs.createWriteStream('.env'));

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('node:path');
 
 const nodeExternals = require('webpack-node-externals');
 


### PR DESCRIPTION
This PR adds the `node:` prefix to Node.js native modules to make their origin and distinction from third-party packages clearer.