### PR TITLE
Use global mocks for model unit tests

### DIFF
--- a/test-unit/src/models/AwardCeremony.test.js
+++ b/test-unit/src/models/AwardCeremony.test.js
@@ -54,13 +54,19 @@ describe('AwardCeremony model', () => {
 	});
 
 	const createSubject = () =>
-		esmock('../../../src/models/AwardCeremony.js', {
-			'../../../src/lib/get-duplicate-indices.js': stubs.getDuplicateIndicesModule,
-			'../../../src/lib/prepare-as-params.js': stubs.prepareAsParamsModule,
-			'../../../src/models/index.js': stubs.models,
-			'../../../src/neo4j/cypher-queries/index.js': stubs.cypherQueriesModule,
-			'../../../src/neo4j/query.js': stubs.neo4jQueryModule
-		});
+		esmock(
+			'../../../src/models/AwardCeremony.js',
+			{},
+			// globalmocks: mock definitions imported everywhere.
+			// Required for when functions are invoked by ancestor class methods.
+			{
+				'../../../src/lib/get-duplicate-indices.js': stubs.getDuplicateIndicesModule,
+				'../../../src/lib/prepare-as-params.js': stubs.prepareAsParamsModule,
+				'../../../src/models/index.js': stubs.models,
+				'../../../src/neo4j/cypher-queries/index.js': stubs.cypherQueriesModule,
+				'../../../src/neo4j/query.js': stubs.neo4jQueryModule
+			}
+		);
 
 	describe('constructor method', () => {
 

--- a/test-unit/src/models/CastMember.test.js
+++ b/test-unit/src/models/CastMember.test.js
@@ -28,10 +28,16 @@ describe('CastMember model', () => {
 	});
 
 	const createSubject = () =>
-		esmock('../../../src/models/CastMember.js', {
-			'../../../src/lib/get-duplicate-indices.js': stubs.getDuplicateIndicesModule,
-			'../../../src/models/index.js': stubs.models
-		});
+		esmock(
+			'../../../src/models/CastMember.js',
+			{},
+			// globalmocks: mock definitions imported everywhere.
+			// Required for when functions are invoked by ancestor class methods.
+			{
+				'../../../src/lib/get-duplicate-indices.js': stubs.getDuplicateIndicesModule,
+				'../../../src/models/index.js': stubs.models
+			}
+		);
 
 	describe('constructor method', () => {
 

--- a/test-unit/src/models/CharacterDepiction.test.js
+++ b/test-unit/src/models/CharacterDepiction.test.js
@@ -17,9 +17,15 @@ describe('CharacterDepiction model', () => {
 	});
 
 	const createSubject = () =>
-		esmock('../../../src/models/CharacterDepiction.js', {
-			'../../../src/lib/strings.js': stubs.stringsModule
-		});
+		esmock(
+			'../../../src/models/CharacterDepiction.js',
+			{},
+			// globalmocks: mock definitions imported everywhere.
+			// Required for when functions are invoked by ancestor class methods.
+			{
+				'../../../src/lib/strings.js': stubs.stringsModule
+			}
+		);
 
 	describe('constructor method', () => {
 
@@ -27,7 +33,7 @@ describe('CharacterDepiction model', () => {
 
 			const CharacterDepiction = await createSubject();
 			new CharacterDepiction();
-			expect(stubs.stringsModule.getTrimmedOrEmptyString.callCount).to.equal(2);
+			expect(stubs.stringsModule.getTrimmedOrEmptyString.callCount).to.equal(4);
 
 		});
 
@@ -37,7 +43,7 @@ describe('CharacterDepiction model', () => {
 
 				const CharacterDepiction = await createSubject();
 				const instance = new CharacterDepiction({ underlyingName: 'King Henry V' });
-				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.firstCall, 'King Henry V');
+				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.thirdCall, 'King Henry V');
 				expect(instance.underlyingName).to.equal('King Henry V');
 
 			});
@@ -50,7 +56,7 @@ describe('CharacterDepiction model', () => {
 
 				const CharacterDepiction = await createSubject();
 				const instance = new CharacterDepiction({ qualifier: 'older' });
-				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.secondCall, 'older');
+				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.getCall(3), 'older');
 				expect(instance.qualifier).to.equal('older');
 
 			});

--- a/test-unit/src/models/CharacterGroup.test.js
+++ b/test-unit/src/models/CharacterGroup.test.js
@@ -28,10 +28,16 @@ describe('CharacterGroup model', () => {
 	});
 
 	const createSubject = () =>
-		esmock('../../../src/models/CharacterGroup.js', {
-			'../../../src/lib/get-duplicate-indices.js': stubs.getDuplicateIndicesModule,
-			'../../../src/models/index.js': stubs.models
-		});
+		esmock(
+			'../../../src/models/CharacterGroup.js',
+			{},
+			// globalmocks: mock definitions imported everywhere.
+			// Required for when functions are invoked by ancestor class methods.
+			{
+				'../../../src/lib/get-duplicate-indices.js': stubs.getDuplicateIndicesModule,
+				'../../../src/models/index.js': stubs.models
+			}
+		);
 
 	describe('constructor method', () => {
 

--- a/test-unit/src/models/CompanyWithMembers.test.js
+++ b/test-unit/src/models/CompanyWithMembers.test.js
@@ -28,10 +28,16 @@ describe('CompanyWithMembers model', () => {
 	});
 
 	const createSubject = () =>
-		esmock('../../../src/models/CompanyWithMembers', {
-			'../../../src/lib/get-duplicate-entity-info': stubs.getDuplicateEntityInfoModule,
-			'../../../src/models/index.js': stubs.models
-		});
+		esmock(
+			'../../../src/models/CompanyWithMembers.js',
+			{},
+			// globalmocks: mock definitions imported everywhere.
+			// Required for when functions are invoked by ancestor class methods.
+			{
+				'../../../src/lib/get-duplicate-entity-info': stubs.getDuplicateEntityInfoModule,
+				'../../../src/models/index.js': stubs.models
+			}
+		);
 
 	describe('constructor method', () => {
 

--- a/test-unit/src/models/Festival.test.js
+++ b/test-unit/src/models/Festival.test.js
@@ -25,9 +25,15 @@ describe('Festival model', () => {
 	});
 
 	const createSubject = () =>
-		esmock('../../../src/models/Festival.js', {
-			'../../../src/models/index.js': stubs.models
-		});
+		esmock(
+			'../../../src/models/Festival.js',
+			{},
+			// globalmocks: mock definitions imported everywhere.
+			// Required for when functions are invoked by ancestor class methods.
+			{
+				'../../../src/models/index.js': stubs.models
+			}
+		);
 
 	describe('constructor method', () => {
 

--- a/test-unit/src/models/Material.test.js
+++ b/test-unit/src/models/Material.test.js
@@ -64,12 +64,18 @@ describe('Material model', () => {
 	});
 
 	const createSubject = () =>
-		esmock('../../../src/models/Material.js', {
-			'../../../src/lib/get-duplicate-indices.js': stubs.getDuplicateIndicesModule,
-			'../../../src/lib/is-valid-year.js': stubs.isValidYearModule,
-			'../../../src/lib/strings.js': stubs.stringsModule,
-			'../../../src/models/index.js': stubs.models
-		});
+		esmock(
+			'../../../src/models/Material.js',
+			{},
+			// globalmocks: mock definitions imported everywhere.
+			// Required for when functions are invoked by ancestor class methods.
+			{
+				'../../../src/lib/get-duplicate-indices.js': stubs.getDuplicateIndicesModule,
+				'../../../src/lib/is-valid-year.js': stubs.isValidYearModule,
+				'../../../src/lib/strings.js': stubs.stringsModule,
+				'../../../src/models/index.js': stubs.models
+			}
+		);
 
 	describe('constructor method', () => {
 
@@ -77,7 +83,7 @@ describe('Material model', () => {
 
 			const Material = await createSubject();
 			new Material();
-			expect(stubs.stringsModule.getTrimmedOrEmptyString.callCount).to.equal(3);
+			expect(stubs.stringsModule.getTrimmedOrEmptyString.callCount).to.equal(5);
 
 		});
 
@@ -87,7 +93,7 @@ describe('Material model', () => {
 
 				const Material = await createSubject();
 				const instance = new Material({ subtitle: 'Prince of Denmark' });
-				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.firstCall, 'Prince of Denmark');
+				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.thirdCall, 'Prince of Denmark');
 				expect(instance.subtitle).to.equal('Prince of Denmark');
 
 			});
@@ -100,7 +106,7 @@ describe('Material model', () => {
 
 				const Material = await createSubject();
 				const instance = new Material({ format: 'play' });
-				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.secondCall, 'play');
+				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.getCall(3), 'play');
 				expect(instance.format).to.equal('play');
 
 			});
@@ -115,7 +121,7 @@ describe('Material model', () => {
 
 					const Material = await createSubject();
 					const instance = new Material({ year: 'Nineteen Fifty-Nine' });
-					assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.thirdCall, 'Nineteen Fifty-Nine');
+					assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.getCall(4), 'Nineteen Fifty-Nine');
 					expect(instance.year).to.equal('Nineteen Fifty-Nine');
 
 				});

--- a/test-unit/src/models/Nomination.test.js
+++ b/test-unit/src/models/Nomination.test.js
@@ -57,12 +57,18 @@ describe('Nomination model', () => {
 	});
 
 	const createSubject = () =>
-		esmock('../../../src/models/Nomination.js', {
-			'../../../src/lib/get-duplicate-entity-info.js': stubs.getDuplicateEntityInfoModule,
-			'../../../src/lib/get-duplicate-indices.js': stubs.getDuplicateIndicesModule,
-			'../../../src/lib/strings.js': stubs.stringsModule,
-			'../../../src/models/index.js': stubs.models
-		});
+		esmock(
+			'../../../src/models/Nomination.js',
+			{},
+			// globalmocks: mock definitions imported everywhere.
+			// Required for when functions are invoked by ancestor class methods.
+			{
+				'../../../src/lib/get-duplicate-entity-info.js': stubs.getDuplicateEntityInfoModule,
+				'../../../src/lib/get-duplicate-indices.js': stubs.getDuplicateIndicesModule,
+				'../../../src/lib/strings.js': stubs.stringsModule,
+				'../../../src/models/index.js': stubs.models
+			}
+		);
 
 	describe('constructor method', () => {
 

--- a/test-unit/src/models/OriginalVersionMaterial.test.js
+++ b/test-unit/src/models/OriginalVersionMaterial.test.js
@@ -29,6 +29,9 @@ describe('OriginalVersionMaterial model', () => {
 	const createSubject = () =>
 		esmock(
 			'../../../src/models/OriginalVersionMaterial.js',
+			{},
+			// globalmocks: mock definitions imported everywhere.
+			// Required for when functions are invoked by ancestor class methods.
 			{
 				'../../../src/lib/prepare-as-params.js': stubs.prepareAsParamsModule,
 				'../../../src/neo4j/cypher-queries/index.js': stubs.cypherQueriesModule,

--- a/test-unit/src/models/ProducerCredit.test.js
+++ b/test-unit/src/models/ProducerCredit.test.js
@@ -36,10 +36,16 @@ describe('ProducerCredit model', () => {
 	});
 
 	const createSubject = () =>
-		esmock('../../../src/models/ProducerCredit.js', {
-			'../../../src/lib/get-duplicate-entity-info.js': stubs.getDuplicateEntityInfoModule,
-			'../../../src/models/index.js': stubs.models
-		});
+		esmock(
+			'../../../src/models/ProducerCredit.js',
+			{},
+			// globalmocks: mock definitions imported everywhere.
+			// Required for when functions are invoked by ancestor class methods.
+			{
+				'../../../src/lib/get-duplicate-entity-info.js': stubs.getDuplicateEntityInfoModule,
+				'../../../src/models/index.js': stubs.models
+			}
+		);
 
 	describe('constructor method', () => {
 

--- a/test-unit/src/models/Production.test.js
+++ b/test-unit/src/models/Production.test.js
@@ -111,12 +111,18 @@ describe('Production model', () => {
 	});
 
 	const createSubject = () =>
-		esmock('../../../src/models/Production.js', {
-			'../../../src/lib/get-duplicate-indices.js': stubs.getDuplicateIndicesModule,
-			'../../../src/lib/is-valid-date.js': stubs.isValidDateModule,
-			'../../../src/lib/strings.js': stubs.stringsModule,
-			'../../../src/models/index.js': stubs.models
-		});
+		esmock(
+			'../../../src/models/Production.js',
+			{},
+			// globalmocks: mock definitions imported everywhere.
+			// Required for when functions are invoked by ancestor class methods.
+			{
+				'../../../src/lib/get-duplicate-indices.js': stubs.getDuplicateIndicesModule,
+				'../../../src/lib/is-valid-date.js': stubs.isValidDateModule,
+				'../../../src/lib/strings.js': stubs.stringsModule,
+				'../../../src/models/index.js': stubs.models
+			}
+		);
 
 	describe('constructor method', () => {
 
@@ -124,7 +130,7 @@ describe('Production model', () => {
 
 			const Production = await createSubject();
 			new Production();
-			expect(stubs.stringsModule.getTrimmedOrEmptyString.callCount).to.equal(4);
+			expect(stubs.stringsModule.getTrimmedOrEmptyString.callCount).to.equal(5);
 
 		});
 
@@ -134,7 +140,7 @@ describe('Production model', () => {
 
 				const Production = await createSubject();
 				const instance = new Production({ subtitle: 'Prince of Denmark' });
-				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.firstCall, 'Prince of Denmark');
+				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.secondCall, 'Prince of Denmark');
 				expect(instance.subtitle).to.equal('Prince of Denmark');
 
 			});
@@ -147,7 +153,7 @@ describe('Production model', () => {
 
 				const Production = await createSubject();
 				const instance = new Production({ startDate: '2010-09-30' });
-				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.secondCall, '2010-09-30');
+				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.thirdCall, '2010-09-30');
 				expect(instance.startDate).to.equal('2010-09-30');
 
 			});
@@ -160,7 +166,7 @@ describe('Production model', () => {
 
 				const Production = await createSubject();
 				const instance = new Production({ pressDate: '2010-10-07' });
-				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.thirdCall, '2010-10-07');
+				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.getCall(3), '2010-10-07');
 				expect(instance.pressDate).to.equal('2010-10-07');
 
 			});
@@ -173,7 +179,7 @@ describe('Production model', () => {
 
 				const Production = await createSubject();
 				const instance = new Production({ endDate: '2011-01-26' });
-				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.getCall(3), '2011-01-26');
+				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.getCall(4), '2011-01-26');
 				expect(instance.endDate).to.equal('2011-01-26');
 
 			});

--- a/test-unit/src/models/ProductionIdentifier.test.js
+++ b/test-unit/src/models/ProductionIdentifier.test.js
@@ -19,6 +19,9 @@ describe('ProductionIdentifier model', () => {
 	const createSubject = () =>
 		esmock(
 			'../../../src/models/ProductionIdentifier.js',
+			{},
+			// globalmocks: mock definitions imported everywhere.
+			// Required for when functions are invoked by ancestor class methods.
 			{
 				'../../../src/lib/strings.js': stubs.stringsModule
 			}

--- a/test-unit/src/models/ProductionTeamCredit.test.js
+++ b/test-unit/src/models/ProductionTeamCredit.test.js
@@ -36,10 +36,16 @@ describe('ProductionTeamCredit model', () => {
 	});
 
 	const createSubject = () =>
-		esmock('../../../src/models/ProductionTeamCredit.js', {
-			'../../../src/lib/get-duplicate-entity-info.js': stubs.getDuplicateEntityInfoModule,
-			'../../../src/models/index.js': stubs.models
-		});
+		esmock(
+			'../../../src/models/ProductionTeamCredit.js',
+			{},
+			// globalmocks: mock definitions imported everywhere.
+			// Required for when functions are invoked by ancestor class methods.
+			{
+				'../../../src/lib/get-duplicate-entity-info.js': stubs.getDuplicateEntityInfoModule,
+				'../../../src/models/index.js': stubs.models
+			}
+		);
 
 	describe('constructor method', () => {
 

--- a/test-unit/src/models/Review.test.js
+++ b/test-unit/src/models/Review.test.js
@@ -38,11 +38,17 @@ describe('Review model', () => {
 	});
 
 	const createSubject = () =>
-		esmock('../../../src/models/Review.js', {
-			'../../../src/lib/is-valid-date.js': stubs.isValidDateModule,
-			'../../../src/lib/strings.js': stubs.stringsModule,
-			'../../../src/models/index.js': stubs.models
-		});
+		esmock(
+			'../../../src/models/Review.js',
+			{},
+			// globalmocks: mock definitions imported everywhere.
+			// Required for when functions are invoked by ancestor class methods.
+			{
+				'../../../src/lib/is-valid-date.js': stubs.isValidDateModule,
+				'../../../src/lib/strings.js': stubs.stringsModule,
+				'../../../src/models/index.js': stubs.models
+			}
+		);
 
 	describe('constructor method', () => {
 

--- a/test-unit/src/models/Role.test.js
+++ b/test-unit/src/models/Role.test.js
@@ -19,6 +19,9 @@ describe('Role model', () => {
 	const createSubject = () =>
 		esmock(
 			'../../../src/models/Role.js',
+			{},
+			// globalmocks: mock definitions imported everywhere.
+			// Required for when functions are invoked by ancestor class methods.
 			{
 				'../../../src/lib/strings.js': stubs.stringsModule
 			}
@@ -30,7 +33,7 @@ describe('Role model', () => {
 
 			const Role = await createSubject();
 			new Role();
-			expect(stubs.stringsModule.getTrimmedOrEmptyString.callCount).to.equal(3);
+			expect(stubs.stringsModule.getTrimmedOrEmptyString.callCount).to.equal(4);
 
 		});
 
@@ -40,7 +43,7 @@ describe('Role model', () => {
 
 				const Role = await createSubject();
 				const instance = new Role({ characterName: 'Hamlet' });
-				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.firstCall, 'Hamlet');
+				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.secondCall, 'Hamlet');
 				expect(instance.characterName).to.equal('Hamlet');
 
 			});
@@ -53,7 +56,7 @@ describe('Role model', () => {
 
 				const Role = await createSubject();
 				const instance = new Role({ characterDifferentiator: '1' });
-				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.secondCall, '1');
+				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.thirdCall, '1');
 				expect(instance.characterDifferentiator).to.equal('1');
 
 			});
@@ -66,7 +69,7 @@ describe('Role model', () => {
 
 				const Role = await createSubject();
 				const instance = new Role({ qualifier: 'younger' });
-				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.thirdCall, 'younger');
+				assert.calledWithExactly(stubs.stringsModule.getTrimmedOrEmptyString.getCall(3), 'younger');
 				expect(instance.qualifier).to.equal('younger');
 
 			});

--- a/test-unit/src/models/SourceMaterial.test.js
+++ b/test-unit/src/models/SourceMaterial.test.js
@@ -28,6 +28,9 @@ describe('SourceMaterial model', () => {
 	const createSubject = () =>
 		esmock(
 			'../../../src/models/SourceMaterial.js',
+			{},
+			// globalmocks: mock definitions imported everywhere.
+			// Required for when functions are invoked by ancestor class methods.
 			{
 				'../../../src/lib/prepare-as-params.js': stubs.prepareAsParamsModule,
 				'../../../src/neo4j/cypher-queries/index.js': stubs.cypherQueriesModule,

--- a/test-unit/src/models/SubMaterial.test.js
+++ b/test-unit/src/models/SubMaterial.test.js
@@ -28,6 +28,9 @@ describe('SubMaterial model', () => {
 	const createSubject = () =>
 		esmock(
 			'../../../src/models/SubMaterial.js',
+			{},
+			// globalmocks: mock definitions imported everywhere.
+			// Required for when functions are invoked by ancestor class methods.
 			{
 				'../../../src/lib/prepare-as-params.js': stubs.prepareAsParamsModule,
 				'../../../src/neo4j/cypher-queries/index.js': stubs.cypherQueriesModule,

--- a/test-unit/src/models/SubProductionIdentifier.test.js
+++ b/test-unit/src/models/SubProductionIdentifier.test.js
@@ -25,6 +25,9 @@ describe('SubProductionIdentifier model', () => {
 	const createSubject = () =>
 		esmock(
 			'../../../src/models/SubProductionIdentifier.js',
+			{},
+			// globalmocks: mock definitions imported everywhere.
+			// Required for when functions are invoked by ancestor class methods.
 			{
 				'../../../src/lib/prepare-as-params.js': stubs.prepareAsParamsModule,
 				'../../../src/neo4j/cypher-queries/index.js': stubs.cypherQueriesModule,

--- a/test-unit/src/models/SubVenue.test.js
+++ b/test-unit/src/models/SubVenue.test.js
@@ -28,6 +28,9 @@ describe('SubVenue model', () => {
 	const createSubject = () =>
 		esmock(
 			'../../../src/models/SubVenue.js',
+			{},
+			// globalmocks: mock definitions imported everywhere.
+			// Required for when functions are invoked by ancestor class methods.
 			{
 				'../../../src/lib/prepare-as-params.js': stubs.prepareAsParamsModule,
 				'../../../src/neo4j/cypher-queries/index.js': stubs.cypherQueriesModule,

--- a/test-unit/src/models/Venue.test.js
+++ b/test-unit/src/models/Venue.test.js
@@ -28,10 +28,16 @@ describe('Venue model', () => {
 	});
 
 	const createSubject = () =>
-		esmock('../../../src/models/Venue.js', {
-			'../../../src/lib/get-duplicate-indices.js': stubs.getDuplicateIndicesModule,
-			'../../../src/models/index.js': stubs.models
-		});
+		esmock(
+			'../../../src/models/Venue.js',
+			{},
+			// globalmocks: mock definitions imported everywhere.
+			// Required for when functions are invoked by ancestor class methods.
+			{
+				'../../../src/lib/get-duplicate-indices.js': stubs.getDuplicateIndicesModule,
+				'../../../src/models/index.js': stubs.models
+			}
+		);
 
 	describe('constructor method', () => {
 

--- a/test-unit/src/models/WritingCredit.test.js
+++ b/test-unit/src/models/WritingCredit.test.js
@@ -42,10 +42,16 @@ describe('WritingCredit model', () => {
 	});
 
 	const createSubject = () =>
-		esmock('../../../src/models/WritingCredit.js', {
-			'../../../src/lib/get-duplicate-indices.js': stubs.getDuplicateIndicesModule,
-			'../../../src/models/index.js': stubs.models
-		});
+		esmock(
+			'../../../src/models/WritingCredit.js',
+			{},
+			// globalmocks: mock definitions imported everywhere.
+			// Required for when functions are invoked by ancestor class methods.
+			{
+				'../../../src/lib/get-duplicate-indices.js': stubs.getDuplicateIndicesModule,
+				'../../../src/models/index.js': stubs.models
+			}
+		);
 
 	describe('constructor method', () => {
 


### PR DESCRIPTION
This PR updates the unit tests for models to use global mocks.

This is already applied for unit test of model classes that are extended by other classes to account for those descendants invoking methods that call the mocked functions.

This PR ensure the same pattern happens for when class instances invoke ancestor methods that call the mocked functions.

There are several cases where the mock is set up in this way and the ancestor does not call the mocked function, but the decision has been made to consistently apply global mocks to ensure cases are not missed in the future (e.g. if the ancestor did start calling the function and I forgot to mock the call in the test) and to remove the overhead of establishing whether an ancestor does or does not call a function whenever one is added for a descendant's tests.

Admittedly, in some cases it does require extra work when writing certain tests (e.g. call count of `stubs.stringsModule.getTrimmedOrEmptyString`) to ensure the call count is correct through having to check the number of times the subject instances and any of its ancestors call the function, but the mentioned benefits seem to outweigh this drawback.