### PR TITLE
Preserve output upon process restart from watch mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "webpack",
     "watch": "webpack --watch",
     "setup": "node --require source-map-support/register built/setup.js",
-    "start": "npm run setup && npm run watch & node --watch --require source-map-support/register built/app.js"
+    "start": "npm run setup && npm run watch & node --watch --watch-preserve-output --require source-map-support/register built/app.js"
   },
   "pre-commit": [
     "lint-check",


### PR DESCRIPTION
This PR is a follow up to https://github.com/andygout/dramatis-api/pull/676.

It adds the [`--watch-preserve-output`](https://nodejs.org/api/cli.html#--watch-preserve-output) flag to disable the clearing of the console when watch mode restarts the process.

### References:
- [Command-line API | Node.js Documentation: `--watch-preserve-output`](https://nodejs.org/api/cli.html#--watch-preserve-output)