### PR TITLE
Update Docker compose command

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint-check": "npm run lint && npm run lintspaces",
     "unit-test": "mocha --config test-unit/.mocharc.json",
     "int-test": "mocha --config test-int/.mocharc.json",
-    "e2e-test-resources": "docker-compose -f docker/docker-compose.yml up",
+    "e2e-test-resources": "docker compose -f docker/docker-compose.yml up",
     "e2e-test": "mocha --config test-e2e/.mocharc.json",
     "seed-db": "node db-seeding/seed-db",
     "transfer-env-dev": "node transfer-env-dev",


### PR DESCRIPTION
This PR updates the Docker compose command that is run as part of the `e2e-test-resources` script so that it uses the Docker Compose v2 command.

### References:
- [GitHub: community — Discussions: Error: docker-compose command not found](https://github.com/orgs/community/discussions/116610)
  - > If you've encountered the error "docker-compose command not found" on or about April 2, 2024, it means you're using the v1 Docker Compose command.
    >
    > GitHub deprecated v1, and you need to change the command from, e.g., docker-compose build to docker compose build (remove the dash)
- [Docker Docs: Migrate to Compose V2](https://docs.docker.com/compose/releases/migrate)