### PR TITLE
Use mochaGlobalSetup + mochaGlobalTeardown

### DIFF
--- a/test-e2e/.mocharc.json
+++ b/test-e2e/.mocharc.json
@@ -1,7 +1,11 @@
 {
-  "file": ["test-e2e/mocha.env.js", "test-e2e/setup.js"],
   "reporter-option": "maxDiffSize=8192",
-  "require": "@babel/register",
+  "require": [
+    "@babel/register",
+    "test-e2e/mocha.env.js",
+    "test-e2e/setup.js",
+    "test-e2e/teardown.js"
+  ],
   "spec": "test-e2e/**/*.test.js",
   "timeout": "60000"
 }

--- a/test-e2e/setup.js
+++ b/test-e2e/setup.js
@@ -1,9 +1,8 @@
 import createNeo4jConstraints from '../src/neo4j/create-constraints';
 import createNeo4jFullTextIndexes from '../src/neo4j/create-full-text-indexes';
 import createNeo4jIndexes from '../src/neo4j/create-indexes';
-import { shutDown } from '../src/app';
 
-before(async () => {
+export async function mochaGlobalSetup () {
 
 	await createNeo4jConstraints();
 
@@ -11,10 +10,4 @@ before(async () => {
 
 	await createNeo4jFullTextIndexes();
 
-});
-
-after(() => {
-
-	shutDown();
-
-});
+}

--- a/test-e2e/teardown.js
+++ b/test-e2e/teardown.js
@@ -1,0 +1,7 @@
+import { shutDown } from '../src/app';
+
+export async function mochaGlobalTeardown () {
+
+	shutDown();
+
+}


### PR DESCRIPTION
This PR implements Mocha global setup fixtures (`mochaGlobalSetup` and `mochaGlobalTeardown`) to run the end-to-end setup and teardown tasks (which are designed exclusively for this task), rather than the current setup, which Mocha-specific linting (to be implemented later) will complain does not meet the [no-top-level-hooks](https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/docs/rules/no-top-level-hooks.md) rule.

### References:
- [Mocha — global setup fixtures](https://mochajs.org/#global-fixtures)
- [GitHub: mochajs/mocha — Releases v8.2.0](https://github.com/mochajs/mocha/releases/tag/v8.2.0)
- [GitHub: mochajs/mocha — Issues: global setup / teardown hooks](https://github.com/mochajs/mocha/issues/4308)