### PR TITLE
Upgrade Chai packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "neo4j-driver": "5.21.0"
   },
   "devDependencies": {
-    "chai": "4.4.1",
-    "chai-http": "4.4.0",
+    "chai": "5.1.2",
+    "chai-http": "5.1.1",
     "eslint": "8.57.0",
     "eslint-plugin-mocha": "^10.4.3",
     "eslint-plugin-no-only-tests": "3.1.0",

--- a/test-e2e/crud/award-ceremonies-api.test.js
+++ b/test-e2e/crud/award-ceremonies-api.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { countNodesWithLabel, purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -13,7 +15,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 
 		it('responds with data required to prepare new award ceremony', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/award-ceremonies/new');
 
 			const expectedResponseBody = {
@@ -89,7 +91,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 
 			expect(await countNodesWithLabel('AwardCeremony')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.post('/award-ceremonies')
 				.send({
 					name: '2020'
@@ -154,7 +156,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 
 		it('gets data required to edit specific award ceremony', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/award-ceremonies/${AWARD_CEREMONY_UUID}/edit`);
 
 			const expectedResponseBody = {
@@ -217,7 +219,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 
 			expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/award-ceremonies/${AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2019'
@@ -282,7 +284,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 
 		it('shows award ceremony', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/award-ceremonies/${AWARD_CEREMONY_UUID}`);
 
 			const expectedResponseBody = {
@@ -302,7 +304,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 
 			expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.delete(`/award-ceremonies/${AWARD_CEREMONY_UUID}`);
 
 			const expectedResponseBody = {
@@ -407,7 +409,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 
 			expect(await countNodesWithLabel('AwardCeremony')).to.equal(0);
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/productions')
 				.send({
 					name: 'Hairspray',
@@ -418,7 +420,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 					}
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/productions')
 				.send({
 					name: 'Garply',
@@ -429,7 +431,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 					}
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/productions')
 				.send({
 					name: 'Garply',
@@ -440,7 +442,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 					}
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/productions')
 				.send({
 					name: 'Saint Joan',
@@ -451,7 +453,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 					}
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/productions')
 				.send({
 					name: 'Parade',
@@ -462,7 +464,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 					}
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/productions')
 				.send({
 					name: 'Grault',
@@ -473,7 +475,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 					}
 				});
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.post('/award-ceremonies')
 				.send({
 					name: '2008',
@@ -1574,7 +1576,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 
 		it('shows award ceremony (post-creation)', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/award-ceremonies/${AWARD_CEREMONY_UUID}`);
 
 			const expectedResponseBody = {
@@ -2063,7 +2065,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 
 		it('gets data required to edit specific award ceremony', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/award-ceremonies/${AWARD_CEREMONY_UUID}/edit`);
 
 			const expectedResponseBody = {
@@ -2923,7 +2925,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 
 			expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/award-ceremonies/${AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2008',
@@ -4026,7 +4028,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 
 			expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/productions')
 				.send({
 					name: 'The Chalk Garden',
@@ -4037,7 +4039,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 					}
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/productions')
 				.send({
 					name: 'Piaf',
@@ -4048,7 +4050,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 					}
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/productions')
 				.send({
 					name: 'Piaf',
@@ -4059,7 +4061,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 					}
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/productions')
 				.send({
 					name: 'Ivanov',
@@ -4070,7 +4072,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 					}
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/productions')
 				.send({
 					name: 'Waldo',
@@ -4081,7 +4083,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 					}
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/productions')
 				.send({
 					name: 'Waldo',
@@ -4092,7 +4094,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 					}
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/productions')
 				.send({
 					name: 'Fred',
@@ -4103,7 +4105,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 					}
 				});
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/award-ceremonies/${AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2009',
@@ -5220,7 +5222,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 
 		it('shows award ceremony (post-update)', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/award-ceremonies/${AWARD_CEREMONY_UUID}`);
 
 			const expectedResponseBody = {
@@ -5739,7 +5741,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 
 			expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/award-ceremonies/${AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2009'
@@ -5806,7 +5808,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 
 			expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.delete(`/award-ceremonies/${AWARD_CEREMONY_UUID}`);
 
 			const expectedResponseBody = {
@@ -5847,7 +5849,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 
 			await purgeDatabase();
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/award-ceremonies')
 				.send({
 					name: '2019',
@@ -5856,7 +5858,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 					}
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/award-ceremonies')
 				.send({
 					name: '2020',
@@ -5865,7 +5867,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 					}
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/award-ceremonies')
 				.send({
 					name: '2018',
@@ -5874,7 +5876,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 					}
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/award-ceremonies')
 				.send({
 					name: '2019',
@@ -5883,7 +5885,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 					}
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/award-ceremonies')
 				.send({
 					name: '2020',
@@ -5892,7 +5894,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 					}
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/award-ceremonies')
 				.send({
 					name: '2018',
@@ -5905,7 +5907,7 @@ describe('CRUD (Create, Read, Update, Delete): Award ceremonies API', () => {
 
 		it('lists all award ceremonies ordered by name then award name', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/award-ceremonies');
 
 			const expectedResponseBody = [

--- a/test-e2e/crud/awards-api.test.js
+++ b/test-e2e/crud/awards-api.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { countNodesWithLabel, purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -13,7 +15,7 @@ describe('CRUD (Create, Read, Update, Delete): Awards API', () => {
 
 		it('responds with data required to prepare new award', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/awards/new');
 
 			const expectedResponseBody = {
@@ -46,7 +48,7 @@ describe('CRUD (Create, Read, Update, Delete): Awards API', () => {
 
 			expect(await countNodesWithLabel('Award')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.post('/awards')
 				.send({
 					name: 'Laurence Olivier Awards'
@@ -68,7 +70,7 @@ describe('CRUD (Create, Read, Update, Delete): Awards API', () => {
 
 		it('gets data required to edit specific award', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/awards/${AWARD_UUID}/edit`);
 
 			const expectedResponseBody = {
@@ -88,7 +90,7 @@ describe('CRUD (Create, Read, Update, Delete): Awards API', () => {
 
 			expect(await countNodesWithLabel('Award')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/awards/${AWARD_UUID}`)
 				.send({
 					name: 'Evening Standard Theatre Awards'
@@ -110,7 +112,7 @@ describe('CRUD (Create, Read, Update, Delete): Awards API', () => {
 
 		it('shows award', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/awards/${AWARD_UUID}`);
 
 			const expectedResponseBody = {
@@ -130,7 +132,7 @@ describe('CRUD (Create, Read, Update, Delete): Awards API', () => {
 
 			expect(await countNodesWithLabel('Award')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.delete(`/awards/${AWARD_UUID}`);
 
 			const expectedResponseBody = {
@@ -160,19 +162,19 @@ describe('CRUD (Create, Read, Update, Delete): Awards API', () => {
 
 			await purgeDatabase();
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/awards')
 				.send({
 					name: 'Evening Standard Theatre Awards'
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/awards')
 				.send({
 					name: 'Laurence Olivier Awards'
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/awards')
 				.send({
 					name: 'Critics\' Circle Theatre Awards'
@@ -182,7 +184,7 @@ describe('CRUD (Create, Read, Update, Delete): Awards API', () => {
 
 		it('lists all awards ordered by name', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/awards');
 
 			const expectedResponseBody = [

--- a/test-e2e/crud/characters-api.test.js
+++ b/test-e2e/crud/characters-api.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { countNodesWithLabel, purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -13,7 +15,7 @@ describe('CRUD (Create, Read, Update, Delete): Characters API', () => {
 
 		it('responds with data required to prepare new character', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/characters/new');
 
 			const expectedResponseBody = {
@@ -46,7 +48,7 @@ describe('CRUD (Create, Read, Update, Delete): Characters API', () => {
 
 			expect(await countNodesWithLabel('Character')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.post('/characters')
 				.send({
 					name: 'Romeo'
@@ -68,7 +70,7 @@ describe('CRUD (Create, Read, Update, Delete): Characters API', () => {
 
 		it('gets data required to edit specific character', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/characters/${CHARACTER_UUID}/edit`);
 
 			const expectedResponseBody = {
@@ -88,7 +90,7 @@ describe('CRUD (Create, Read, Update, Delete): Characters API', () => {
 
 			expect(await countNodesWithLabel('Character')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/characters/${CHARACTER_UUID}`)
 				.send({
 					name: 'Juliet'
@@ -110,7 +112,7 @@ describe('CRUD (Create, Read, Update, Delete): Characters API', () => {
 
 		it('shows character', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/characters/${CHARACTER_UUID}`);
 
 			const expectedResponseBody = {
@@ -133,7 +135,7 @@ describe('CRUD (Create, Read, Update, Delete): Characters API', () => {
 
 			expect(await countNodesWithLabel('Character')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.delete(`/characters/${CHARACTER_UUID}`);
 
 			const expectedResponseBody = {
@@ -163,19 +165,19 @@ describe('CRUD (Create, Read, Update, Delete): Characters API', () => {
 
 			await purgeDatabase();
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/characters')
 				.send({
 					name: 'Romeo'
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/characters')
 				.send({
 					name: 'Juliet'
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/characters')
 				.send({
 					name: 'Nurse'
@@ -185,7 +187,7 @@ describe('CRUD (Create, Read, Update, Delete): Characters API', () => {
 
 		it('lists all characters ordered by name', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/characters');
 
 			const expectedResponseBody = [

--- a/test-e2e/crud/companies-api.test.js
+++ b/test-e2e/crud/companies-api.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { countNodesWithLabel, purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -13,7 +15,7 @@ describe('CRUD (Create, Read, Update, Delete): Companies API', () => {
 
 		it('responds with data required to prepare new company', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/companies/new');
 
 			const expectedResponseBody = {
@@ -46,7 +48,7 @@ describe('CRUD (Create, Read, Update, Delete): Companies API', () => {
 
 			expect(await countNodesWithLabel('Company')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.post('/companies')
 				.send({
 					name: 'National Theatre Company'
@@ -68,7 +70,7 @@ describe('CRUD (Create, Read, Update, Delete): Companies API', () => {
 
 		it('gets data required to edit specific company', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/companies/${COMPANY_UUID}/edit`);
 
 			const expectedResponseBody = {
@@ -88,7 +90,7 @@ describe('CRUD (Create, Read, Update, Delete): Companies API', () => {
 
 			expect(await countNodesWithLabel('Company')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/companies/${COMPANY_UUID}`)
 				.send({
 					name: 'Royal Shakespeare Company'
@@ -110,7 +112,7 @@ describe('CRUD (Create, Read, Update, Delete): Companies API', () => {
 
 		it('shows company', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/companies/${COMPANY_UUID}`);
 
 			const expectedResponseBody = {
@@ -145,7 +147,7 @@ describe('CRUD (Create, Read, Update, Delete): Companies API', () => {
 
 			expect(await countNodesWithLabel('Company')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.delete(`/companies/${COMPANY_UUID}`);
 
 			const expectedResponseBody = {
@@ -175,19 +177,19 @@ describe('CRUD (Create, Read, Update, Delete): Companies API', () => {
 
 			await purgeDatabase();
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/companies')
 				.send({
 					name: 'National Theatre Company'
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/companies')
 				.send({
 					name: 'Royal Shakespeare Company'
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/companies')
 				.send({
 					name: 'Almeida Theatre Company'
@@ -197,7 +199,7 @@ describe('CRUD (Create, Read, Update, Delete): Companies API', () => {
 
 		it('lists all companies ordered by name', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/companies');
 
 			const expectedResponseBody = [

--- a/test-e2e/crud/festival-serieses-api.test.js
+++ b/test-e2e/crud/festival-serieses-api.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { countNodesWithLabel, purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -13,7 +15,7 @@ describe('CRUD (Create, Read, Update, Delete): Festival Serieses API', () => {
 
 		it('responds with data required to prepare new festival series', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/festival-serieses/new');
 
 			const expectedResponseBody = {
@@ -46,7 +48,7 @@ describe('CRUD (Create, Read, Update, Delete): Festival Serieses API', () => {
 
 			expect(await countNodesWithLabel('FestivalSeries')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.post('/festival-serieses')
 				.send({
 					name: 'Edinburgh International Festival'
@@ -68,7 +70,7 @@ describe('CRUD (Create, Read, Update, Delete): Festival Serieses API', () => {
 
 		it('gets data required to edit specific festival series', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/festival-serieses/${FESTIVAL_SERIES_UUID}/edit`);
 
 			const expectedResponseBody = {
@@ -88,7 +90,7 @@ describe('CRUD (Create, Read, Update, Delete): Festival Serieses API', () => {
 
 			expect(await countNodesWithLabel('FestivalSeries')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/festival-serieses/${FESTIVAL_SERIES_UUID}`)
 				.send({
 					name: 'Connections'
@@ -110,7 +112,7 @@ describe('CRUD (Create, Read, Update, Delete): Festival Serieses API', () => {
 
 		it('shows festival series', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/festival-serieses/${FESTIVAL_SERIES_UUID}`);
 
 			const expectedResponseBody = {
@@ -130,7 +132,7 @@ describe('CRUD (Create, Read, Update, Delete): Festival Serieses API', () => {
 
 			expect(await countNodesWithLabel('FestivalSeries')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.delete(`/festival-serieses/${FESTIVAL_SERIES_UUID}`);
 
 			const expectedResponseBody = {
@@ -160,19 +162,19 @@ describe('CRUD (Create, Read, Update, Delete): Festival Serieses API', () => {
 
 			await purgeDatabase();
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/festival-serieses')
 				.send({
 					name: 'Edinburgh International Festival'
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/festival-serieses')
 				.send({
 					name: 'HighTide Festival'
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/festival-serieses')
 				.send({
 					name: 'Connections'
@@ -182,7 +184,7 @@ describe('CRUD (Create, Read, Update, Delete): Festival Serieses API', () => {
 
 		it('lists all festival serieses ordered by name', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/festival-serieses');
 
 			const expectedResponseBody = [

--- a/test-e2e/crud/festivals-api.test.js
+++ b/test-e2e/crud/festivals-api.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { countNodesWithLabel, purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -13,7 +15,7 @@ describe('CRUD (Create, Read, Update, Delete): Festivals API', () => {
 
 		it('responds with data required to prepare new festival', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/festivals/new');
 
 			const expectedResponseBody = {
@@ -52,7 +54,7 @@ describe('CRUD (Create, Read, Update, Delete): Festivals API', () => {
 
 			expect(await countNodesWithLabel('Festival')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.post('/festivals')
 				.send({
 					name: 'The Complete Works'
@@ -80,7 +82,7 @@ describe('CRUD (Create, Read, Update, Delete): Festivals API', () => {
 
 		it('gets data required to edit specific festival', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/festivals/${FESTIVAL_UUID}/edit`);
 
 			const expectedResponseBody = {
@@ -106,7 +108,7 @@ describe('CRUD (Create, Read, Update, Delete): Festivals API', () => {
 
 			expect(await countNodesWithLabel('Festival')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/festivals/${FESTIVAL_UUID}`)
 				.send({
 					name: 'Globe to Globe'
@@ -134,7 +136,7 @@ describe('CRUD (Create, Read, Update, Delete): Festivals API', () => {
 
 		it('shows festival', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/festivals/${FESTIVAL_UUID}`);
 
 			const expectedResponseBody = {
@@ -155,7 +157,7 @@ describe('CRUD (Create, Read, Update, Delete): Festivals API', () => {
 
 			expect(await countNodesWithLabel('Festival')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.delete(`/festivals/${FESTIVAL_UUID}`);
 
 			const expectedResponseBody = {
@@ -197,7 +199,7 @@ describe('CRUD (Create, Read, Update, Delete): Festivals API', () => {
 
 			expect(await countNodesWithLabel('Festival')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.post('/festivals')
 				.send({
 					name: '2008',
@@ -230,7 +232,7 @@ describe('CRUD (Create, Read, Update, Delete): Festivals API', () => {
 
 		it('shows festival (post-creation)', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/festivals/${FESTIVAL_UUID}`);
 
 			const expectedResponseBody = {
@@ -253,7 +255,7 @@ describe('CRUD (Create, Read, Update, Delete): Festivals API', () => {
 
 		it('gets data required to edit specific festival', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/festivals/${FESTIVAL_UUID}/edit`);
 
 			const expectedResponseBody = {
@@ -279,7 +281,7 @@ describe('CRUD (Create, Read, Update, Delete): Festivals API', () => {
 
 			expect(await countNodesWithLabel('Festival')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/festivals/${FESTIVAL_UUID}`)
 				.send({
 					name: '2008',
@@ -314,7 +316,7 @@ describe('CRUD (Create, Read, Update, Delete): Festivals API', () => {
 
 			expect(await countNodesWithLabel('Festival')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/festivals/${FESTIVAL_UUID}`)
 				.send({
 					name: '2009',
@@ -347,7 +349,7 @@ describe('CRUD (Create, Read, Update, Delete): Festivals API', () => {
 
 		it('shows festival (post-update)', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/festivals/${FESTIVAL_UUID}`);
 
 			const expectedResponseBody = {
@@ -372,7 +374,7 @@ describe('CRUD (Create, Read, Update, Delete): Festivals API', () => {
 
 			expect(await countNodesWithLabel('Festival')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/festivals/${FESTIVAL_UUID}`)
 				.send({
 					name: '2009',
@@ -403,7 +405,7 @@ describe('CRUD (Create, Read, Update, Delete): Festivals API', () => {
 
 			expect(await countNodesWithLabel('Festival')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.delete(`/festivals/${FESTIVAL_UUID}`);
 
 			const expectedResponseBody = {
@@ -439,19 +441,19 @@ describe('CRUD (Create, Read, Update, Delete): Festivals API', () => {
 
 			await purgeDatabase();
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/festivals')
 				.send({
 					name: 'Shakespeare 400 Arts Festival'
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/festivals')
 				.send({
 					name: 'The Complete Works'
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/festivals')
 				.send({
 					name: 'Globe to Globe'
@@ -461,7 +463,7 @@ describe('CRUD (Create, Read, Update, Delete): Festivals API', () => {
 
 		it('lists all festivals ordered by name in descending order (and then by festival series name)', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/festivals');
 
 			const expectedResponseBody = [

--- a/test-e2e/crud/materials-api.test.js
+++ b/test-e2e/crud/materials-api.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { countNodesWithLabel, purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -13,7 +15,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 
 		it('responds with data required to prepare new material', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/materials/new');
 
 			const expectedResponseBody = {
@@ -96,7 +98,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.post('/materials')
 				.send({
 					name: 'Uncle Vanya'
@@ -168,7 +170,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 
 		it('gets data required to edit specific material', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/materials/${MATERIAL_UUID}/edit`);
 
 			const expectedResponseBody = {
@@ -238,7 +240,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${MATERIAL_UUID}`)
 				.send({
 					name: 'The Cherry Orchard'
@@ -310,7 +312,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 
 		it('shows material', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/materials/${MATERIAL_UUID}`);
 
 			const expectedResponseBody = {
@@ -345,7 +347,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.delete(`/materials/${MATERIAL_UUID}`);
 
 			const expectedResponseBody = {
@@ -413,7 +415,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.post('/materials')
 				.send({
 					name: 'John Gabriel Borkman',
@@ -690,7 +692,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 
 		it('shows material (post-creation)', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/materials/${MATERIAL_UUID}`);
 
 			const expectedResponseBody = {
@@ -837,7 +839,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 
 		it('gets data required to edit specific material', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/materials/${MATERIAL_UUID}/edit`);
 
 			const expectedResponseBody = {
@@ -1030,7 +1032,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(6);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${MATERIAL_UUID}`)
 				.send({
 					name: 'John Gabriel Borkman',
@@ -1309,7 +1311,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(6);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${MATERIAL_UUID}`)
 				.send({
 					name: 'Three Sisters',
@@ -1588,7 +1590,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 
 		it('shows material (post-update)', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/materials/${MATERIAL_UUID}`);
 
 			const expectedResponseBody = {
@@ -1737,7 +1739,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(11);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${MATERIAL_UUID}`)
 				.send({
 					name: 'Three Sisters',
@@ -1812,7 +1814,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(11);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.delete(`/materials/${MATERIAL_UUID}`);
 
 			const expectedResponseBody = {
@@ -1856,7 +1858,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 
 			await purgeDatabase();
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/materials')
 				.send({
 					name: 'Haunting Julia',
@@ -1864,7 +1866,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 					year: 1994
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/materials')
 				.send({
 					name: 'A Word from Our Sponsor',
@@ -1872,7 +1874,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 					year: 1995
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/materials')
 				.send({
 					name: 'The Musical Jigsaw Play',
@@ -1880,7 +1882,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 					year: 1994
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/materials')
 				.send({
 					name: 'Dreams from a Summer House',
@@ -1888,7 +1890,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 					year: 1992
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/materials')
 				.send({
 					name: 'Communicating Doors',
@@ -1900,7 +1902,7 @@ describe('CRUD (Create, Read, Update, Delete): Materials API', () => {
 
 		it('lists all materials ordered by year then name', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/materials');
 
 			const expectedResponseBody = [

--- a/test-e2e/crud/people-api.test.js
+++ b/test-e2e/crud/people-api.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { countNodesWithLabel, purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -13,7 +15,7 @@ describe('CRUD (Create, Read, Update, Delete): People API', () => {
 
 		it('responds with data required to prepare new person', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/people/new');
 
 			const expectedResponseBody = {
@@ -46,7 +48,7 @@ describe('CRUD (Create, Read, Update, Delete): People API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.post('/people')
 				.send({
 					name: 'Ian McKellen'
@@ -68,7 +70,7 @@ describe('CRUD (Create, Read, Update, Delete): People API', () => {
 
 		it('gets data required to edit specific person', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/people/${PERSON_UUID}/edit`);
 
 			const expectedResponseBody = {
@@ -88,7 +90,7 @@ describe('CRUD (Create, Read, Update, Delete): People API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/people/${PERSON_UUID}`)
 				.send({
 					name: 'Patrick Stewart'
@@ -110,7 +112,7 @@ describe('CRUD (Create, Read, Update, Delete): People API', () => {
 
 		it('shows person', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/people/${PERSON_UUID}`);
 
 			const expectedResponseBody = {
@@ -146,7 +148,7 @@ describe('CRUD (Create, Read, Update, Delete): People API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.delete(`/people/${PERSON_UUID}`);
 
 			const expectedResponseBody = {
@@ -176,19 +178,19 @@ describe('CRUD (Create, Read, Update, Delete): People API', () => {
 
 			await purgeDatabase();
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/people')
 				.send({
 					name: 'Ian McKellen'
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/people')
 				.send({
 					name: 'Patrick Stewart'
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/people')
 				.send({
 					name: 'Matthew Kelly'
@@ -198,7 +200,7 @@ describe('CRUD (Create, Read, Update, Delete): People API', () => {
 
 		it('lists all people ordered by name', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/people');
 
 			const expectedResponseBody = [

--- a/test-e2e/crud/productions-api.test.js
+++ b/test-e2e/crud/productions-api.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { countNodesWithLabel, purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -13,7 +15,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 
 		it('responds with data required to prepare new production', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/productions/new');
 
 			const expectedResponseBody = {
@@ -164,7 +166,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 
 			expect(await countNodesWithLabel('Production')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.post('/productions')
 				.send({
 					name: 'As You Like It'
@@ -304,7 +306,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 
 		it('gets data required to edit specific production', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/productions/${PRODUCTION_UUID}/edit`);
 
 			const expectedResponseBody = {
@@ -442,7 +444,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 
 			expect(await countNodesWithLabel('Production')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${PRODUCTION_UUID}`)
 				.send({
 					name: 'The Tempest'
@@ -582,7 +584,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 
 		it('shows production', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/productions/${PRODUCTION_UUID}`);
 
 			const expectedResponseBody = {
@@ -616,7 +618,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 
 			expect(await countNodesWithLabel('Production')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.delete(`/productions/${PRODUCTION_UUID}`);
 
 			const expectedResponseBody = {
@@ -749,37 +751,37 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 
 			await purgeDatabase();
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/productions')
 				.send({
 					name: 'Hamlet sub-production #1'
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/productions')
 				.send({
 					name: 'Hamlet sub-production #2'
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/productions')
 				.send({
 					name: 'Hamlet sub-production #3'
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/productions')
 				.send({
 					name: 'Richard III sub-production #1'
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/productions')
 				.send({
 					name: 'Richard III sub-production #2'
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/productions')
 				.send({
 					name: 'Richard III sub-production #3'
@@ -791,7 +793,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 
 			expect(await countNodesWithLabel('Production')).to.equal(6);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.post('/productions')
 				.send({
 					name: 'Hamlet',
@@ -1877,7 +1879,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 
 		it('shows production (post-creation)', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/productions/${PRODUCTION_UUID}`);
 
 			const expectedResponseBody = {
@@ -2345,7 +2347,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 
 		it('gets data required to edit specific production', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/productions/${PRODUCTION_UUID}/edit`);
 
 			const expectedResponseBody = {
@@ -3094,7 +3096,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 
 			expect(await countNodesWithLabel('Production')).to.equal(7);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${PRODUCTION_UUID}`)
 				.send({
 					name: 'Hamlet',
@@ -4182,7 +4184,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 
 			expect(await countNodesWithLabel('Production')).to.equal(7);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${PRODUCTION_UUID}`)
 				.send({
 					name: 'Richard III',
@@ -5267,7 +5269,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 
 		it('shows production (post-update)', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/productions/${PRODUCTION_UUID}`);
 
 			const expectedResponseBody = {
@@ -5737,7 +5739,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 
 			expect(await countNodesWithLabel('Production')).to.equal(7);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${PRODUCTION_UUID}`)
 				.send({
 					name: 'Richard III'
@@ -5879,7 +5881,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 
 			expect(await countNodesWithLabel('Production')).to.equal(7);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.delete(`/productions/${PRODUCTION_UUID}`);
 
 			const expectedResponseBody = {
@@ -5948,7 +5950,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 
 			await purgeDatabase();
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/productions')
 				.send({
 					name: 'Macbeth',
@@ -5960,7 +5962,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 					}
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/productions')
 				.send({
 					name: 'Hamlet',
@@ -5972,7 +5974,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 					}
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/productions')
 				.send({
 					name: 'Macbeth',
@@ -5984,7 +5986,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 					}
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/productions')
 				.send({
 					name: 'Hamlet',
@@ -5996,7 +5998,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 					}
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/productions')
 				.send({
 					name: 'Hamlet',
@@ -6012,7 +6014,7 @@ describe('CRUD (Create, Read, Update, Delete): Productions API', () => {
 
 		it('lists all productions ordered by start date then name then venue name', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/productions');
 
 			const expectedResponseBody = [

--- a/test-e2e/crud/seasons-api.test.js
+++ b/test-e2e/crud/seasons-api.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { countNodesWithLabel, purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -13,7 +15,7 @@ describe('CRUD (Create, Read, Update, Delete): Seasons API', () => {
 
 		it('responds with data required to prepare new season', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/seasons/new');
 
 			const expectedResponseBody = {
@@ -46,7 +48,7 @@ describe('CRUD (Create, Read, Update, Delete): Seasons API', () => {
 
 			expect(await countNodesWithLabel('Season')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.post('/seasons')
 				.send({
 					name: 'Not Black and White'
@@ -68,7 +70,7 @@ describe('CRUD (Create, Read, Update, Delete): Seasons API', () => {
 
 		it('gets data required to edit specific season', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/seasons/${SEASON_UUID}/edit`);
 
 			const expectedResponseBody = {
@@ -88,7 +90,7 @@ describe('CRUD (Create, Read, Update, Delete): Seasons API', () => {
 
 			expect(await countNodesWithLabel('Season')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/seasons/${SEASON_UUID}`)
 				.send({
 					name: 'The David Hare Season'
@@ -110,7 +112,7 @@ describe('CRUD (Create, Read, Update, Delete): Seasons API', () => {
 
 		it('shows season', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/seasons/${SEASON_UUID}`);
 
 			const expectedResponseBody = {
@@ -130,7 +132,7 @@ describe('CRUD (Create, Read, Update, Delete): Seasons API', () => {
 
 			expect(await countNodesWithLabel('Season')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.delete(`/seasons/${SEASON_UUID}`);
 
 			const expectedResponseBody = {
@@ -160,19 +162,19 @@ describe('CRUD (Create, Read, Update, Delete): Seasons API', () => {
 
 			await purgeDatabase();
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/seasons')
 				.send({
 					name: 'The David Hare Season'
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/seasons')
 				.send({
 					name: 'Not Black and White'
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/seasons')
 				.send({
 					name: 'Donmar in the West End'
@@ -182,7 +184,7 @@ describe('CRUD (Create, Read, Update, Delete): Seasons API', () => {
 
 		it('lists all seasons ordered by name', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/seasons');
 
 			const expectedResponseBody = [

--- a/test-e2e/crud/venues-api.test.js
+++ b/test-e2e/crud/venues-api.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { countNodesWithLabel, purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -13,7 +15,7 @@ describe('CRUD (Create, Read, Update, Delete): Venues API', () => {
 
 		it('responds with data required to prepare new venue', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/venues/new');
 
 			const expectedResponseBody = {
@@ -54,7 +56,7 @@ describe('CRUD (Create, Read, Update, Delete): Venues API', () => {
 
 			expect(await countNodesWithLabel('Venue')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.post('/venues')
 				.send({
 					name: 'National Theatre'
@@ -84,7 +86,7 @@ describe('CRUD (Create, Read, Update, Delete): Venues API', () => {
 
 		it('gets data required to edit specific venue', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/venues/${VENUE_UUID}/edit`);
 
 			const expectedResponseBody = {
@@ -112,7 +114,7 @@ describe('CRUD (Create, Read, Update, Delete): Venues API', () => {
 
 			expect(await countNodesWithLabel('Venue')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/venues/${VENUE_UUID}`)
 				.send({
 					name: 'Almeida Theatre'
@@ -142,7 +144,7 @@ describe('CRUD (Create, Read, Update, Delete): Venues API', () => {
 
 		it('shows venue', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/venues/${VENUE_UUID}`);
 
 			const expectedResponseBody = {
@@ -164,7 +166,7 @@ describe('CRUD (Create, Read, Update, Delete): Venues API', () => {
 
 			expect(await countNodesWithLabel('Venue')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.delete(`/venues/${VENUE_UUID}`);
 
 			const expectedResponseBody = {
@@ -204,7 +206,7 @@ describe('CRUD (Create, Read, Update, Delete): Venues API', () => {
 
 			expect(await countNodesWithLabel('Venue')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.post('/venues')
 				.send({
 					name: 'National Theatre',
@@ -267,7 +269,7 @@ describe('CRUD (Create, Read, Update, Delete): Venues API', () => {
 
 		it('shows venue (post-creation)', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/venues/${VENUE_UUID}`);
 
 			const expectedResponseBody = {
@@ -303,7 +305,7 @@ describe('CRUD (Create, Read, Update, Delete): Venues API', () => {
 
 		it('gets data required to edit specific venue', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/venues/${VENUE_UUID}/edit`);
 
 			const expectedResponseBody = {
@@ -349,7 +351,7 @@ describe('CRUD (Create, Read, Update, Delete): Venues API', () => {
 
 			expect(await countNodesWithLabel('Venue')).to.equal(4);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/venues/${VENUE_UUID}`)
 				.send({
 					name: 'National Theatre',
@@ -414,7 +416,7 @@ describe('CRUD (Create, Read, Update, Delete): Venues API', () => {
 
 			expect(await countNodesWithLabel('Venue')).to.equal(4);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/venues/${VENUE_UUID}`)
 				.send({
 					name: 'Royal Court Theatre',
@@ -467,7 +469,7 @@ describe('CRUD (Create, Read, Update, Delete): Venues API', () => {
 
 		it('shows venue (post-update)', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get(`/venues/${VENUE_UUID}`);
 
 			const expectedResponseBody = {
@@ -500,7 +502,7 @@ describe('CRUD (Create, Read, Update, Delete): Venues API', () => {
 
 			expect(await countNodesWithLabel('Venue')).to.equal(6);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/venues/${VENUE_UUID}`)
 				.send({
 					name: 'Royal Court Theatre',
@@ -533,7 +535,7 @@ describe('CRUD (Create, Read, Update, Delete): Venues API', () => {
 
 			expect(await countNodesWithLabel('Venue')).to.equal(6);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.delete(`/venues/${VENUE_UUID}`);
 
 			const expectedResponseBody = {
@@ -564,19 +566,19 @@ describe('CRUD (Create, Read, Update, Delete): Venues API', () => {
 
 			await purgeDatabase();
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/venues')
 				.send({
 					name: 'Donmar Warehouse'
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/venues')
 				.send({
 					name: 'National Theatre'
 				});
 
-			await chai.request(app)
+			await request.execute(app)
 				.post('/venues')
 				.send({
 					name: 'Almeida Theatre'
@@ -586,7 +588,7 @@ describe('CRUD (Create, Read, Update, Delete): Venues API', () => {
 
 		it('lists all venues ordered by name', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/venues');
 
 			const expectedResponseBody = [

--- a/test-e2e/database-validation-failures/award-ceremonies-api.test.js
+++ b/test-e2e/database-validation-failures/award-ceremonies-api.test.js
@@ -1,5 +1,5 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import {
@@ -9,6 +9,8 @@ import {
 	isNodeExistent,
 	purgeDatabase
 } from '../test-helpers/neo4j/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -28,7 +30,7 @@ describe('Database validation failures: Award ceremonies API', () => {
 
 				expect(await countNodesWithLabel('AwardCeremony')).to.equal(0);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/award-ceremonies')
 					.send({
 						name: '2020',
@@ -139,7 +141,7 @@ describe('Database validation failures: Award ceremonies API', () => {
 
 				expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/award-ceremonies/${TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID}`)
 					.send({
 						name: '2020',

--- a/test-e2e/database-validation-failures/materials-api.test.js
+++ b/test-e2e/database-validation-failures/materials-api.test.js
@@ -1,5 +1,5 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import {
@@ -9,6 +9,8 @@ import {
 	isNodeExistent,
 	purgeDatabase
 } from '../test-helpers/neo4j/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -51,7 +53,7 @@ describe('Database validation failures: Materials API', () => {
 
 				expect(await countNodesWithLabel('Material')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/materials')
 					.send({
 						name: 'Sur-Garply',
@@ -158,7 +160,7 @@ describe('Database validation failures: Materials API', () => {
 
 				expect(await countNodesWithLabel('Material')).to.equal(3);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/materials')
 					.send({
 						name: 'Sur-Sur-Grault',
@@ -254,7 +256,7 @@ describe('Database validation failures: Materials API', () => {
 
 				expect(await countNodesWithLabel('Material')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/materials/${SUB_GRAULT_MATERIAL_UUID}`)
 					.send({
 						name: 'Sub-Grault',
@@ -355,7 +357,7 @@ describe('Database validation failures: Materials API', () => {
 
 				expect(await countNodesWithLabel('Material')).to.equal(3);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/materials/${SUR_GARPLY_MATERIAL_UUID}`)
 					.send({
 						name: 'Sur-Garply',
@@ -471,7 +473,7 @@ describe('Database validation failures: Materials API', () => {
 
 				expect(await countNodesWithLabel('Material')).to.equal(4);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/materials/${SUR_SUR_GRAULT_MATERIAL_UUID}`)
 					.send({
 						name: 'Sur-Sur-Grault',
@@ -587,7 +589,7 @@ describe('Database validation failures: Materials API', () => {
 
 				expect(await countNodesWithLabel('Material')).to.equal(4);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/materials/${SUB_GRAULT_MATERIAL_UUID}`)
 					.send({
 						name: 'Sub-Grault',
@@ -681,7 +683,7 @@ describe('Database validation failures: Materials API', () => {
 
 				expect(await countNodesWithLabel('Material')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/materials/${UR_PLUGH_ORIGINAL_VERSION_MATERIAL_UUID}`)
 					.send({
 						name: 'Ur-Plugh',
@@ -766,7 +768,7 @@ describe('Database validation failures: Materials API', () => {
 
 				expect(await countNodesWithLabel('Material')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/materials/${WALDO_MATERIAL_UUID}`)
 					.send({
 						name: 'Waldo',

--- a/test-e2e/database-validation-failures/productions-api.test.js
+++ b/test-e2e/database-validation-failures/productions-api.test.js
@@ -1,5 +1,5 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import {
@@ -9,6 +9,8 @@ import {
 	isNodeExistent,
 	purgeDatabase
 } from '../test-helpers/neo4j/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -28,7 +30,7 @@ describe('Database validation failures: Productions API', () => {
 
 				expect(await countNodesWithLabel('Production')).to.equal(0);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/productions')
 					.send({
 						name: 'Sur-Grault',
@@ -133,7 +135,7 @@ describe('Database validation failures: Productions API', () => {
 
 				expect(await countNodesWithLabel('Production')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/productions')
 					.send({
 						name: 'Sur-Garply',
@@ -257,7 +259,7 @@ describe('Database validation failures: Productions API', () => {
 
 				expect(await countNodesWithLabel('Production')).to.equal(3);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/productions')
 					.send({
 						name: 'Sur-Sur-Grault',
@@ -355,7 +357,7 @@ describe('Database validation failures: Productions API', () => {
 
 				expect(await countNodesWithLabel('Production')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/productions/${SUR_GRAULT_PRODUCTION_UUID}`)
 					.send({
 						name: 'Sur-Grault',
@@ -466,7 +468,7 @@ describe('Database validation failures: Productions API', () => {
 
 				expect(await countNodesWithLabel('Production')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/productions/${SUB_GRAULT_PRODUCTION_UUID}`)
 					.send({
 						name: 'Sub-Grault',
@@ -584,7 +586,7 @@ describe('Database validation failures: Productions API', () => {
 
 				expect(await countNodesWithLabel('Production')).to.equal(3);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/productions/${SUR_GARPLY_PRODUCTION_UUID}`)
 					.send({
 						name: 'Sur-Garply',
@@ -717,7 +719,7 @@ describe('Database validation failures: Productions API', () => {
 
 				expect(await countNodesWithLabel('Production')).to.equal(4);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/productions/${SUR_SUR_GRAULT_PRODUCTION_UUID}`)
 					.send({
 						name: 'Sur-Sur-Grault',
@@ -850,7 +852,7 @@ describe('Database validation failures: Productions API', () => {
 
 				expect(await countNodesWithLabel('Production')).to.equal(4);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/productions/${SUB_GRAULT_PRODUCTION_UUID}`)
 					.send({
 						name: 'Sub-Grault',

--- a/test-e2e/database-validation-failures/venues-api.test.js
+++ b/test-e2e/database-validation-failures/venues-api.test.js
@@ -1,5 +1,5 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import {
@@ -9,6 +9,8 @@ import {
 	isNodeExistent,
 	purgeDatabase
 } from '../test-helpers/neo4j/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -51,7 +53,7 @@ describe('Database validation failures: Venues API', () => {
 
 				expect(await countNodesWithLabel('Venue')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/venues')
 					.send({
 						name: 'Sur-Bar Theatre',
@@ -132,7 +134,7 @@ describe('Database validation failures: Venues API', () => {
 
 				expect(await countNodesWithLabel('Venue')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/venues')
 					.send({
 						name: 'Sur-Sur-Foo Theatre',
@@ -224,7 +226,7 @@ describe('Database validation failures: Venues API', () => {
 
 				expect(await countNodesWithLabel('Venue')).to.equal(3);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/venues/${SUR_BAR_VENUE_UUID}`)
 					.send({
 						name: 'Sur-Bar Theatre',
@@ -314,7 +316,7 @@ describe('Database validation failures: Venues API', () => {
 
 				expect(await countNodesWithLabel('Venue')).to.equal(3);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/venues/${SUR_SUR_FOO_THEATRE_VENUE_UUID}`)
 					.send({
 						name: 'Sur-Sur-Foo Theatre',
@@ -404,7 +406,7 @@ describe('Database validation failures: Venues API', () => {
 
 				expect(await countNodesWithLabel('Venue')).to.equal(3);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/venues/${SUB_FOO_THEATRE_VENUE_UUID}`)
 					.send({
 						name: 'Sub-Foo Theatre',

--- a/test-e2e/instance-validation-failures/award-ceremonies-api.test.js
+++ b/test-e2e/instance-validation-failures/award-ceremonies-api.test.js
@@ -1,5 +1,5 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import {
@@ -12,6 +12,8 @@ import {
 
 const STRING_MAX_LENGTH = 1000;
 const ABOVE_MAX_LENGTH_STRING = 'a'.repeat(STRING_MAX_LENGTH + 1);
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -54,7 +56,7 @@ describe('Instance validation failures: Award ceremonies API', () => {
 
 				expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/award-ceremonies')
 					.send({
 						name: ''
@@ -92,7 +94,7 @@ describe('Instance validation failures: Award ceremonies API', () => {
 
 				expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/award-ceremonies')
 					.send({
 						name: '2020',
@@ -140,7 +142,7 @@ describe('Instance validation failures: Award ceremonies API', () => {
 
 				expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/award-ceremonies')
 					.send({
 						name: '2020',
@@ -244,7 +246,7 @@ describe('Instance validation failures: Award ceremonies API', () => {
 
 				expect(await countNodesWithLabel('AwardCeremony')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/award-ceremonies/${TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID}`)
 					.send({
 						name: ''
@@ -288,7 +290,7 @@ describe('Instance validation failures: Award ceremonies API', () => {
 
 				expect(await countNodesWithLabel('AwardCeremony')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/award-ceremonies/${TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID}`)
 					.send({
 						name: '2020',
@@ -342,7 +344,7 @@ describe('Instance validation failures: Award ceremonies API', () => {
 
 				expect(await countNodesWithLabel('AwardCeremony')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/award-ceremonies/${TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID}`)
 					.send({
 						name: '2020',
@@ -445,7 +447,7 @@ describe('Instance validation failures: Award ceremonies API', () => {
 
 				expect(await countNodesWithLabel('AwardCeremony')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.delete(`/award-ceremonies/${TWO_THOUSAND_AND_NINETEEN_AWARD_CEREMONY_UUID}`);
 
 				const expectedResponseBody = {

--- a/test-e2e/instance-validation-failures/awards-api.test.js
+++ b/test-e2e/instance-validation-failures/awards-api.test.js
@@ -1,5 +1,5 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import {
@@ -9,6 +9,8 @@ import {
 	isNodeExistent,
 	purgeDatabase
 } from '../test-helpers/neo4j/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -36,7 +38,7 @@ describe('Instance validation failures: Awards API', () => {
 
 				expect(await countNodesWithLabel('Award')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/awards')
 					.send({
 						name: ''
@@ -68,7 +70,7 @@ describe('Instance validation failures: Awards API', () => {
 
 				expect(await countNodesWithLabel('Award')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/awards')
 					.send({
 						name: 'Laurence Olivier Awards'
@@ -128,7 +130,7 @@ describe('Instance validation failures: Awards API', () => {
 
 				expect(await countNodesWithLabel('Award')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/awards/${EVENING_STANDARD_THEATRE_AWARDS_AWARD_UUID}`)
 					.send({
 						name: ''
@@ -166,7 +168,7 @@ describe('Instance validation failures: Awards API', () => {
 
 				expect(await countNodesWithLabel('Award')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/awards/${EVENING_STANDARD_THEATRE_AWARDS_AWARD_UUID}`)
 					.send({
 						name: 'Laurence Olivier Awards'
@@ -240,7 +242,7 @@ describe('Instance validation failures: Awards API', () => {
 
 				expect(await countNodesWithLabel('Award')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.delete(`/awards/${EVENING_STANDARD_THEATRE_AWARDS_AWARD_UUID}`);
 
 				const expectedResponseBody = {

--- a/test-e2e/instance-validation-failures/characters-api.test.js
+++ b/test-e2e/instance-validation-failures/characters-api.test.js
@@ -1,5 +1,5 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import {
@@ -9,6 +9,8 @@ import {
 	isNodeExistent,
 	purgeDatabase
 } from '../test-helpers/neo4j/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -36,7 +38,7 @@ describe('Instance validation failures: Characters API', () => {
 
 				expect(await countNodesWithLabel('Character')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/characters')
 					.send({
 						name: ''
@@ -68,7 +70,7 @@ describe('Instance validation failures: Characters API', () => {
 
 				expect(await countNodesWithLabel('Character')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/characters')
 					.send({
 						name: 'Orsino'
@@ -128,7 +130,7 @@ describe('Instance validation failures: Characters API', () => {
 
 				expect(await countNodesWithLabel('Character')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/characters/${VIOLA_CHARACTER_UUID}`)
 					.send({
 						name: ''
@@ -166,7 +168,7 @@ describe('Instance validation failures: Characters API', () => {
 
 				expect(await countNodesWithLabel('Character')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/characters/${VIOLA_CHARACTER_UUID}`)
 					.send({
 						name: 'Orsino'
@@ -240,7 +242,7 @@ describe('Instance validation failures: Characters API', () => {
 
 				expect(await countNodesWithLabel('Character')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.delete(`/characters/${VIOLA_CHARACTER_UUID}`);
 
 				const expectedResponseBody = {

--- a/test-e2e/instance-validation-failures/companies-api.test.js
+++ b/test-e2e/instance-validation-failures/companies-api.test.js
@@ -1,5 +1,5 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import {
@@ -9,6 +9,8 @@ import {
 	isNodeExistent,
 	purgeDatabase
 } from '../test-helpers/neo4j/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -36,7 +38,7 @@ describe('Instance validation failures: Companies API', () => {
 
 				expect(await countNodesWithLabel('Company')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/companies')
 					.send({
 						name: ''
@@ -68,7 +70,7 @@ describe('Instance validation failures: Companies API', () => {
 
 				expect(await countNodesWithLabel('Company')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/companies')
 					.send({
 						name: 'Donmar Warehouse Projects'
@@ -128,7 +130,7 @@ describe('Instance validation failures: Companies API', () => {
 
 				expect(await countNodesWithLabel('Company')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/companies/${SHAKESPEARE_GLOBE_TRUST_COMPANY_UUID}`)
 					.send({
 						name: ''
@@ -166,7 +168,7 @@ describe('Instance validation failures: Companies API', () => {
 
 				expect(await countNodesWithLabel('Company')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/companies/${SHAKESPEARE_GLOBE_TRUST_COMPANY_UUID}`)
 					.send({
 						name: 'Donmar Warehouse Projects'
@@ -240,7 +242,7 @@ describe('Instance validation failures: Companies API', () => {
 
 				expect(await countNodesWithLabel('Company')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.delete(`/companies/${SHAKESPEARE_GLOBE_TRUST_COMPANY_UUID}`);
 
 				const expectedResponseBody = {

--- a/test-e2e/instance-validation-failures/festival-serieses-api.test.js
+++ b/test-e2e/instance-validation-failures/festival-serieses-api.test.js
@@ -1,5 +1,5 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import {
@@ -9,6 +9,8 @@ import {
 	isNodeExistent,
 	purgeDatabase
 } from '../test-helpers/neo4j/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -36,7 +38,7 @@ describe('Instance validation failures: Festival Serieses API', () => {
 
 				expect(await countNodesWithLabel('FestivalSeries')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/festival-serieses')
 					.send({
 						name: ''
@@ -68,7 +70,7 @@ describe('Instance validation failures: Festival Serieses API', () => {
 
 				expect(await countNodesWithLabel('FestivalSeries')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/festival-serieses')
 					.send({
 						name: 'Edinburgh International Festival'
@@ -128,7 +130,7 @@ describe('Instance validation failures: Festival Serieses API', () => {
 
 				expect(await countNodesWithLabel('FestivalSeries')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/festival-serieses/${CONNECTIONS_FESTIVAL_SERIES_UUID}`)
 					.send({
 						name: ''
@@ -166,7 +168,7 @@ describe('Instance validation failures: Festival Serieses API', () => {
 
 				expect(await countNodesWithLabel('FestivalSeries')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/festival-serieses/${CONNECTIONS_FESTIVAL_SERIES_UUID}`)
 					.send({
 						name: 'Edinburgh International Festival'
@@ -240,7 +242,7 @@ describe('Instance validation failures: Festival Serieses API', () => {
 
 				expect(await countNodesWithLabel('FestivalSeries')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.delete(`/festival-serieses/${EDINBURGH_INTERNATIONAL_FESTIVAL_FESTIVAL_SERIES_UUID}`);
 
 				const expectedResponseBody = {

--- a/test-e2e/instance-validation-failures/festivals-api.test.js
+++ b/test-e2e/instance-validation-failures/festivals-api.test.js
@@ -1,5 +1,5 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import {
@@ -9,6 +9,8 @@ import {
 	isNodeExistent,
 	purgeDatabase
 } from '../test-helpers/neo4j/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -36,7 +38,7 @@ describe('Instance validation failures: Festivals API', () => {
 
 				expect(await countNodesWithLabel('Festival')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/festivals')
 					.send({
 						name: ''
@@ -74,7 +76,7 @@ describe('Instance validation failures: Festivals API', () => {
 
 				expect(await countNodesWithLabel('Festival')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/festivals')
 					.send({
 						name: 'The Complete Works'
@@ -140,7 +142,7 @@ describe('Instance validation failures: Festivals API', () => {
 
 				expect(await countNodesWithLabel('Festival')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/festivals/${GLOBE_TO_GLOBE_FESTIVAL_UUID}`)
 					.send({
 						name: ''
@@ -184,7 +186,7 @@ describe('Instance validation failures: Festivals API', () => {
 
 				expect(await countNodesWithLabel('Festival')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/festivals/${GLOBE_TO_GLOBE_FESTIVAL_UUID}`)
 					.send({
 						name: 'The Complete Works'
@@ -264,7 +266,7 @@ describe('Instance validation failures: Festivals API', () => {
 
 				expect(await countNodesWithLabel('Festival')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.delete(`/festivals/${GLOBE_TO_GLOBE_FESTIVAL_UUID}`);
 
 				const expectedResponseBody = {

--- a/test-e2e/instance-validation-failures/materials-api.test.js
+++ b/test-e2e/instance-validation-failures/materials-api.test.js
@@ -1,5 +1,5 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import {
@@ -12,6 +12,8 @@ import {
 
 const STRING_MAX_LENGTH = 1000;
 const ABOVE_MAX_LENGTH_STRING = 'a'.repeat(STRING_MAX_LENGTH + 1);
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -39,7 +41,7 @@ describe('Instance validation failures: Materials API', () => {
 
 				expect(await countNodesWithLabel('Material')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/materials')
 					.send({
 						name: ''
@@ -83,7 +85,7 @@ describe('Instance validation failures: Materials API', () => {
 
 				expect(await countNodesWithLabel('Material')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/materials')
 					.send({
 						name: 'The Wild Duck'
@@ -130,7 +132,7 @@ describe('Instance validation failures: Materials API', () => {
 
 				expect(await countNodesWithLabel('Material')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/materials')
 					.send({
 						name: 'The Wild Duck',
@@ -218,7 +220,7 @@ describe('Instance validation failures: Materials API', () => {
 
 				expect(await countNodesWithLabel('Material')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/materials/${GHOSTS_MATERIAL_UUID}`)
 					.send({
 						name: ''
@@ -268,7 +270,7 @@ describe('Instance validation failures: Materials API', () => {
 
 				expect(await countNodesWithLabel('Material')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/materials/${GHOSTS_MATERIAL_UUID}`)
 					.send({
 						name: 'The Wild Duck'
@@ -321,7 +323,7 @@ describe('Instance validation failures: Materials API', () => {
 
 				expect(await countNodesWithLabel('Material')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/materials/${GHOSTS_MATERIAL_UUID}`)
 					.send({
 						name: 'The Wild Duck',
@@ -423,7 +425,7 @@ describe('Instance validation failures: Materials API', () => {
 
 				expect(await countNodesWithLabel('Material')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.delete(`/materials/${GHOSTS_MATERIAL_UUID}`);
 
 				const expectedResponseBody = {

--- a/test-e2e/instance-validation-failures/people-api.test.js
+++ b/test-e2e/instance-validation-failures/people-api.test.js
@@ -1,5 +1,5 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import {
@@ -9,6 +9,8 @@ import {
 	isNodeExistent,
 	purgeDatabase
 } from '../test-helpers/neo4j/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -36,7 +38,7 @@ describe('Instance validation failures: People API', () => {
 
 				expect(await countNodesWithLabel('Person')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/people')
 					.send({
 						name: ''
@@ -68,7 +70,7 @@ describe('Instance validation failures: People API', () => {
 
 				expect(await countNodesWithLabel('Person')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/people')
 					.send({
 						name: 'Maggie Smith'
@@ -128,7 +130,7 @@ describe('Instance validation failures: People API', () => {
 
 				expect(await countNodesWithLabel('Person')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/people/${JUDI_DENCH_PERSON_UUID}`)
 					.send({
 						name: ''
@@ -166,7 +168,7 @@ describe('Instance validation failures: People API', () => {
 
 				expect(await countNodesWithLabel('Person')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/people/${JUDI_DENCH_PERSON_UUID}`)
 					.send({
 						name: 'Maggie Smith'
@@ -240,7 +242,7 @@ describe('Instance validation failures: People API', () => {
 
 				expect(await countNodesWithLabel('Person')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.delete(`/people/${JUDI_DENCH_PERSON_UUID}`);
 
 				const expectedResponseBody = {

--- a/test-e2e/instance-validation-failures/productions-api.test.js
+++ b/test-e2e/instance-validation-failures/productions-api.test.js
@@ -1,5 +1,5 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import {
@@ -12,6 +12,8 @@ import {
 
 const STRING_MAX_LENGTH = 1000;
 const ABOVE_MAX_LENGTH_STRING = 'a'.repeat(STRING_MAX_LENGTH + 1);
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -31,7 +33,7 @@ describe('Instance validation failures: Productions API', () => {
 
 				expect(await countNodesWithLabel('Production')).to.equal(0);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/productions')
 					.send({
 						name: ''
@@ -96,7 +98,7 @@ describe('Instance validation failures: Productions API', () => {
 
 				expect(await countNodesWithLabel('Production')).to.equal(0);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/productions')
 					.send({
 						name: 'Macbeth',
@@ -172,7 +174,7 @@ describe('Instance validation failures: Productions API', () => {
 
 				expect(await countNodesWithLabel('Production')).to.equal(0);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/productions')
 					.send({
 						name: 'Macbeth',
@@ -273,7 +275,7 @@ describe('Instance validation failures: Productions API', () => {
 
 				expect(await countNodesWithLabel('Production')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/productions/${MACBETH_PRODUCTION_UUID}`)
 					.send({
 						name: ''
@@ -344,7 +346,7 @@ describe('Instance validation failures: Productions API', () => {
 
 				expect(await countNodesWithLabel('Production')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/productions/${MACBETH_PRODUCTION_UUID}`)
 					.send({
 						name: 'Macbeth',
@@ -421,7 +423,7 @@ describe('Instance validation failures: Productions API', () => {
 
 				expect(await countNodesWithLabel('Production')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/productions/${MACBETH_PRODUCTION_UUID}`)
 					.send({
 						name: 'Macbeth',
@@ -553,7 +555,7 @@ describe('Instance validation failures: Productions API', () => {
 
 				expect(await countNodesWithLabel('Production')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.delete(`/productions/${OTHELLO_DONMAR_PRODUCTION_UUID}`);
 
 				const expectedResponseBody = {

--- a/test-e2e/instance-validation-failures/seasons-api.test.js
+++ b/test-e2e/instance-validation-failures/seasons-api.test.js
@@ -1,5 +1,5 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import {
@@ -9,6 +9,8 @@ import {
 	isNodeExistent,
 	purgeDatabase
 } from '../test-helpers/neo4j/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -36,7 +38,7 @@ describe('Instance validation failures: Seasons API', () => {
 
 				expect(await countNodesWithLabel('Season')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/seasons')
 					.send({
 						name: ''
@@ -68,7 +70,7 @@ describe('Instance validation failures: Seasons API', () => {
 
 				expect(await countNodesWithLabel('Season')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/seasons')
 					.send({
 						name: 'Not Black and White'
@@ -128,7 +130,7 @@ describe('Instance validation failures: Seasons API', () => {
 
 				expect(await countNodesWithLabel('Season')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/seasons/${THE_DAVID_HARE_SEASON_UUID}`)
 					.send({
 						name: ''
@@ -166,7 +168,7 @@ describe('Instance validation failures: Seasons API', () => {
 
 				expect(await countNodesWithLabel('Season')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/seasons/${THE_DAVID_HARE_SEASON_UUID}`)
 					.send({
 						name: 'Not Black and White'
@@ -240,7 +242,7 @@ describe('Instance validation failures: Seasons API', () => {
 
 				expect(await countNodesWithLabel('Season')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.delete(`/seasons/${THE_DAVID_HARE_SEASON_UUID}`);
 
 				const expectedResponseBody = {

--- a/test-e2e/instance-validation-failures/venues-api.test.js
+++ b/test-e2e/instance-validation-failures/venues-api.test.js
@@ -1,5 +1,5 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import {
@@ -12,6 +12,8 @@ import {
 
 const STRING_MAX_LENGTH = 1000;
 const ABOVE_MAX_LENGTH_STRING = 'a'.repeat(STRING_MAX_LENGTH + 1);
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -39,7 +41,7 @@ describe('Instance validation failures: Venues API', () => {
 
 				expect(await countNodesWithLabel('Venue')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/venues')
 					.send({
 						name: ''
@@ -72,7 +74,7 @@ describe('Instance validation failures: Venues API', () => {
 
 				expect(await countNodesWithLabel('Venue')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/venues')
 					.send({
 						name: 'Donmar Warehouse'
@@ -108,7 +110,7 @@ describe('Instance validation failures: Venues API', () => {
 
 				expect(await countNodesWithLabel('Venue')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.post('/venues')
 					.send({
 						name: 'Donmar Warehouse',
@@ -185,7 +187,7 @@ describe('Instance validation failures: Venues API', () => {
 
 				expect(await countNodesWithLabel('Venue')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/venues/${ALMEIDA_THEATRE_VENUE_UUID}`)
 					.send({
 						name: ''
@@ -224,7 +226,7 @@ describe('Instance validation failures: Venues API', () => {
 
 				expect(await countNodesWithLabel('Venue')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/venues/${ALMEIDA_THEATRE_VENUE_UUID}`)
 					.send({
 						name: 'Donmar Warehouse'
@@ -266,7 +268,7 @@ describe('Instance validation failures: Venues API', () => {
 
 				expect(await countNodesWithLabel('Venue')).to.equal(2);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/venues/${ALMEIDA_THEATRE_VENUE_UUID}`)
 					.send({
 						name: 'Donmar Warehouse',
@@ -357,7 +359,7 @@ describe('Instance validation failures: Venues API', () => {
 
 				expect(await countNodesWithLabel('Venue')).to.equal(1);
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.delete(`/venues/${ALMEIDA_THEATRE_VENUE_UUID}`);
 
 				const expectedResponseBody = {

--- a/test-e2e/model-interaction/award-ceremonies-with-crediting-mat-collections-via-assocs.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-crediting-mat-collections-via-assocs.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { createRelationship, deleteRelationship, purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -73,7 +75,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Plugh: Part I',
@@ -95,7 +97,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Plugh: Part II',
@@ -104,7 +106,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 				year: '1899'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Mid-Plugh: Section I',
@@ -136,7 +138,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Mid-Plugh: Section II',
@@ -145,7 +147,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 				year: '1899'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Plugh',
@@ -177,7 +179,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Plugh: Part I',
@@ -211,7 +213,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Plugh: Part II',
@@ -220,7 +222,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 				year: '2009'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Mid-Plugh: Section I',
@@ -264,7 +266,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Mid-Plugh: Section II',
@@ -273,7 +275,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 				year: '2009'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Plugh',
@@ -317,7 +319,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Waldo: Part I',
@@ -338,7 +340,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Waldo: Part II',
@@ -346,7 +348,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 				year: '1974'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Mid-Waldo: Section I',
@@ -375,7 +377,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Mid-Waldo: Section II',
@@ -383,7 +385,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 				year: '1974'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Waldo',
@@ -412,7 +414,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Wibble: Part I',
@@ -433,7 +435,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Wibble: Part II',
@@ -441,7 +443,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 				year: '2009'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Mid-Wibble: Section I',
@@ -470,7 +472,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Mid-Wibble: Section II',
@@ -478,7 +480,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 				year: '2009'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Wibble',
@@ -507,7 +509,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2010',
@@ -539,7 +541,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2009',
@@ -571,7 +573,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2008',
@@ -603,7 +605,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2009',
@@ -635,7 +637,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2009',
@@ -699,7 +701,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of its subsequent versions (and their sur-material and sur-sur-material)', async () => {
 
-				subPlughPartIOriginalVersionMaterial = await chai.request(app)
+				subPlughPartIOriginalVersionMaterial = await request.execute(app)
 					.get(`/materials/${SUB_PLUGH_PART_I_ORIGINAL_VERSION_MATERIAL_UUID}`);
 
 				const expectedSubsequentVersionMaterialAwards = [
@@ -845,7 +847,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of its sub-material\'s subsequent versions (and their sur-material and sur-sur-material)', async () => {
 
-				midPlughSectionIOriginalVersionMaterial = await chai.request(app)
+				midPlughSectionIOriginalVersionMaterial = await request.execute(app)
 					.get(`/materials/${MID_PLUGH_SECTION_I_ORIGINAL_VERSION_MATERIAL_UUID}`);
 
 				const expectedSubsequentVersionMaterialAwards = [
@@ -991,7 +993,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of its sub-sub-material\'s subsequent versions (and their sur-material and sur-sur-material)', async () => {
 
-				surPlughOriginalVersionMaterial = await chai.request(app)
+				surPlughOriginalVersionMaterial = await request.execute(app)
 					.get(`/materials/${SUR_PLUGH_ORIGINAL_VERSION_MATERIAL_UUID}`);
 
 				const expectedSubsequentVersionMaterialAwards = [
@@ -1137,7 +1139,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s subsequent versions (and their sur-material and sur-sur-material)', async () => {
 
-				francisFlobJrPerson = await chai.request(app)
+				francisFlobJrPerson = await request.execute(app)
 					.get(`/people/${FRANCIS_FLOB_JR_PERSON_UUID}`);
 
 				const expectedSubsequentVersionMaterialAwards = [
@@ -1283,7 +1285,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s sub-material\'s subsequent versions (and their sur-material and sur-sur-material)', async () => {
 
-				francisFlobPerson = await chai.request(app)
+				francisFlobPerson = await request.execute(app)
 					.get(`/people/${FRANCIS_FLOB_PERSON_UUID}`);
 
 				const expectedSubsequentVersionMaterialAwards = [
@@ -1429,7 +1431,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s sub-sub-material\'s subsequent versions (and their sur-material and sur-sur-material)', async () => {
 
-				francisFlobSrPerson = await chai.request(app)
+				francisFlobSrPerson = await request.execute(app)
 					.get(`/people/${FRANCIS_FLOB_SR_PERSON_UUID}`);
 
 				const expectedSubsequentVersionMaterialAwards = [
@@ -1575,7 +1577,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s subsequent versions (and their sur-material and sur-sur-material)', async () => {
 
-				subCurtainUpLtdCompany = await chai.request(app)
+				subCurtainUpLtdCompany = await request.execute(app)
 					.get(`/companies/${SUB_CURTAIN_UP_LTD_COMPANY_UUID}`);
 
 				const expectedSubsequentVersionMaterialAwards = [
@@ -1721,7 +1723,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s sub-material\'s subsequent versions (and their sur-material and sur-sur-material)', async () => {
 
-				midCurtainUpLtdCompany = await chai.request(app)
+				midCurtainUpLtdCompany = await request.execute(app)
 					.get(`/companies/${MID_CURTAIN_UP_LTD_COMPANY_UUID}`);
 
 				const expectedSubsequentVersionMaterialAwards = [
@@ -1867,7 +1869,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s sub-sub-material\'s subsequent versions (and their sur-material and sur-sur-material)', async () => {
 
-				surCurtainUpLtdCompany = await chai.request(app)
+				surCurtainUpLtdCompany = await request.execute(app)
 					.get(`/companies/${SUR_CURTAIN_UP_LTD_COMPANY_UUID}`);
 
 				const expectedSubsequentVersionMaterialAwards = [
@@ -2041,7 +2043,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of its sur-material\'s subsequent versions (and their sur-material, but not their sub-materials)', async () => {
 
-				subPlughPartIOriginalVersionMaterial = await chai.request(app)
+				subPlughPartIOriginalVersionMaterial = await request.execute(app)
 					.get(`/materials/${SUB_PLUGH_PART_I_ORIGINAL_VERSION_MATERIAL_UUID}`);
 
 				const expectedSubsequentVersionMaterialAwards = [
@@ -2140,7 +2142,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of its subsequent versions (and their sur-material and sub-materials)', async () => {
 
-				midPlughSectionIOriginalVersionMaterial = await chai.request(app)
+				midPlughSectionIOriginalVersionMaterial = await request.execute(app)
 					.get(`/materials/${MID_PLUGH_SECTION_I_ORIGINAL_VERSION_MATERIAL_UUID}`);
 
 				const expectedSubsequentVersionMaterialAwards = [
@@ -2333,7 +2335,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of its sub-material\'s subsequent versions (and their sur-material and sub-materials)', async () => {
 
-				surPlughOriginalVersionMaterial = await chai.request(app)
+				surPlughOriginalVersionMaterial = await request.execute(app)
 					.get(`/materials/${SUR_PLUGH_ORIGINAL_VERSION_MATERIAL_UUID}`);
 
 				const expectedSubsequentVersionMaterialAwards = [
@@ -2526,7 +2528,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s sur-material\'s subsequent versions (and their sur-material, but not their sub-materials)', async () => {
 
-				francisFlobJrPerson = await chai.request(app)
+				francisFlobJrPerson = await request.execute(app)
 					.get(`/people/${FRANCIS_FLOB_JR_PERSON_UUID}`);
 
 				const expectedSubsequentVersionMaterialAwards = [
@@ -2625,7 +2627,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s subsequent versions (and their sur-material and sub-materials)', async () => {
 
-				francisFlobPerson = await chai.request(app)
+				francisFlobPerson = await request.execute(app)
 					.get(`/people/${FRANCIS_FLOB_PERSON_UUID}`);
 
 				const expectedSubsequentVersionMaterialAwards = [
@@ -2818,7 +2820,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s sub-material\'s subsequent versions (and their sur-material and sub-materials)', async () => {
 
-				francisFlobSrPerson = await chai.request(app)
+				francisFlobSrPerson = await request.execute(app)
 					.get(`/people/${FRANCIS_FLOB_SR_PERSON_UUID}`);
 
 				const expectedSubsequentVersionMaterialAwards = [
@@ -3011,7 +3013,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s sur-material\'s subsequent versions (and their sur-material, but not their sub-materials)', async () => {
 
-				subCurtainUpLtdCompany = await chai.request(app)
+				subCurtainUpLtdCompany = await request.execute(app)
 					.get(`/companies/${SUB_CURTAIN_UP_LTD_COMPANY_UUID}`);
 
 				const expectedSubsequentVersionMaterialAwards = [
@@ -3110,7 +3112,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s subsequent versions (and their sur-material and sub-materials)', async () => {
 
-				midCurtainUpLtdCompany = await chai.request(app)
+				midCurtainUpLtdCompany = await request.execute(app)
 					.get(`/companies/${MID_CURTAIN_UP_LTD_COMPANY_UUID}`);
 
 				const expectedSubsequentVersionMaterialAwards = [
@@ -3303,7 +3305,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s sub-material\'s subsequent versions (and their sur-material and sub-materials)', async () => {
 
-				surCurtainUpLtdCompany = await chai.request(app)
+				surCurtainUpLtdCompany = await request.execute(app)
 					.get(`/companies/${SUR_CURTAIN_UP_LTD_COMPANY_UUID}`);
 
 				const expectedSubsequentVersionMaterialAwards = [
@@ -3524,7 +3526,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of its sur-sur-material\'s subsequent versions (but not their sub-materials and sub-sub-materials)', async () => {
 
-				subPlughPartIOriginalVersionMaterial = await chai.request(app)
+				subPlughPartIOriginalVersionMaterial = await request.execute(app)
 					.get(`/materials/${SUB_PLUGH_PART_I_ORIGINAL_VERSION_MATERIAL_UUID}`);
 
 				const expectedSubsequentVersionMaterialAwards = [
@@ -3580,7 +3582,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of its sur-material\'s subsequent versions (but not their sub-materials and sub-sub-materials)', async () => {
 
-				midPlughSectionIOriginalVersionMaterial = await chai.request(app)
+				midPlughSectionIOriginalVersionMaterial = await request.execute(app)
 					.get(`/materials/${MID_PLUGH_SECTION_I_ORIGINAL_VERSION_MATERIAL_UUID}`);
 
 				const expectedSubsequentVersionMaterialAwards = [
@@ -3636,7 +3638,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of its subsequent versions (and their sub-materials and sub-sub-materials)', async () => {
 
-				surPlughOriginalVersionMaterial = await chai.request(app)
+				surPlughOriginalVersionMaterial = await request.execute(app)
 					.get(`/materials/${SUR_PLUGH_ORIGINAL_VERSION_MATERIAL_UUID}`);
 
 				const expectedSubsequentVersionMaterialAwards = [
@@ -3872,7 +3874,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s sur-sur-material\'s subsequent versions (but not their sub-materials and sub-sub-materials)', async () => {
 
-				francisFlobJrPerson = await chai.request(app)
+				francisFlobJrPerson = await request.execute(app)
 					.get(`/people/${FRANCIS_FLOB_JR_PERSON_UUID}`);
 
 				const expectedSubsequentVersionMaterialAwards = [
@@ -3928,7 +3930,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s sur-material\'s subsequent versions (but not their sub-materials and sub-sub-materials)', async () => {
 
-				francisFlobPerson = await chai.request(app)
+				francisFlobPerson = await request.execute(app)
 					.get(`/people/${FRANCIS_FLOB_PERSON_UUID}`);
 
 				const expectedSubsequentVersionMaterialAwards = [
@@ -3984,7 +3986,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s subsequent versions (and their sub-materials and sub-sub-materials)', async () => {
 
-				francisFlobSrPerson = await chai.request(app)
+				francisFlobSrPerson = await request.execute(app)
 					.get(`/people/${FRANCIS_FLOB_SR_PERSON_UUID}`);
 
 				const expectedSubsequentVersionMaterialAwards = [
@@ -4220,7 +4222,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s sur-sur-material\'s subsequent versions (but not their sub-materials and sub-sub-materials)', async () => {
 
-				subCurtainUpLtdCompany = await chai.request(app)
+				subCurtainUpLtdCompany = await request.execute(app)
 					.get(`/companies/${SUB_CURTAIN_UP_LTD_COMPANY_UUID}`);
 
 				const expectedSubsequentVersionMaterialAwards = [
@@ -4276,7 +4278,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s sur-material\'s subsequent versions (but not their sub-materials and sub-sub-materials)', async () => {
 
-				midCurtainUpLtdCompany = await chai.request(app)
+				midCurtainUpLtdCompany = await request.execute(app)
 					.get(`/companies/${MID_CURTAIN_UP_LTD_COMPANY_UUID}`);
 
 				const expectedSubsequentVersionMaterialAwards = [
@@ -4332,7 +4334,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s subsequent versions (and their sub-materials and sub-sub-materials)', async () => {
 
-				surCurtainUpLtdCompany = await chai.request(app)
+				surCurtainUpLtdCompany = await request.execute(app)
 					.get(`/companies/${SUR_CURTAIN_UP_LTD_COMPANY_UUID}`);
 
 				const expectedSubsequentVersionMaterialAwards = [
@@ -4596,7 +4598,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of its sourcing materials (and their sur-material and sur-sur-material)', async () => {
 
-				subWaldoPartIMaterial = await chai.request(app)
+				subWaldoPartIMaterial = await request.execute(app)
 					.get(`/materials/${SUB_WALDO_PART_I_MATERIAL_UUID}`);
 
 				const expectedSourcingMaterialAwards = [
@@ -4742,7 +4744,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of its sub-material\'s sourcing materials (and their sur-material and sur-sur-material)', async () => {
 
-				midWaldoSectionIMaterial = await chai.request(app)
+				midWaldoSectionIMaterial = await request.execute(app)
 					.get(`/materials/${MID_WALDO_SECTION_I_MATERIAL_UUID}`);
 
 				const expectedSourcingMaterialAwards = [
@@ -4888,7 +4890,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of its sub-sub-material\'s sourcing materials (and their sur-material and sur-sur-material)', async () => {
 
-				surWaldoMaterial = await chai.request(app)
+				surWaldoMaterial = await request.execute(app)
 					.get(`/materials/${SUR_WALDO_MATERIAL_UUID}`);
 
 				const expectedSourcingMaterialAwards = [
@@ -5034,7 +5036,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s sourcing materials (and their sur-material and sur-sur-material)', async () => {
 
-				janeRoeJrPerson = await chai.request(app)
+				janeRoeJrPerson = await request.execute(app)
 					.get(`/people/${JANE_ROE_JR_PERSON_UUID}`);
 
 				const expectedSourcingMaterialAwards = [
@@ -5180,7 +5182,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s sub-material\'s sourcing materials (and their sur-material and sur-sur-material)', async () => {
 
-				janeRoePerson = await chai.request(app)
+				janeRoePerson = await request.execute(app)
 					.get(`/people/${JANE_ROE_PERSON_UUID}`);
 
 				const expectedSourcingMaterialAwards = [
@@ -5326,7 +5328,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s sub-sub-material\'s sourcing materials (and their sur-material and sur-sur-material)', async () => {
 
-				janeRoeSrPerson = await chai.request(app)
+				janeRoeSrPerson = await request.execute(app)
 					.get(`/people/${JANE_ROE_SR_PERSON_UUID}`);
 
 				const expectedSourcingMaterialAwards = [
@@ -5472,7 +5474,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s sourcing materials (and their sur-material and sur-sur-material)', async () => {
 
-				subFictioneersLtdCompany = await chai.request(app)
+				subFictioneersLtdCompany = await request.execute(app)
 					.get(`/companies/${SUB_FICTIONEERS_LTD_COMPANY_UUID}`);
 
 				const expectedSourcingMaterialAwards = [
@@ -5618,7 +5620,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s sub-material\'s sourcing materials (and their sur-material and sur-sur-material)', async () => {
 
-				midFictioneersLtdCompany = await chai.request(app)
+				midFictioneersLtdCompany = await request.execute(app)
 					.get(`/companies/${MID_FICTIONEERS_LTD_COMPANY_UUID}`);
 
 				const expectedSourcingMaterialAwards = [
@@ -5764,7 +5766,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s sub-sub-material\'s sourcing materials (and their sur-material and sur-sur-material)', async () => {
 
-				surFictioneersLtdCompany = await chai.request(app)
+				surFictioneersLtdCompany = await request.execute(app)
 					.get(`/companies/${SUR_FICTIONEERS_LTD_COMPANY_UUID}`);
 
 				const expectedSourcingMaterialAwards = [
@@ -5938,7 +5940,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of its sur-material\'s sourcing materials (and their sur-material, but not their sub-materials)', async () => {
 
-				subWaldoPartIMaterial = await chai.request(app)
+				subWaldoPartIMaterial = await request.execute(app)
 					.get(`/materials/${SUB_WALDO_PART_I_MATERIAL_UUID}`);
 
 				const expectedSourcingMaterialAwards = [
@@ -6037,7 +6039,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of its sourcing materials (and their sur-material and sub-materials)', async () => {
 
-				midWaldoSectionIMaterial = await chai.request(app)
+				midWaldoSectionIMaterial = await request.execute(app)
 					.get(`/materials/${MID_WALDO_SECTION_I_MATERIAL_UUID}`);
 
 				const expectedSourcingMaterialAwards = [
@@ -6230,7 +6232,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of its sub-material\'s sourcing materials (and their sur-material and sub-materials)', async () => {
 
-				surWaldoMaterial = await chai.request(app)
+				surWaldoMaterial = await request.execute(app)
 					.get(`/materials/${SUR_WALDO_MATERIAL_UUID}`);
 
 				const expectedSourcingMaterialAwards = [
@@ -6423,7 +6425,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s sur-material\'s sourcing materials (and their sur-material, but not their sub-materials)', async () => {
 
-				janeRoeJrPerson = await chai.request(app)
+				janeRoeJrPerson = await request.execute(app)
 					.get(`/people/${JANE_ROE_JR_PERSON_UUID}`);
 
 				const expectedSourcingMaterialAwards = [
@@ -6522,7 +6524,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s sourcing materials (and their sur-material and sub-materials)', async () => {
 
-				janeRoePerson = await chai.request(app)
+				janeRoePerson = await request.execute(app)
 					.get(`/people/${JANE_ROE_PERSON_UUID}`);
 
 				const expectedSourcingMaterialAwards = [
@@ -6715,7 +6717,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s sub-material\'s sourcing materials (and their sur-material and sub-materials)', async () => {
 
-				janeRoeSrPerson = await chai.request(app)
+				janeRoeSrPerson = await request.execute(app)
 					.get(`/people/${JANE_ROE_SR_PERSON_UUID}`);
 
 				const expectedSourcingMaterialAwards = [
@@ -6908,7 +6910,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s sur-material\'s sourcing materials (and their sur-material, but not their sub-materials)', async () => {
 
-				subFictioneersLtdCompany = await chai.request(app)
+				subFictioneersLtdCompany = await request.execute(app)
 					.get(`/companies/${SUB_FICTIONEERS_LTD_COMPANY_UUID}`);
 
 				const expectedSourcingMaterialAwards = [
@@ -7007,7 +7009,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s sub-material\'s sourcing materials (and their sur-material and sur-sur-material)', async () => {
 
-				midFictioneersLtdCompany = await chai.request(app)
+				midFictioneersLtdCompany = await request.execute(app)
 					.get(`/companies/${MID_FICTIONEERS_LTD_COMPANY_UUID}`);
 
 				const expectedSourcingMaterialAwards = [
@@ -7200,7 +7202,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s sub-material\'s sourcing materials (and their sur-material and sub-materials)', async () => {
 
-				surFictioneersLtdCompany = await chai.request(app)
+				surFictioneersLtdCompany = await request.execute(app)
 					.get(`/companies/${SUR_FICTIONEERS_LTD_COMPANY_UUID}`);
 
 				const expectedSourcingMaterialAwards = [
@@ -7421,7 +7423,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of its sur-sur-material\'s sourcing materials (but not their sub-materials and sub-sub-materials)', async () => {
 
-				subWaldoPartIMaterial = await chai.request(app)
+				subWaldoPartIMaterial = await request.execute(app)
 					.get(`/materials/${SUB_WALDO_PART_I_MATERIAL_UUID}`);
 
 				const expectedSourcingMaterialAwards = [
@@ -7477,7 +7479,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of its sur-material\'s sourcing materials (but not their sub-materials and sub-sub-materials)', async () => {
 
-				midWaldoSectionIMaterial = await chai.request(app)
+				midWaldoSectionIMaterial = await request.execute(app)
 					.get(`/materials/${MID_WALDO_SECTION_I_MATERIAL_UUID}`);
 
 				const expectedSourcingMaterialAwards = [
@@ -7533,7 +7535,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of its sourcing materials (and their sub-materials and sub-sub-materials)', async () => {
 
-				surWaldoMaterial = await chai.request(app)
+				surWaldoMaterial = await request.execute(app)
 					.get(`/materials/${SUR_WALDO_MATERIAL_UUID}`);
 
 				const expectedSourcingMaterialAwards = [
@@ -7769,7 +7771,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s sur-sur-material\'s sourcing materials (but not their sub-materials and sub-sub-materials)', async () => {
 
-				janeRoeJrPerson = await chai.request(app)
+				janeRoeJrPerson = await request.execute(app)
 					.get(`/people/${JANE_ROE_JR_PERSON_UUID}`);
 
 				const expectedSourcingMaterialAwards = [
@@ -7825,7 +7827,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s sur-material\'s sourcing materials (but not their sub-materials and sub-sub-materials)', async () => {
 
-				janeRoePerson = await chai.request(app)
+				janeRoePerson = await request.execute(app)
 					.get(`/people/${JANE_ROE_PERSON_UUID}`);
 
 				const expectedSourcingMaterialAwards = [
@@ -7881,7 +7883,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s sourcing materials (and their sub-materials and sub-sub-materials)', async () => {
 
-				janeRoeSrPerson = await chai.request(app)
+				janeRoeSrPerson = await request.execute(app)
 					.get(`/people/${JANE_ROE_SR_PERSON_UUID}`);
 
 				const expectedSourcingMaterialAwards = [
@@ -8117,7 +8119,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s sur-sur-material\'s sourcing materials (but not their sub-materials and sub-sub-materials)', async () => {
 
-				subFictioneersLtdCompany = await chai.request(app)
+				subFictioneersLtdCompany = await request.execute(app)
 					.get(`/companies/${SUB_FICTIONEERS_LTD_COMPANY_UUID}`);
 
 				const expectedSourcingMaterialAwards = [
@@ -8173,7 +8175,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s sur-material\'s sourcing materials (but not their sub-materials and sub-sub-materials)', async () => {
 
-				midFictioneersLtdCompany = await chai.request(app)
+				midFictioneersLtdCompany = await request.execute(app)
 					.get(`/companies/${MID_FICTIONEERS_LTD_COMPANY_UUID}`);
 
 				const expectedSourcingMaterialAwards = [
@@ -8229,7 +8231,7 @@ describe('Award ceremonies with crediting material collections loosely connected
 
 			it('includes awards of their work\'s sourcing materials (and their sub-materials and sub-sub-materials)', async () => {
 
-				surFictioneersLtdCompany = await chai.request(app)
+				surFictioneersLtdCompany = await request.execute(app)
 					.get(`/companies/${SUR_FICTIONEERS_LTD_COMPANY_UUID}`);
 
 				const expectedSourcingMaterialAwards = [

--- a/test-e2e/model-interaction/award-ceremonies-with-crediting-mats.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-crediting-mats.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -104,7 +106,7 @@ describe('Award ceremonies with crediting materials', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Piyo',
@@ -149,7 +151,7 @@ describe('Award ceremonies with crediting materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Waldo',
@@ -170,7 +172,7 @@ describe('Award ceremonies with crediting materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Wibble',
@@ -200,7 +202,7 @@ describe('Award ceremonies with crediting materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Xyzzy',
@@ -234,7 +236,7 @@ describe('Award ceremonies with crediting materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Fred',
@@ -255,7 +257,7 @@ describe('Award ceremonies with crediting materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Garply',
@@ -272,7 +274,7 @@ describe('Award ceremonies with crediting materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Plugh',
@@ -294,7 +296,7 @@ describe('Award ceremonies with crediting materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Plugh',
@@ -332,7 +334,7 @@ describe('Award ceremonies with crediting materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Hoge',
@@ -366,7 +368,7 @@ describe('Award ceremonies with crediting materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Thud',
@@ -383,7 +385,7 @@ describe('Award ceremonies with crediting materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Tutu',
@@ -400,7 +402,7 @@ describe('Award ceremonies with crediting materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Toto',
@@ -433,7 +435,7 @@ describe('Award ceremonies with crediting materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Fuga',
@@ -450,7 +452,7 @@ describe('Award ceremonies with crediting materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Grault',
@@ -467,7 +469,7 @@ describe('Award ceremonies with crediting materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/venues')
 			.send({
 				name: 'National Theatre',
@@ -484,7 +486,7 @@ describe('Award ceremonies with crediting materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/venues')
 			.send({
 				name: 'Royal Court Theatre',
@@ -498,7 +500,7 @@ describe('Award ceremonies with crediting materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Piyo',
@@ -509,7 +511,7 @@ describe('Award ceremonies with crediting materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Piyo',
@@ -520,7 +522,7 @@ describe('Award ceremonies with crediting materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Wibble',
@@ -531,7 +533,7 @@ describe('Award ceremonies with crediting materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Wibble',
@@ -542,7 +544,7 @@ describe('Award ceremonies with crediting materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Xyzzy',
@@ -553,7 +555,7 @@ describe('Award ceremonies with crediting materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Xyzzy',
@@ -564,7 +566,7 @@ describe('Award ceremonies with crediting materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Fred',
@@ -575,7 +577,7 @@ describe('Award ceremonies with crediting materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Fred',
@@ -586,7 +588,7 @@ describe('Award ceremonies with crediting materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Garply',
@@ -597,7 +599,7 @@ describe('Award ceremonies with crediting materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Plugh',
@@ -608,7 +610,7 @@ describe('Award ceremonies with crediting materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Plugh',
@@ -619,7 +621,7 @@ describe('Award ceremonies with crediting materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Hoge',
@@ -630,7 +632,7 @@ describe('Award ceremonies with crediting materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Hoge',
@@ -641,7 +643,7 @@ describe('Award ceremonies with crediting materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Thud',
@@ -652,7 +654,7 @@ describe('Award ceremonies with crediting materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Tutu',
@@ -663,7 +665,7 @@ describe('Award ceremonies with crediting materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Toto',
@@ -674,7 +676,7 @@ describe('Award ceremonies with crediting materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Toto',
@@ -685,7 +687,7 @@ describe('Award ceremonies with crediting materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Fuga',
@@ -696,7 +698,7 @@ describe('Award ceremonies with crediting materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Grault',
@@ -707,7 +709,7 @@ describe('Award ceremonies with crediting materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2009',
@@ -772,7 +774,7 @@ describe('Award ceremonies with crediting materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2010',
@@ -835,7 +837,7 @@ describe('Award ceremonies with crediting materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2008',
@@ -891,7 +893,7 @@ describe('Award ceremonies with crediting materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2008',
@@ -947,7 +949,7 @@ describe('Award ceremonies with crediting materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2009',
@@ -1007,7 +1009,7 @@ describe('Award ceremonies with crediting materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2007',
@@ -1060,58 +1062,58 @@ describe('Award ceremonies with crediting materials', () => {
 				]
 			});
 
-		wordsmithAward2009AwardCeremony = await chai.request(app)
+		wordsmithAward2009AwardCeremony = await request.execute(app)
 			.get(`/award-ceremonies/${WORDSMITH_AWARD_2009_AWARD_CEREMONY_UUID}`);
 
-		playwritingPrize2009AwardCeremony = await chai.request(app)
+		playwritingPrize2009AwardCeremony = await request.execute(app)
 			.get(`/award-ceremonies/${PLAYWRITING_PRIZE_2009_AWARD_CEREMONY_UUID}`);
 
-		johnDoePerson = await chai.request(app)
+		johnDoePerson = await request.execute(app)
 			.get(`/people/${JOHN_DOE_PERSON_UUID}`);
 
-		playwrightsLtdCompany = await chai.request(app)
+		playwrightsLtdCompany = await request.execute(app)
 			.get(`/companies/${PLAYWRIGHTS_LTD_COMPANY_UUID}`);
 
-		claraQuuxPerson = await chai.request(app)
+		claraQuuxPerson = await request.execute(app)
 			.get(`/people/${CLARA_QUUX_PERSON_UUID}`);
 
-		songbirdsLtdCompany = await chai.request(app)
+		songbirdsLtdCompany = await request.execute(app)
 			.get(`/companies/${SONGBIRDS_LTD_COMPANY_UUID}`);
 
-		beatriceBarPerson = await chai.request(app)
+		beatriceBarPerson = await request.execute(app)
 			.get(`/people/${BEATRICE_BAR_PERSON_UUID}`);
 
-		theatricalsLtdCompany = await chai.request(app)
+		theatricalsLtdCompany = await request.execute(app)
 			.get(`/companies/${THEATRICALS_LTD_COMPANY_UUID}`);
 
-		waldoMaterial = await chai.request(app)
+		waldoMaterial = await request.execute(app)
 			.get(`/materials/${WALDO_MATERIAL_UUID}`);
 
-		janeRoePerson = await chai.request(app)
+		janeRoePerson = await request.execute(app)
 			.get(`/people/${JANE_ROE_PERSON_UUID}`);
 
-		fictioneersLtdCompany = await chai.request(app)
+		fictioneersLtdCompany = await request.execute(app)
 			.get(`/companies/${FICTIONEERS_LTD_COMPANY_UUID}`);
 
-		brandonBazPerson = await chai.request(app)
+		brandonBazPerson = await request.execute(app)
 			.get(`/people/${BRANDON_BAZ_PERSON_UUID}`);
 
-		creatorsLtdCompany = await chai.request(app)
+		creatorsLtdCompany = await request.execute(app)
 			.get(`/companies/${CREATORS_LTD_COMPANY_UUID}`);
 
-		plughOriginalVersionMaterial = await chai.request(app)
+		plughOriginalVersionMaterial = await request.execute(app)
 			.get(`/materials/${PLUGH_ORIGINAL_VERSION_MATERIAL_UUID}`);
 
-		francisFlobPerson = await chai.request(app)
+		francisFlobPerson = await request.execute(app)
 			.get(`/people/${FRANCIS_FLOB_PERSON_UUID}`);
 
-		curtainUpLtdCompany = await chai.request(app)
+		curtainUpLtdCompany = await request.execute(app)
 			.get(`/companies/${CURTAIN_UP_LTD_COMPANY_UUID}`);
 
-		talyseTataPerson = await chai.request(app)
+		talyseTataPerson = await request.execute(app)
 			.get(`/people/${TALYSE_TATA_PERSON_UUID}`);
 
-		cinerightsLtdCompany = await chai.request(app)
+		cinerightsLtdCompany = await request.execute(app)
 			.get(`/companies/${CINERIGHTS_LTD_COMPANY_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-mats-via-assocs.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-mats-via-assocs.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -100,7 +102,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Fred: Part I',
@@ -121,7 +123,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Fred: Part II',
@@ -129,7 +131,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				year: '2010'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Fred',
@@ -158,7 +160,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Plugh: Part I',
@@ -180,7 +182,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Plugh: Part II',
@@ -189,7 +191,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				year: '1899'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Plugh',
@@ -221,7 +223,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Plugh: Part I',
@@ -259,7 +261,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Plugh: Part II',
@@ -272,7 +274,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Plugh',
@@ -320,7 +322,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Waldo: Part I',
@@ -341,7 +343,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Waldo: Part II',
@@ -349,7 +351,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				year: '1974'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Waldo',
@@ -378,7 +380,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Wibble: Part I',
@@ -408,7 +410,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Wibble: Part II',
@@ -416,7 +418,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				year: '2009'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Wibble',
@@ -454,7 +456,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Hoge: Part I',
@@ -488,7 +490,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Hoge: Part II',
@@ -496,7 +498,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				year: '2008'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Hoge',
@@ -538,7 +540,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/venues')
 			.send({
 				name: 'National Theatre',
@@ -552,7 +554,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/venues')
 			.send({
 				name: 'Royal Court Theatre',
@@ -566,7 +568,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Fred: Part I',
@@ -577,7 +579,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Fred',
@@ -593,7 +595,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Fred: Part I',
@@ -604,7 +606,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Fred',
@@ -620,7 +622,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Plugh: Part I',
@@ -631,7 +633,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Plugh',
@@ -647,7 +649,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Plugh: Part I',
@@ -658,7 +660,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Plugh',
@@ -674,7 +676,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Wibble: Part I',
@@ -685,7 +687,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Wibble',
@@ -701,7 +703,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Wibble: Part I',
@@ -712,7 +714,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Wibble',
@@ -728,7 +730,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Hoge: Part I',
@@ -739,7 +741,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Hoge',
@@ -755,7 +757,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Hoge: Part I',
@@ -766,7 +768,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Hoge',
@@ -782,7 +784,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2010',
@@ -860,7 +862,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2009',
@@ -938,7 +940,7 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2009',
@@ -984,64 +986,64 @@ describe('Award ceremonies with crediting sub-materials (with person/company/mat
 				]
 			});
 
-		johnDoeJrPerson = await chai.request(app)
+		johnDoeJrPerson = await request.execute(app)
 			.get(`/people/${JOHN_DOE_JR_PERSON_UUID}`);
 
-		johnDoeSrPerson = await chai.request(app)
+		johnDoeSrPerson = await request.execute(app)
 			.get(`/people/${JOHN_DOE_SR_PERSON_UUID}`);
 
-		subPlaywrightsLtdCompany = await chai.request(app)
+		subPlaywrightsLtdCompany = await request.execute(app)
 			.get(`/companies/${SUB_PLAYWRIGHTS_LTD_COMPANY_UUID}`);
 
-		surPlaywrightsLtdCompany = await chai.request(app)
+		surPlaywrightsLtdCompany = await request.execute(app)
 			.get(`/companies/${SUR_PLAYWRIGHTS_LTD_COMPANY_UUID}`);
 
-		subPlughPartIOriginalVersionMaterial = await chai.request(app)
+		subPlughPartIOriginalVersionMaterial = await request.execute(app)
 			.get(`/materials/${SUB_PLUGH_PART_I_ORIGINAL_VERSION_MATERIAL_UUID}`);
 
-		surPlughOriginalVersionMaterial = await chai.request(app)
+		surPlughOriginalVersionMaterial = await request.execute(app)
 			.get(`/materials/${SUR_PLUGH_ORIGINAL_VERSION_MATERIAL_UUID}`);
 
-		francisFlobJrPerson = await chai.request(app)
+		francisFlobJrPerson = await request.execute(app)
 			.get(`/people/${FRANCIS_FLOB_JR_PERSON_UUID}`);
 
-		francisFlobSrPerson = await chai.request(app)
+		francisFlobSrPerson = await request.execute(app)
 			.get(`/people/${FRANCIS_FLOB_SR_PERSON_UUID}`);
 
-		subCurtainUpLtdCompany = await chai.request(app)
+		subCurtainUpLtdCompany = await request.execute(app)
 			.get(`/companies/${SUB_CURTAIN_UP_LTD_COMPANY_UUID}`);
 
-		surCurtainUpLtdCompany = await chai.request(app)
+		surCurtainUpLtdCompany = await request.execute(app)
 			.get(`/companies/${SUR_CURTAIN_UP_LTD_COMPANY_UUID}`);
 
-		subWaldoPartIMaterial = await chai.request(app)
+		subWaldoPartIMaterial = await request.execute(app)
 			.get(`/materials/${SUB_WALDO_PART_I_MATERIAL_UUID}`);
 
-		surWaldoMaterial = await chai.request(app)
+		surWaldoMaterial = await request.execute(app)
 			.get(`/materials/${SUR_WALDO_MATERIAL_UUID}`);
 
-		janeRoeJrPerson = await chai.request(app)
+		janeRoeJrPerson = await request.execute(app)
 			.get(`/people/${JANE_ROE_JR_PERSON_UUID}`);
 
-		janeRoeSrPerson = await chai.request(app)
+		janeRoeSrPerson = await request.execute(app)
 			.get(`/people/${JANE_ROE_SR_PERSON_UUID}`);
 
-		subFictioneersLtdCompany = await chai.request(app)
+		subFictioneersLtdCompany = await request.execute(app)
 			.get(`/companies/${SUB_FICTIONEERS_LTD_COMPANY_UUID}`);
 
-		surFictioneersLtdCompany = await chai.request(app)
+		surFictioneersLtdCompany = await request.execute(app)
 			.get(`/companies/${SUR_FICTIONEERS_LTD_COMPANY_UUID}`);
 
-		talyseTataJrPerson = await chai.request(app)
+		talyseTataJrPerson = await request.execute(app)
 			.get(`/people/${TALYSE_TATA_JR_PERSON_UUID}`);
 
-		talyseTataSrPerson = await chai.request(app)
+		talyseTataSrPerson = await request.execute(app)
 			.get(`/people/${TALYSE_TATA_SR_PERSON_UUID}`);
 
-		subCinerightsLtdCompany = await chai.request(app)
+		subCinerightsLtdCompany = await request.execute(app)
 			.get(`/companies/${SUB_CINERIGHTS_LTD_COMPANY_UUID}`);
 
-		surCinerightsLtdCompany = await chai.request(app)
+		surCinerightsLtdCompany = await request.execute(app)
 			.get(`/companies/${SUR_CINERIGHTS_LTD_COMPANY_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-mats.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-mats.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -78,7 +80,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Fred',
@@ -99,7 +101,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Fred',
@@ -125,7 +127,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Plugh',
@@ -147,7 +149,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Plugh',
@@ -175,7 +177,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Plugh',
@@ -213,7 +215,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Plugh',
@@ -257,7 +259,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Waldo',
@@ -278,7 +280,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Waldo',
@@ -304,7 +306,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Wibble',
@@ -334,7 +336,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Wibble',
@@ -369,7 +371,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Hoge',
@@ -403,7 +405,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Hoge',
@@ -442,7 +444,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/venues')
 			.send({
 				name: 'National Theatre',
@@ -456,7 +458,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/venues')
 			.send({
 				name: 'Royal Court Theatre',
@@ -470,7 +472,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Fred',
@@ -481,7 +483,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Fred',
@@ -497,7 +499,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Fred',
@@ -508,7 +510,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Fred',
@@ -524,7 +526,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Plugh',
@@ -535,7 +537,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Plugh',
@@ -551,7 +553,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Plugh',
@@ -562,7 +564,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Plugh',
@@ -578,7 +580,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Wibble',
@@ -589,7 +591,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Wibble',
@@ -605,7 +607,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Wibble',
@@ -616,7 +618,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Wibble',
@@ -632,7 +634,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Hoge',
@@ -643,7 +645,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Hoge',
@@ -659,7 +661,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Hoge',
@@ -670,7 +672,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Hoge',
@@ -686,7 +688,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2010',
@@ -764,7 +766,7 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2009',
@@ -842,34 +844,34 @@ describe('Award ceremonies with crediting sub-materials', () => {
 				]
 			});
 
-		wordsmithAward2010AwardCeremony = await chai.request(app)
+		wordsmithAward2010AwardCeremony = await request.execute(app)
 			.get(`/award-ceremonies/${WORDSMITH_AWARD_2010_AWARD_CEREMONY_UUID}`);
 
-		playwritingPrize2009AwardCeremony = await chai.request(app)
+		playwritingPrize2009AwardCeremony = await request.execute(app)
 			.get(`/award-ceremonies/${PLAYWRITING_PRIZE_2009_AWARD_CEREMONY_UUID}`);
 
-		johnDoePerson = await chai.request(app)
+		johnDoePerson = await request.execute(app)
 			.get(`/people/${JOHN_DOE_PERSON_UUID}`);
 
-		playwrightsLtdCompany = await chai.request(app)
+		playwrightsLtdCompany = await request.execute(app)
 			.get(`/companies/${PLAYWRIGHTS_LTD_COMPANY_UUID}`);
 
-		francisFlobPerson = await chai.request(app)
+		francisFlobPerson = await request.execute(app)
 			.get(`/people/${FRANCIS_FLOB_PERSON_UUID}`);
 
-		curtainUpLtdCompany = await chai.request(app)
+		curtainUpLtdCompany = await request.execute(app)
 			.get(`/companies/${CURTAIN_UP_LTD_COMPANY_UUID}`);
 
-		janeRoePerson = await chai.request(app)
+		janeRoePerson = await request.execute(app)
 			.get(`/people/${JANE_ROE_PERSON_UUID}`);
 
-		fictioneersLtdCompany = await chai.request(app)
+		fictioneersLtdCompany = await request.execute(app)
 			.get(`/companies/${FICTIONEERS_LTD_COMPANY_UUID}`);
 
-		talyseTataPerson = await chai.request(app)
+		talyseTataPerson = await request.execute(app)
 			.get(`/people/${TALYSE_TATA_PERSON_UUID}`);
 
-		cinerightsLtdCompany = await chai.request(app)
+		cinerightsLtdCompany = await request.execute(app)
 			.get(`/companies/${CINERIGHTS_LTD_COMPANY_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-sub-mats-via-assocs.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-sub-mats-via-assocs.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -140,7 +142,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Fred: Part I',
@@ -161,7 +163,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Fred: Part II',
@@ -169,7 +171,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				year: '2010'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Mid-Fred: Section I',
@@ -198,7 +200,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Mid-Fred: Section II',
@@ -206,7 +208,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				year: '2010'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Fred',
@@ -235,7 +237,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Plugh: Part I',
@@ -257,7 +259,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Plugh: Part II',
@@ -266,7 +268,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				year: '1899'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Mid-Plugh: Section I',
@@ -298,7 +300,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Mid-Plugh: Section II',
@@ -307,7 +309,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				year: '1899'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Plugh',
@@ -339,7 +341,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Plugh: Part I',
@@ -377,7 +379,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Plugh: Part II',
@@ -390,7 +392,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Mid-Plugh: Section I',
@@ -438,7 +440,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Mid-Plugh: Section II',
@@ -451,7 +453,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Plugh',
@@ -499,7 +501,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Waldo: Part I',
@@ -520,7 +522,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Waldo: Part II',
@@ -528,7 +530,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				year: '1974'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Mid-Waldo: Section I',
@@ -557,7 +559,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Mid-Waldo: Section II',
@@ -565,7 +567,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				year: '1974'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Waldo',
@@ -594,7 +596,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Wibble: Part I',
@@ -624,7 +626,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Wibble: Part II',
@@ -643,7 +645,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Mid-Wibble: Section I',
@@ -681,7 +683,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Mid-Wibble: Section II',
@@ -700,7 +702,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Wibble',
@@ -738,7 +740,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Hoge: Part I',
@@ -772,7 +774,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Hoge: Part II',
@@ -780,7 +782,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				year: '2008'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Mid-Hoge: Section I',
@@ -822,7 +824,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Mid-Hoge: Section II',
@@ -830,7 +832,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				year: '2008'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Hoge',
@@ -872,7 +874,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/venues')
 			.send({
 				name: 'National Theatre',
@@ -886,7 +888,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/venues')
 			.send({
 				name: 'Royal Court Theatre',
@@ -900,7 +902,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Fred: Part I',
@@ -911,7 +913,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Mid-Fred: Section I',
@@ -927,7 +929,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Fred',
@@ -943,7 +945,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Fred: Part I',
@@ -954,7 +956,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Mid-Fred: Section I',
@@ -970,7 +972,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Fred',
@@ -986,7 +988,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Plugh: Part I',
@@ -997,7 +999,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Mid-Plugh: Section I',
@@ -1013,7 +1015,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Plugh',
@@ -1029,7 +1031,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Plugh: Part I',
@@ -1040,7 +1042,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Mid-Plugh: Section I',
@@ -1056,7 +1058,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Plugh',
@@ -1072,7 +1074,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Wibble: Part I',
@@ -1083,7 +1085,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Mid-Wibble: Section I',
@@ -1099,7 +1101,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Wibble',
@@ -1115,7 +1117,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Wibble: Part I',
@@ -1126,7 +1128,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Mid-Wibble: Section I',
@@ -1142,7 +1144,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Wibble',
@@ -1158,7 +1160,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Hoge: Part I',
@@ -1169,7 +1171,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Mid-Hoge: Section I',
@@ -1185,7 +1187,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Hoge',
@@ -1201,7 +1203,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Hoge: Part I',
@@ -1212,7 +1214,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Mid-Hoge: Section I',
@@ -1228,7 +1230,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Hoge',
@@ -1244,7 +1246,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2010',
@@ -1322,7 +1324,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2009',
@@ -1400,7 +1402,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2008',
@@ -1478,7 +1480,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2009',
@@ -1524,7 +1526,7 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2009',
@@ -1570,94 +1572,94 @@ describe('Award ceremonies with crediting sub-sub-materials (with person/company
 				]
 			});
 
-		johnDoeJrPerson = await chai.request(app)
+		johnDoeJrPerson = await request.execute(app)
 			.get(`/people/${JOHN_DOE_JR_PERSON_UUID}`);
 
-		johnDoePerson = await chai.request(app)
+		johnDoePerson = await request.execute(app)
 			.get(`/people/${JOHN_DOE_PERSON_UUID}`);
 
-		johnDoeSrPerson = await chai.request(app)
+		johnDoeSrPerson = await request.execute(app)
 			.get(`/people/${JOHN_DOE_SR_PERSON_UUID}`);
 
-		subPlaywrightsLtdCompany = await chai.request(app)
+		subPlaywrightsLtdCompany = await request.execute(app)
 			.get(`/companies/${SUB_PLAYWRIGHTS_LTD_COMPANY_UUID}`);
 
-		midPlaywrightsLtdCompany = await chai.request(app)
+		midPlaywrightsLtdCompany = await request.execute(app)
 			.get(`/companies/${MID_PLAYWRIGHTS_LTD_COMPANY_UUID}`);
 
-		surPlaywrightsLtdCompany = await chai.request(app)
+		surPlaywrightsLtdCompany = await request.execute(app)
 			.get(`/companies/${SUR_PLAYWRIGHTS_LTD_COMPANY_UUID}`);
 
-		subPlughPartIOriginalVersionMaterial = await chai.request(app)
+		subPlughPartIOriginalVersionMaterial = await request.execute(app)
 			.get(`/materials/${SUB_PLUGH_PART_I_ORIGINAL_VERSION_MATERIAL_UUID}`);
 
-		midPlughSectionIOriginalVersionMaterial = await chai.request(app)
+		midPlughSectionIOriginalVersionMaterial = await request.execute(app)
 			.get(`/materials/${MID_PLUGH_SECTION_I_ORIGINAL_VERSION_MATERIAL_UUID}`);
 
-		surPlughOriginalVersionMaterial = await chai.request(app)
+		surPlughOriginalVersionMaterial = await request.execute(app)
 			.get(`/materials/${SUR_PLUGH_ORIGINAL_VERSION_MATERIAL_UUID}`);
 
-		francisFlobJrPerson = await chai.request(app)
+		francisFlobJrPerson = await request.execute(app)
 			.get(`/people/${FRANCIS_FLOB_JR_PERSON_UUID}`);
 
-		francisFlobPerson = await chai.request(app)
+		francisFlobPerson = await request.execute(app)
 			.get(`/people/${FRANCIS_FLOB_PERSON_UUID}`);
 
-		francisFlobSrPerson = await chai.request(app)
+		francisFlobSrPerson = await request.execute(app)
 			.get(`/people/${FRANCIS_FLOB_SR_PERSON_UUID}`);
 
-		subCurtainUpLtdCompany = await chai.request(app)
+		subCurtainUpLtdCompany = await request.execute(app)
 			.get(`/companies/${SUB_CURTAIN_UP_LTD_COMPANY_UUID}`);
 
-		midCurtainUpLtdCompany = await chai.request(app)
+		midCurtainUpLtdCompany = await request.execute(app)
 			.get(`/companies/${MID_CURTAIN_UP_LTD_COMPANY_UUID}`);
 
-		surCurtainUpLtdCompany = await chai.request(app)
+		surCurtainUpLtdCompany = await request.execute(app)
 			.get(`/companies/${SUR_CURTAIN_UP_LTD_COMPANY_UUID}`);
 
-		subWaldoPartIMaterial = await chai.request(app)
+		subWaldoPartIMaterial = await request.execute(app)
 			.get(`/materials/${SUB_WALDO_PART_I_MATERIAL_UUID}`);
 
-		midWaldoSectionIMaterial = await chai.request(app)
+		midWaldoSectionIMaterial = await request.execute(app)
 			.get(`/materials/${MID_WALDO_SECTION_I_MATERIAL_UUID}`);
 
-		surWaldoMaterial = await chai.request(app)
+		surWaldoMaterial = await request.execute(app)
 			.get(`/materials/${SUR_WALDO_MATERIAL_UUID}`);
 
-		janeRoeJrPerson = await chai.request(app)
+		janeRoeJrPerson = await request.execute(app)
 			.get(`/people/${JANE_ROE_JR_PERSON_UUID}`);
 
-		janeRoePerson = await chai.request(app)
+		janeRoePerson = await request.execute(app)
 			.get(`/people/${JANE_ROE_PERSON_UUID}`);
 
-		janeRoeSrPerson = await chai.request(app)
+		janeRoeSrPerson = await request.execute(app)
 			.get(`/people/${JANE_ROE_SR_PERSON_UUID}`);
 
-		subFictioneersLtdCompany = await chai.request(app)
+		subFictioneersLtdCompany = await request.execute(app)
 			.get(`/companies/${SUB_FICTIONEERS_LTD_COMPANY_UUID}`);
 
-		midFictioneersLtdCompany = await chai.request(app)
+		midFictioneersLtdCompany = await request.execute(app)
 			.get(`/companies/${MID_FICTIONEERS_LTD_COMPANY_UUID}`);
 
-		surFictioneersLtdCompany = await chai.request(app)
+		surFictioneersLtdCompany = await request.execute(app)
 			.get(`/companies/${SUR_FICTIONEERS_LTD_COMPANY_UUID}`);
 
-		talyseTataJrPerson = await chai.request(app)
+		talyseTataJrPerson = await request.execute(app)
 			.get(`/people/${TALYSE_TATA_JR_PERSON_UUID}`);
 
-		talyseTataPerson = await chai.request(app)
+		talyseTataPerson = await request.execute(app)
 			.get(`/people/${TALYSE_TATA_PERSON_UUID}`);
 
-		talyseTataSrPerson = await chai.request(app)
+		talyseTataSrPerson = await request.execute(app)
 			.get(`/people/${TALYSE_TATA_SR_PERSON_UUID}`);
 
-		subCinerightsLtdCompany = await chai.request(app)
+		subCinerightsLtdCompany = await request.execute(app)
 			.get(`/companies/${SUB_CINERIGHTS_LTD_COMPANY_UUID}`);
 
-		midCinerightsLtdCompany = await chai.request(app)
+		midCinerightsLtdCompany = await request.execute(app)
 			.get(`/companies/${MID_CINERIGHTS_LTD_COMPANY_UUID}`);
 
-		surCinerightsLtdCompany = await chai.request(app)
+		surCinerightsLtdCompany = await request.execute(app)
 			.get(`/companies/${SUR_CINERIGHTS_LTD_COMPANY_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-sub-mats.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-crediting-sub-sub-mats.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -94,7 +96,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Fred',
@@ -115,7 +117,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Mid-Fred',
@@ -141,7 +143,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Fred',
@@ -167,7 +169,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Plugh',
@@ -189,7 +191,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Mid-Plugh',
@@ -217,7 +219,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Plugh',
@@ -245,7 +247,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Plugh',
@@ -283,7 +285,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Mid-Plugh',
@@ -327,7 +329,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Plugh',
@@ -371,7 +373,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Waldo',
@@ -392,7 +394,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Mid-Waldo',
@@ -418,7 +420,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Waldo',
@@ -444,7 +446,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Wibble',
@@ -474,7 +476,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Mid-Wibble',
@@ -509,7 +511,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Wibble',
@@ -544,7 +546,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Hoge',
@@ -578,7 +580,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Mid-Hoge',
@@ -617,7 +619,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Hoge',
@@ -656,7 +658,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/venues')
 			.send({
 				name: 'National Theatre',
@@ -670,7 +672,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/venues')
 			.send({
 				name: 'Royal Court Theatre',
@@ -684,7 +686,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Fred',
@@ -695,7 +697,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Mid-Fred',
@@ -711,7 +713,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Fred',
@@ -727,7 +729,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Fred',
@@ -738,7 +740,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Mid-Fred',
@@ -754,7 +756,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Fred',
@@ -770,7 +772,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Plugh',
@@ -781,7 +783,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Mid-Plugh',
@@ -797,7 +799,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Plugh',
@@ -813,7 +815,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Plugh',
@@ -824,7 +826,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Mid-Plugh',
@@ -840,7 +842,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Plugh',
@@ -856,7 +858,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Wibble',
@@ -867,7 +869,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Mid-Wibble',
@@ -883,7 +885,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Wibble',
@@ -899,7 +901,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Wibble',
@@ -910,7 +912,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Mid-Wibble',
@@ -926,7 +928,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Wibble',
@@ -942,7 +944,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Hoge',
@@ -953,7 +955,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Mid-Hoge',
@@ -969,7 +971,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Hoge',
@@ -985,7 +987,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Hoge',
@@ -996,7 +998,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Mid-Hoge',
@@ -1012,7 +1014,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Hoge',
@@ -1028,7 +1030,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2010',
@@ -1106,7 +1108,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2009',
@@ -1184,7 +1186,7 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2008',
@@ -1262,37 +1264,37 @@ describe('Award ceremonies with crediting sub-sub-materials', () => {
 				]
 			});
 
-		wordsmithAward2010AwardCeremony = await chai.request(app)
+		wordsmithAward2010AwardCeremony = await request.execute(app)
 			.get(`/award-ceremonies/${WORDSMITH_AWARD_2010_AWARD_CEREMONY_UUID}`);
 
-		playwritingPrize2009AwardCeremony = await chai.request(app)
+		playwritingPrize2009AwardCeremony = await request.execute(app)
 			.get(`/award-ceremonies/${PLAYWRITING_PRIZE_2009_AWARD_CEREMONY_UUID}`);
 
-		dramatistsMedal2008AwardCeremony = await chai.request(app)
+		dramatistsMedal2008AwardCeremony = await request.execute(app)
 			.get(`/award-ceremonies/${DRAMATISTS_MEDAL_2008_AWARD_CEREMONY_UUID}`);
 
-		johnDoePerson = await chai.request(app)
+		johnDoePerson = await request.execute(app)
 			.get(`/people/${JOHN_DOE_PERSON_UUID}`);
 
-		playwrightsLtdCompany = await chai.request(app)
+		playwrightsLtdCompany = await request.execute(app)
 			.get(`/companies/${PLAYWRIGHTS_LTD_COMPANY_UUID}`);
 
-		francisFlobPerson = await chai.request(app)
+		francisFlobPerson = await request.execute(app)
 			.get(`/people/${FRANCIS_FLOB_PERSON_UUID}`);
 
-		curtainUpLtdCompany = await chai.request(app)
+		curtainUpLtdCompany = await request.execute(app)
 			.get(`/companies/${CURTAIN_UP_LTD_COMPANY_UUID}`);
 
-		janeRoePerson = await chai.request(app)
+		janeRoePerson = await request.execute(app)
 			.get(`/people/${JANE_ROE_PERSON_UUID}`);
 
-		fictioneersLtdCompany = await chai.request(app)
+		fictioneersLtdCompany = await request.execute(app)
 			.get(`/companies/${FICTIONEERS_LTD_COMPANY_UUID}`);
 
-		talyseTataPerson = await chai.request(app)
+		talyseTataPerson = await request.execute(app)
 			.get(`/people/${TALYSE_TATA_PERSON_UUID}`);
 
-		cinerightsLtdCompany = await chai.request(app)
+		cinerightsLtdCompany = await request.execute(app)
 			.get(`/companies/${CINERIGHTS_LTD_COMPANY_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/award-ceremonies-with-sub-mats-sub-prods.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-sub-mats-sub-prods.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -50,7 +52,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/venues')
 			.send({
 				name: 'Royal Court Theatre',
@@ -61,7 +63,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Hoge',
@@ -69,7 +71,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 				year: '2019'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Hoge',
@@ -82,7 +84,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Wibble: Part I',
@@ -90,7 +92,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 				year: '2019'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Wibble: Part II',
@@ -98,7 +100,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 				year: '2019'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Wibble',
@@ -114,7 +116,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Hoge',
@@ -125,7 +127,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Hoge',
@@ -141,7 +143,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Wibble: Part I',
@@ -152,7 +154,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Wibble: Part II',
@@ -163,7 +165,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Wibble',
@@ -182,7 +184,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2020',
@@ -230,7 +232,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2019',
@@ -279,7 +281,7 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2019',
@@ -308,37 +310,37 @@ describe('Award ceremonies with sub-materials and sub-productions', () => {
 				]
 			});
 
-		laurenceOlivierAwards2020AwardCeremony = await chai.request(app)
+		laurenceOlivierAwards2020AwardCeremony = await request.execute(app)
 			.get(`/award-ceremonies/${LAURENCE_OLIVIER_AWARDS_2020_AWARD_CEREMONY_UUID}`);
 
-		eveningStandardTheatreAwards2019AwardCeremony = await chai.request(app)
+		eveningStandardTheatreAwards2019AwardCeremony = await request.execute(app)
 			.get(`/award-ceremonies/${EVENING_STANDARD_THEATRE_AWARDS_2019_AWARD_CEREMONY_UUID}`);
 
-		conorCorgePerson = await chai.request(app)
+		conorCorgePerson = await request.execute(app)
 			.get(`/people/${CONOR_CORGE_PERSON_UUID}`);
 
-		stagecraftLtdCompany = await chai.request(app)
+		stagecraftLtdCompany = await request.execute(app)
 			.get(`/companies/${STAGECRAFT_LTD_COMPANY_UUID}`);
 
-		ferdinandFooPerson = await chai.request(app)
+		ferdinandFooPerson = await request.execute(app)
 			.get(`/people/${FERDINAND_FOO_PERSON_UUID}`);
 
-		subHogeNoëlCowardProduction = await chai.request(app)
+		subHogeNoëlCowardProduction = await request.execute(app)
 			.get(`/productions/${SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID}`);
 
-		surHogeNoëlCowardProduction = await chai.request(app)
+		surHogeNoëlCowardProduction = await request.execute(app)
 			.get(`/productions/${SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID}`);
 
-		subWibblePartIJerwoodTheatreUpstairsProduction = await chai.request(app)
+		subWibblePartIJerwoodTheatreUpstairsProduction = await request.execute(app)
 			.get(`/productions/${SUB_WIBBLE_PART_I_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID}`);
 
-		surWibbleJerwoodTheatreUpstairsProduction = await chai.request(app)
+		surWibbleJerwoodTheatreUpstairsProduction = await request.execute(app)
 			.get(`/productions/${SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID}`);
 
-		subWibblePartIMaterial = await chai.request(app)
+		subWibblePartIMaterial = await request.execute(app)
 			.get(`/materials/${SUB_WIBBLE_PART_I_MATERIAL_UUID}`);
 
-		surWibbleMaterial = await chai.request(app)
+		surWibbleMaterial = await request.execute(app)
 			.get(`/materials/${SUR_WIBBLE_MATERIAL_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/award-ceremonies-with-sub-sub-mats-sub-sub-prods.test.js
+++ b/test-e2e/model-interaction/award-ceremonies-with-sub-sub-mats-sub-sub-prods.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -64,7 +66,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/venues')
 			.send({
 				name: 'Royal Court Theatre',
@@ -75,7 +77,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Hoge',
@@ -83,7 +85,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 				year: '2019'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Mid-Hoge',
@@ -96,7 +98,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Hoge',
@@ -109,7 +111,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Wibble: Part I',
@@ -117,7 +119,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 				year: '2019'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Wibble: Part II',
@@ -125,7 +127,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 				year: '2019'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Mid-Wibble: Section I',
@@ -141,7 +143,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Mid-Wibble: Section II',
@@ -149,7 +151,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 				year: '2019'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Wibble',
@@ -165,7 +167,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Hoge',
@@ -176,7 +178,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Mid-Hoge',
@@ -192,7 +194,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Hoge',
@@ -208,7 +210,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Wibble: Part I',
@@ -219,7 +221,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Wibble: Part II',
@@ -230,7 +232,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Mid-Wibble: Section I',
@@ -249,7 +251,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Mid-Wibble: Section II',
@@ -260,7 +262,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Wibble',
@@ -279,7 +281,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2020',
@@ -327,7 +329,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2019',
@@ -376,7 +378,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2018',
@@ -425,7 +427,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2018',
@@ -453,7 +455,7 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2018',
@@ -482,49 +484,49 @@ describe('Award ceremonies with sub-sub-materials and sub-sub-productions', () =
 				]
 			});
 
-		laurenceOlivierAwards2020AwardCeremony = await chai.request(app)
+		laurenceOlivierAwards2020AwardCeremony = await request.execute(app)
 			.get(`/award-ceremonies/${LAURENCE_OLIVIER_AWARDS_2020_AWARD_CEREMONY_UUID}`);
 
-		eveningStandardTheatreAwards2019AwardCeremony = await chai.request(app)
+		eveningStandardTheatreAwards2019AwardCeremony = await request.execute(app)
 			.get(`/award-ceremonies/${EVENING_STANDARD_THEATRE_AWARDS_2019_AWARD_CEREMONY_UUID}`);
 
-		criticsCircleTheatreAwards2018AwardCeremony = await chai.request(app)
+		criticsCircleTheatreAwards2018AwardCeremony = await request.execute(app)
 			.get(`/award-ceremonies/${CRITICS_CIRCLE_THEATRE_AWARDS_2018_AWARD_CEREMONY_UUID}`);
 
-		conorCorgePerson = await chai.request(app)
+		conorCorgePerson = await request.execute(app)
 			.get(`/people/${CONOR_CORGE_PERSON_UUID}`);
 
-		stagecraftLtdCompany = await chai.request(app)
+		stagecraftLtdCompany = await request.execute(app)
 			.get(`/companies/${STAGECRAFT_LTD_COMPANY_UUID}`);
 
-		ferdinandFooPerson = await chai.request(app)
+		ferdinandFooPerson = await request.execute(app)
 			.get(`/people/${FERDINAND_FOO_PERSON_UUID}`);
 
-		subHogeNoëlCowardProduction = await chai.request(app)
+		subHogeNoëlCowardProduction = await request.execute(app)
 			.get(`/productions/${SUB_HOGE_NOËL_COWARD_PRODUCTION_UUID}`);
 
-		midHogeNoëlCowardProduction = await chai.request(app)
+		midHogeNoëlCowardProduction = await request.execute(app)
 			.get(`/productions/${MID_HOGE_NOËL_COWARD_PRODUCTION_UUID}`);
 
-		surHogeNoëlCowardProduction = await chai.request(app)
+		surHogeNoëlCowardProduction = await request.execute(app)
 			.get(`/productions/${SUR_HOGE_NOËL_COWARD_PRODUCTION_UUID}`);
 
-		subWibblePartIJerwoodTheatreUpstairsProduction = await chai.request(app)
+		subWibblePartIJerwoodTheatreUpstairsProduction = await request.execute(app)
 			.get(`/productions/${SUB_WIBBLE_PART_I_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID}`);
 
-		midWibbleSectionIJerwoodTheatreUpstairsProduction = await chai.request(app)
+		midWibbleSectionIJerwoodTheatreUpstairsProduction = await request.execute(app)
 			.get(`/productions/${MID_WIBBLE_SECTION_I_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID}`);
 
-		surWibbleJerwoodTheatreUpstairsProduction = await chai.request(app)
+		surWibbleJerwoodTheatreUpstairsProduction = await request.execute(app)
 			.get(`/productions/${SUR_WIBBLE_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID}`);
 
-		subWibblePartIMaterial = await chai.request(app)
+		subWibblePartIMaterial = await request.execute(app)
 			.get(`/materials/${SUB_WIBBLE_PART_I_MATERIAL_UUID}`);
 
-		midWibbleSectionIMaterial = await chai.request(app)
+		midWibbleSectionIMaterial = await request.execute(app)
 			.get(`/materials/${MID_WIBBLE_SECTION_I_MATERIAL_UUID}`);
 
-		surWibbleMaterial = await chai.request(app)
+		surWibbleMaterial = await request.execute(app)
 			.get(`/materials/${SUR_WIBBLE_MATERIAL_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/award-ceremonies.test.js
+++ b/test-e2e/model-interaction/award-ceremonies.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -93,7 +95,7 @@ describe('Award ceremonies', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/venues')
 			.send({
 				name: 'National Theatre',
@@ -110,7 +112,7 @@ describe('Award ceremonies', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Garply',
@@ -121,7 +123,7 @@ describe('Award ceremonies', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Garply',
@@ -132,7 +134,7 @@ describe('Award ceremonies', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Plugh',
@@ -143,7 +145,7 @@ describe('Award ceremonies', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Fred',
@@ -154,7 +156,7 @@ describe('Award ceremonies', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Waldo',
@@ -165,7 +167,7 @@ describe('Award ceremonies', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Waldo',
@@ -176,7 +178,7 @@ describe('Award ceremonies', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Piyo',
@@ -187,7 +189,7 @@ describe('Award ceremonies', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Xyzzy',
@@ -198,7 +200,7 @@ describe('Award ceremonies', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Xyzzy',
@@ -209,7 +211,7 @@ describe('Award ceremonies', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Wibble',
@@ -220,7 +222,7 @@ describe('Award ceremonies', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Wibble',
@@ -231,7 +233,7 @@ describe('Award ceremonies', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Hoge',
@@ -242,7 +244,7 @@ describe('Award ceremonies', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Thud',
@@ -253,7 +255,7 @@ describe('Award ceremonies', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Toto',
@@ -264,7 +266,7 @@ describe('Award ceremonies', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Fuga',
@@ -275,7 +277,7 @@ describe('Award ceremonies', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Tutu',
@@ -286,7 +288,7 @@ describe('Award ceremonies', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Grault',
@@ -297,7 +299,7 @@ describe('Award ceremonies', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Garply',
@@ -305,7 +307,7 @@ describe('Award ceremonies', () => {
 				year: '2019'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Plugh',
@@ -313,7 +315,7 @@ describe('Award ceremonies', () => {
 				year: '2019'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Fred',
@@ -321,7 +323,7 @@ describe('Award ceremonies', () => {
 				year: '2019'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Waldo',
@@ -329,7 +331,7 @@ describe('Award ceremonies', () => {
 				year: '2019'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Piyo',
@@ -337,7 +339,7 @@ describe('Award ceremonies', () => {
 				year: '2017'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Xyzzy',
@@ -345,7 +347,7 @@ describe('Award ceremonies', () => {
 				year: '2017'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Wibble',
@@ -353,7 +355,7 @@ describe('Award ceremonies', () => {
 				year: '2017'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Hoge',
@@ -361,7 +363,7 @@ describe('Award ceremonies', () => {
 				year: '2017'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Thud',
@@ -369,7 +371,7 @@ describe('Award ceremonies', () => {
 				year: '2017'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Toto',
@@ -377,7 +379,7 @@ describe('Award ceremonies', () => {
 				year: '2018'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Fuga',
@@ -385,7 +387,7 @@ describe('Award ceremonies', () => {
 				year: '2018'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Tutu',
@@ -393,7 +395,7 @@ describe('Award ceremonies', () => {
 				year: '2018'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Grault',
@@ -401,7 +403,7 @@ describe('Award ceremonies', () => {
 				year: '2019'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2020',
@@ -671,7 +673,7 @@ describe('Award ceremonies', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2018',
@@ -864,7 +866,7 @@ describe('Award ceremonies', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2018',
@@ -958,7 +960,7 @@ describe('Award ceremonies', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2019',
@@ -1089,7 +1091,7 @@ describe('Award ceremonies', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2017',
@@ -1365,7 +1367,7 @@ describe('Award ceremonies', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/award-ceremonies')
 			.send({
 				name: '2019',
@@ -1561,43 +1563,43 @@ describe('Award ceremonies', () => {
 				]
 			});
 
-		laurenceOlivierAwards2020AwardCeremony = await chai.request(app)
+		laurenceOlivierAwards2020AwardCeremony = await request.execute(app)
 			.get(`/award-ceremonies/${LAURENCE_OLIVIER_AWARDS_2020_AWARD_CEREMONY_UUID}`);
 
-		eveningStandardTheatreAwards2017AwardCeremony = await chai.request(app)
+		eveningStandardTheatreAwards2017AwardCeremony = await request.execute(app)
 			.get(`/award-ceremonies/${EVENING_STANDARD_THEATRE_AWARDS2017AWARD_CEREMONY_UUID}`);
 
-		laurenceOlivierAwardsAward = await chai.request(app)
+		laurenceOlivierAwardsAward = await request.execute(app)
 			.get(`/awards/${LAURENCE_OLIVIER_AWARDS_AWARD_UUID}`);
 
-		eveningStandardTheatreAwardsAward = await chai.request(app)
+		eveningStandardTheatreAwardsAward = await request.execute(app)
 			.get(`/awards/${EVENING_STANDARD_THEATRE_AWARDS_AWARD_UUID}`);
 
-		johnDoePerson = await chai.request(app)
+		johnDoePerson = await request.execute(app)
 			.get(`/people/${JOHN_DOE_PERSON_UUID}`);
 
-		curtainUpLtdCompany = await chai.request(app)
+		curtainUpLtdCompany = await request.execute(app)
 			.get(`/companies/${CURTAIN_UP_LTD_COMPANY_UUID}`);
 
-		conorCorgePerson = await chai.request(app)
+		conorCorgePerson = await request.execute(app)
 			.get(`/people/${CONOR_CORGE_PERSON_UUID}`);
 
-		stagecraftLtdCompany = await chai.request(app)
+		stagecraftLtdCompany = await request.execute(app)
 			.get(`/companies/${STAGECRAFT_LTD_COMPANY_UUID}`);
 
-		quincyQuxPerson = await chai.request(app)
+		quincyQuxPerson = await request.execute(app)
 			.get(`/people/${QUINCY_QUX_PERSON_UUID}`);
 
-		garplyLytteltonProduction = await chai.request(app)
+		garplyLytteltonProduction = await request.execute(app)
 			.get(`/productions/${GARPLY_LYTTELTON_PRODUCTION_UUID}`);
 
-		xyzzyPlayhouseProduction = await chai.request(app)
+		xyzzyPlayhouseProduction = await request.execute(app)
 			.get(`/productions/${XYZZY_PLAYHOUSE_PRODUCTION_UUID}`);
 
-		garplyMaterial = await chai.request(app)
+		garplyMaterial = await request.execute(app)
 			.get(`/materials/${GARPLY_MATERIAL_UUID}`);
 
-		xyzzyMaterial = await chai.request(app)
+		xyzzyMaterial = await request.execute(app)
 			.get(`/materials/${XYZZY_MATERIAL_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/cast-member-diff-roles-diff-prods-same-mat.test.js
+++ b/test-e2e/model-interaction/cast-member-diff-roles-diff-prods-same-mat.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -33,7 +35,7 @@ describe('Cast member performing different roles in different productions of sam
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Tragedy of King Lear',
@@ -51,7 +53,7 @@ describe('Cast member performing different roles in different productions of sam
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'King Lear',
@@ -84,7 +86,7 @@ describe('Cast member performing different roles in different productions of sam
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'King Lear',
@@ -117,25 +119,25 @@ describe('Cast member performing different roles in different productions of sam
 				]
 			});
 
-		kingLearCharacter = await chai.request(app)
+		kingLearCharacter = await request.execute(app)
 			.get(`/characters/${KING_LEAR_CHARACTER_UUID}`);
 
-		foolCharacter = await chai.request(app)
+		foolCharacter = await request.execute(app)
 			.get(`/characters/${FOOL_CHARACTER_UUID}`);
 
-		kingLearRoyalShakespeareProduction = await chai.request(app)
+		kingLearRoyalShakespeareProduction = await request.execute(app)
 			.get(`/productions/${KING_LEAR_ROYAL_SHAKESPEARE_PRODUCTION_UUID}`);
 
-		kingLearBarbicanProduction = await chai.request(app)
+		kingLearBarbicanProduction = await request.execute(app)
 			.get(`/productions/${KING_LEAR_BARBICAN_PRODUCTION_UUID}`);
 
-		michaelGambonPerson = await chai.request(app)
+		michaelGambonPerson = await request.execute(app)
 			.get(`/people/${MICHAEL_GAMBON_PERSON_UUID}`);
 
-		antonySherPerson = await chai.request(app)
+		antonySherPerson = await request.execute(app)
 			.get(`/people/${ANTONY_SHER_PERSON_UUID}`);
 
-		grahamTurnerPerson = await chai.request(app)
+		grahamTurnerPerson = await request.execute(app)
 			.get(`/people/${GRAHAM_TURNER_PERSON_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/cast-member-same-role-diff-prods-same-mat.test.js
+++ b/test-e2e/model-interaction/cast-member-same-role-diff-prods-same-mat.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -27,7 +29,7 @@ describe('Cast member performing same role in different productions of same mate
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'A Midsummer Night\'s Dream',
@@ -42,7 +44,7 @@ describe('Cast member performing same role in different productions of same mate
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'A Midsummer Night\'s Dream',
@@ -68,7 +70,7 @@ describe('Cast member performing same role in different productions of same mate
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'A Midsummer Night\'s Dream',
@@ -94,16 +96,16 @@ describe('Cast member performing same role in different productions of same mate
 				]
 			});
 
-		titaniaCharacter = await chai.request(app)
+		titaniaCharacter = await request.execute(app)
 			.get(`/characters/${TITANIA_CHARACTER_UUID}`);
 
-		aMidsummerNightsDreamRoyalShakespeareProduction = await chai.request(app)
+		aMidsummerNightsDreamRoyalShakespeareProduction = await request.execute(app)
 			.get(`/productions/${A_MIDSUMMER_NIGHTS_DREAM_ROYAL_SHAKESPEARE_PRODUCTION_UUID}`);
 
-		aMidsummerNightsDreamRoseProduction = await chai.request(app)
+		aMidsummerNightsDreamRoseProduction = await request.execute(app)
 			.get(`/productions/${A_MIDSUMMER_NIGHTS_DREAM_ROSE_PRODUCTION_UUID}`);
 
-		judiDenchPerson = await chai.request(app)
+		judiDenchPerson = await request.execute(app)
 			.get(`/people/${JUDI_DENCH_PERSON_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/cast-member-with-prods.test.js
+++ b/test-e2e/model-interaction/cast-member-with-prods.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -28,7 +30,7 @@ describe('Cast member with multiple production credits', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Greeks',
@@ -53,7 +55,7 @@ describe('Cast member with multiple production credits', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'City of Angels',
@@ -78,7 +80,7 @@ describe('Cast member with multiple production credits', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Enron',
@@ -106,16 +108,16 @@ describe('Cast member with multiple production credits', () => {
 				]
 			});
 
-		susannahFellowsPerson = await chai.request(app)
+		susannahFellowsPerson = await request.execute(app)
 			.get(`/people/${SUSANNAH_FELLOWS_PERSON_UUID}`);
 
-		theGreeksAldwychProduction = await chai.request(app)
+		theGreeksAldwychProduction = await request.execute(app)
 			.get(`/productions/${THE_GREEKS_ALDWYCH_PRODUCTION_UUID}`);
 
-		cityOfAngelsPrinceOfWalesProduction = await chai.request(app)
+		cityOfAngelsPrinceOfWalesProduction = await request.execute(app)
 			.get(`/productions/${CITY_OF_ANGELS_PRINCE_OF_WALES_PRODUCTION_UUID}`);
 
-		enronChichesterFestivalProduction = await chai.request(app)
+		enronChichesterFestivalProduction = await request.execute(app)
 			.get(`/productions/${ENRON_CHICHESTER_FESTIVAL_PRODUCTION_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/char-diff-groups-same-mat.test.js
+++ b/test-e2e/model-interaction/char-diff-groups-same-mat.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -42,7 +44,7 @@ describe('Character with multiple appearances in different character groups of t
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: '3 Winters',
@@ -88,7 +90,7 @@ describe('Character with multiple appearances in different character groups of t
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: '3 Winters',
@@ -157,40 +159,40 @@ describe('Character with multiple appearances in different character groups of t
 				]
 			});
 
-		alisaKosCharacter = await chai.request(app)
+		alisaKosCharacter = await request.execute(app)
 			.get(`/characters/${ALISA_KOS_CHARACTER_UUID}`);
 
-		mašaKosCharacter = await chai.request(app)
+		mašaKosCharacter = await request.execute(app)
 			.get(`/characters/${MAŠA_KOS_CHARACTER_UUID}`);
 
-		aleksanderKingCharacter = await chai.request(app)
+		aleksanderKingCharacter = await request.execute(app)
 			.get(`/characters/${ALEKSANDER_KING_CHARACTER_UUID}`);
 
-		roseKingCharacter = await chai.request(app)
+		roseKingCharacter = await request.execute(app)
 			.get(`/characters/${ROSE_KING_CHARACTER_UUID}`);
 
-		threeWintersMaterial = await chai.request(app)
+		threeWintersMaterial = await request.execute(app)
 			.get(`/materials/${THREE_WINTERS_MATERIAL_UUID}`);
 
-		threeWintersNationalProduction = await chai.request(app)
+		threeWintersNationalProduction = await request.execute(app)
 			.get(`/productions/${THREE_WINTERS_NATIONAL_PRODUCTION_UUID}`);
 
-		siobhanFinneranPerson = await chai.request(app)
+		siobhanFinneranPerson = await request.execute(app)
 			.get(`/people/${SIOBHAN_FINNERAN_PERSON_UUID}`);
 
-		joHerbertPerson = await chai.request(app)
+		joHerbertPerson = await request.execute(app)
 			.get(`/people/${JO_HERBERT_PERSON_UUID}`);
 
-		jamesLaurensonPerson = await chai.request(app)
+		jamesLaurensonPerson = await request.execute(app)
 			.get(`/people/${JAMES_LAURENSON_PERSON_UUID}`);
 
-		jodieMcNeePerson = await chai.request(app)
+		jodieMcNeePerson = await request.execute(app)
 			.get(`/people/${JODIE_MCNEE_PERSON_UUID}`);
 
-		alexPricePerson = await chai.request(app)
+		alexPricePerson = await request.execute(app)
 			.get(`/people/${ALEX_PRICE_PERSON_UUID}`);
 
-		bebeSandersPerson = await chai.request(app)
+		bebeSandersPerson = await request.execute(app)
 			.get(`/people/${BEBE_SANDERS_PERSON_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/char-groups-grouping.test.js
+++ b/test-e2e/model-interaction/char-groups-grouping.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -22,7 +24,7 @@ describe('Nameless character groups grouping', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Julius Caesar',
@@ -52,7 +54,7 @@ describe('Nameless character groups grouping', () => {
 				]
 			});
 
-		juliusCaesarMaterial = await chai.request(app)
+		juliusCaesarMaterial = await request.execute(app)
 			.get(`/materials/${JULIUS_CAESAR_MATERIAL_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/char-multi-appearances-same-mat.test.js
+++ b/test-e2e/model-interaction/char-multi-appearances-same-mat.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -50,7 +52,7 @@ describe('Character with multiple appearances in the same material under differe
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Rock \'n\' Roll',
@@ -84,7 +86,7 @@ describe('Character with multiple appearances in the same material under differe
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Rock \'n\' Roll',
@@ -136,7 +138,7 @@ describe('Character with multiple appearances in the same material under differe
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Handbagged',
@@ -174,7 +176,7 @@ describe('Character with multiple appearances in the same material under differe
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Handbagged',
@@ -231,40 +233,40 @@ describe('Character with multiple appearances in the same material under differe
 				]
 			});
 
-		esmeCharacter = await chai.request(app)
+		esmeCharacter = await request.execute(app)
 			.get(`/characters/${ESME_CHARACTER_UUID}`);
 
-		aliceCharacter = await chai.request(app)
+		aliceCharacter = await request.execute(app)
 			.get(`/characters/${ALICE_CHARACTER_UUID}`);
 
-		eleanorCharacter = await chai.request(app)
+		eleanorCharacter = await request.execute(app)
 			.get(`/characters/${ELEANOR_CHARACTER_UUID}`);
 
-		rockNRollMaterial = await chai.request(app)
+		rockNRollMaterial = await request.execute(app)
 			.get(`/materials/${ROCK_N_ROLL_MATERIAL_UUID}`);
 
-		rockNRollRoyalCourtProduction = await chai.request(app)
+		rockNRollRoyalCourtProduction = await request.execute(app)
 			.get(`/productions/${ROCK_N_ROLL_ROYAL_COURT_PRODUCTION_UUID}`);
 
-		aliceEvePerson = await chai.request(app)
+		aliceEvePerson = await request.execute(app)
 			.get(`/people/${ALICE_EVE_PERSON_UUID}`);
 
-		sineadCusackPerson = await chai.request(app)
+		sineadCusackPerson = await request.execute(app)
 			.get(`/people/${SINEAD_CUSACK_PERSON_UUID}`);
 
-		queenElizabethIICharacter = await chai.request(app)
+		queenElizabethIICharacter = await request.execute(app)
 			.get(`/characters/${QUEEN_ELIZABETH_II_CHARACTER_UUID}`);
 
-		handbaggedMaterial = await chai.request(app)
+		handbaggedMaterial = await request.execute(app)
 			.get(`/materials/${HANDBAGGED_MATERIAL_UUID}`);
 
-		handbaggedTricycleProduction = await chai.request(app)
+		handbaggedTricycleProduction = await request.execute(app)
 			.get(`/productions/${HANDBAGGED_TRICYCLE_PRODUCTION_UUID}`);
 
-		kikaMarkhamPerson = await chai.request(app)
+		kikaMarkhamPerson = await request.execute(app)
 			.get(`/people/${KIKA_MARKHAM_PERSON_UUID}`);
 
-		claireCoxPerson = await chai.request(app)
+		claireCoxPerson = await request.execute(app)
 			.get(`/people/${CLAIRE_COX_PERSON_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/char-multi-prods-multi-mats.test.js
+++ b/test-e2e/model-interaction/char-multi-prods-multi-mats.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -40,7 +42,7 @@ describe('Character in multiple productions of multiple materials', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Henry IV, Part 1',
@@ -57,7 +59,7 @@ describe('Character in multiple productions of multiple materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Henry IV, Part 2',
@@ -74,7 +76,7 @@ describe('Character in multiple productions of multiple materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Merry Wives of Windsor',
@@ -91,7 +93,7 @@ describe('Character in multiple productions of multiple materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Henry IV, Part 1',
@@ -116,7 +118,7 @@ describe('Character in multiple productions of multiple materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Henry IV, Part 2',
@@ -141,7 +143,7 @@ describe('Character in multiple productions of multiple materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Merry Wives of Windsor',
@@ -166,7 +168,7 @@ describe('Character in multiple productions of multiple materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Henry IV, Part 1',
@@ -191,7 +193,7 @@ describe('Character in multiple productions of multiple materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Henry IV, Part 2',
@@ -216,7 +218,7 @@ describe('Character in multiple productions of multiple materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Merry Wives of Windsor',
@@ -241,7 +243,7 @@ describe('Character in multiple productions of multiple materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Henry IV, Part 1',
@@ -266,7 +268,7 @@ describe('Character in multiple productions of multiple materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Henry IV, Part 2',
@@ -291,7 +293,7 @@ describe('Character in multiple productions of multiple materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Merry Wives of Windsor',
@@ -316,16 +318,16 @@ describe('Character in multiple productions of multiple materials', () => {
 				]
 			});
 
-		sirJohnFalstaffCharacter = await chai.request(app)
+		sirJohnFalstaffCharacter = await request.execute(app)
 			.get(`/characters/${SIR_JOHN_FALSTAFF_CHARACTER_UUID}`);
 
-		henryIVPart1Material = await chai.request(app)
+		henryIVPart1Material = await request.execute(app)
 			.get(`/materials/${HENRY_IV_PART_1_MATERIAL_UUID}`);
 
-		henryIVPart2Material = await chai.request(app)
+		henryIVPart2Material = await request.execute(app)
 			.get(`/materials/${HENRY_IV_PART_2_MATERIAL_UUID}`);
 
-		merryWivesOfWindsorMaterial = await chai.request(app)
+		merryWivesOfWindsorMaterial = await request.execute(app)
 			.get(`/materials/${THE_MERRY_WIVES_OF_WINDSOR_MATERIAL_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/char-portrayed-with-other-roles.test.js
+++ b/test-e2e/model-interaction/char-portrayed-with-other-roles.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -28,7 +30,7 @@ describe('Character portrayed with other roles', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'War Horse',
@@ -55,7 +57,7 @@ describe('Character portrayed with other roles', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'War Horse',
@@ -97,16 +99,16 @@ describe('Character portrayed with other roles', () => {
 				]
 			});
 
-		joeysMotherCharacter = await chai.request(app)
+		joeysMotherCharacter = await request.execute(app)
 			.get(`/characters/${JOEYS_MOTHER_CHARACTER_UUID}`);
 
-		drSchweykCharacter = await chai.request(app)
+		drSchweykCharacter = await request.execute(app)
 			.get(`/characters/${DR_SCHWEYK_CHARACTER_UUID}`);
 
-		cocoCharacter = await chai.request(app)
+		cocoCharacter = await request.execute(app)
 			.get(`/characters/${COCO_CHARACTER_UUID}`);
 
-		geordieCharacter = await chai.request(app)
+		geordieCharacter = await request.execute(app)
 			.get(`/characters/${GEORDIE_CHARACTER_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/char-with-variant-depiction-portrayal-names.test.js
+++ b/test-e2e/model-interaction/char-with-variant-depiction-portrayal-names.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -59,7 +61,7 @@ describe('Character with variant depiction and portrayal names', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Henry IV, Part 1',
@@ -83,7 +85,7 @@ describe('Character with variant depiction and portrayal names', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Henry IV, Part 2',
@@ -107,7 +109,7 @@ describe('Character with variant depiction and portrayal names', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Henry V',
@@ -130,7 +132,7 @@ describe('Character with variant depiction and portrayal names', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Merry Wives of Windsor',
@@ -148,7 +150,7 @@ describe('Character with variant depiction and portrayal names', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Henry IV, Part 1',
@@ -184,7 +186,7 @@ describe('Character with variant depiction and portrayal names', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Henry IV, Part 2',
@@ -221,7 +223,7 @@ describe('Character with variant depiction and portrayal names', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Henry V',
@@ -258,7 +260,7 @@ describe('Character with variant depiction and portrayal names', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Henry IV, Part 1',
@@ -295,7 +297,7 @@ describe('Character with variant depiction and portrayal names', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Henry IV, Part 2',
@@ -332,7 +334,7 @@ describe('Character with variant depiction and portrayal names', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Henry V',
@@ -369,55 +371,55 @@ describe('Character with variant depiction and portrayal names', () => {
 				]
 			});
 
-		kingHenryVCharacter = await chai.request(app)
+		kingHenryVCharacter = await request.execute(app)
 			.get(`/characters/${KING_HENRY_V_CHARACTER_UUID}`);
 
-		sirJohnFalstaffCharacter = await chai.request(app)
+		sirJohnFalstaffCharacter = await request.execute(app)
 			.get(`/characters/${SIR_JOHN_FALSTAFF_CHARACTER_UUID}`);
 
-		messengerCharacter = await chai.request(app)
+		messengerCharacter = await request.execute(app)
 			.get(`/characters/${MESSENGER_CHARACTER_UUID}`);
 
-		attendantCharacter = await chai.request(app)
+		attendantCharacter = await request.execute(app)
 			.get(`/characters/${ATTENDANT_CHARACTER_UUID}`);
 
-		soldierCharacter = await chai.request(app)
+		soldierCharacter = await request.execute(app)
 			.get(`/characters/${SOLDIER_CHARACTER_UUID}`);
 
-		henryIVPart1Material = await chai.request(app)
+		henryIVPart1Material = await request.execute(app)
 			.get(`/materials/${HENRY_IV_PART_1_MATERIAL_UUID}`);
 
-		henryIVPart2Material = await chai.request(app)
+		henryIVPart2Material = await request.execute(app)
 			.get(`/materials/${HENRY_IV_PART_2_MATERIAL_UUID}`);
 
-		henryVMaterial = await chai.request(app)
+		henryVMaterial = await request.execute(app)
 			.get(`/materials/${HENRY_V_MATERIAL_UUID}`);
 
-		henryIVPart1RoyalShakespeareProduction = await chai.request(app)
+		henryIVPart1RoyalShakespeareProduction = await request.execute(app)
 			.get(`/productions/${HENRY_IV_PART_1_ROYAL_SHAKESPEARE_PRODUCTION_UUID}`);
 
-		henryIVPart2RoyalShakespeareProduction = await chai.request(app)
+		henryIVPart2RoyalShakespeareProduction = await request.execute(app)
 			.get(`/productions/${HENRY_IV_PART_2_ROYAL_SHAKESPEARE_PRODUCTION_UUID}`);
 
-		henryVRoyalShakespeareProduction = await chai.request(app)
+		henryVRoyalShakespeareProduction = await request.execute(app)
 			.get(`/productions/${HENRY_V_ROYAL_SHAKESPEARE_PRODUCTION_UUID}`);
 
-		henryIVPart1NationalProduction = await chai.request(app)
+		henryIVPart1NationalProduction = await request.execute(app)
 			.get(`/productions/${HENRY_IV_PART_1_NATIONAL_PRODUCTION_UUID}`);
 
-		henryIVPart2NationalProduction = await chai.request(app)
+		henryIVPart2NationalProduction = await request.execute(app)
 			.get(`/productions/${HENRY_IV_PART_2_NATIONAL_PRODUCTION_UUID}`);
 
-		henryVNationalProduction = await chai.request(app)
+		henryVNationalProduction = await request.execute(app)
 			.get(`/productions/${HENRY_V_NATIONAL_PRODUCTION_UUID}`);
 
-		alexHassellPerson = await chai.request(app)
+		alexHassellPerson = await request.execute(app)
 			.get(`/people/${ALEX_HASSELL_PERSON_UUID}`);
 
-		matthewMacfadyenPerson = await chai.request(app)
+		matthewMacfadyenPerson = await request.execute(app)
 			.get(`/people/${MATTHEW_MACFADYEN_PERSON_UUID}`);
 
-		adrianLesterPerson = await chai.request(app)
+		adrianLesterPerson = await request.execute(app)
 			.get(`/people/${ADRIAN_LESTER_PERSON_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/char-with-variant-names-prods-diff-mats.test.js
+++ b/test-e2e/model-interaction/char-with-variant-names-prods-diff-mats.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -48,7 +50,7 @@ describe('Character with variant names from productions of different materials',
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Hamlet',
@@ -68,7 +70,7 @@ describe('Character with variant names from productions of different materials',
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Rosencrantz and Guildenstern Are Dead',
@@ -88,7 +90,7 @@ describe('Character with variant names from productions of different materials',
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Fortinbras',
@@ -108,7 +110,7 @@ describe('Character with variant names from productions of different materials',
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Hamletmachine',
@@ -128,7 +130,7 @@ describe('Character with variant names from productions of different materials',
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Hamlet',
@@ -163,7 +165,7 @@ describe('Character with variant names from productions of different materials',
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Rosencrantz and Guildenstern Are Dead',
@@ -198,7 +200,7 @@ describe('Character with variant names from productions of different materials',
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Fortinbras',
@@ -233,7 +235,7 @@ describe('Character with variant names from productions of different materials',
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Hamletmachine',
@@ -267,31 +269,31 @@ describe('Character with variant names from productions of different materials',
 				]
 			});
 
-		hamletCharacter = await chai.request(app)
+		hamletCharacter = await request.execute(app)
 			.get(`/characters/${HAMLET_CHARACTER_UUID}`);
 
-		hamletNationalProduction = await chai.request(app)
+		hamletNationalProduction = await request.execute(app)
 			.get(`/productions/${HAMLET_NATIONAL_PRODUCTION_UUID}`);
 
-		rosencrantzAndGuildensternAreDeadHaymarketProduction = await chai.request(app)
+		rosencrantzAndGuildensternAreDeadHaymarketProduction = await request.execute(app)
 			.get(`/productions/${ROSENCRANTZ_AND_GUILDENSTERN_ARE_DEAD_HAYMARKET_PRODUCTION_UUID}`);
 
-		fortinbrasLaJollaProduction = await chai.request(app)
+		fortinbrasLaJollaProduction = await request.execute(app)
 			.get(`/productions/${FORTINBRAS_LA_JOLLA_PRODUCTION_UUID}`);
 
-		hamletmachineTetroSanNicolòProduction = await chai.request(app)
+		hamletmachineTetroSanNicolòProduction = await request.execute(app)
 			.get(`/productions/${HAMLETMACHINE_TEATRO_SAN_NICOLÒ_PRODUCTION_UUID}`);
 
-		roryKinnearPerson = await chai.request(app)
+		roryKinnearPerson = await request.execute(app)
 			.get(`/people/${RORY_KINNEAR_PERSON_UUID}`);
 
-		jackHawkinsPerson = await chai.request(app)
+		jackHawkinsPerson = await request.execute(app)
 			.get(`/people/${JACK_HAWKINS_PERSON_UUID}`);
 
-		donReillyPerson = await chai.request(app)
+		donReillyPerson = await request.execute(app)
 			.get(`/people/${DON_REILLY_PERSON_UUID}`);
 
-		gabrieleCicirelloPerson = await chai.request(app)
+		gabrieleCicirelloPerson = await request.execute(app)
 			.get(`/people/${GABRIELE_CICIRELLO_PERSON_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/char-with-variant-names-prods-same-mat.test.js
+++ b/test-e2e/model-interaction/char-with-variant-names-prods-same-mat.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -40,7 +42,7 @@ describe('Character with variant names from productions of the same material', (
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Hamlet',
@@ -64,7 +66,7 @@ describe('Character with variant names from productions of the same material', (
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Hamlet',
@@ -103,7 +105,7 @@ describe('Character with variant names from productions of the same material', (
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Hamlet',
@@ -141,7 +143,7 @@ describe('Character with variant names from productions of the same material', (
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Hamlet',
@@ -179,25 +181,25 @@ describe('Character with variant names from productions of the same material', (
 				]
 			});
 
-		ghostCharacter = await chai.request(app)
+		ghostCharacter = await request.execute(app)
 			.get(`/characters/${GHOST_CHARACTER_UUID}`);
 
-		hamletAlmeidaProduction = await chai.request(app)
+		hamletAlmeidaProduction = await request.execute(app)
 			.get(`/productions/${HAMLET_ALMEIDA_PRODUCTION_UUID}`);
 
-		hamletNovelloProduction = await chai.request(app)
+		hamletNovelloProduction = await request.execute(app)
 			.get(`/productions/${HAMLET_NOVELLO_PRODUCTION_UUID}`);
 
-		hamletWyndhamsProduction = await chai.request(app)
+		hamletWyndhamsProduction = await request.execute(app)
 			.get(`/productions/${HAMLET_WYNDHAMS_PRODUCTION_UUID}`);
 
-		davidRintoulPerson = await chai.request(app)
+		davidRintoulPerson = await request.execute(app)
 			.get(`/people/${DAVID_RINTOUL_PERSON_UUID}`);
 
-		patrickStewartPerson = await chai.request(app)
+		patrickStewartPerson = await request.execute(app)
 			.get(`/people/${PATRICK_STEWART_PERSON_UUID}`);
 
-		peterEyrePerson = await chai.request(app)
+		peterEyrePerson = await request.execute(app)
 			.get(`/people/${PETER_EYRE_PERSON_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/chars-same-name-diff-mats.test.js
+++ b/test-e2e/model-interaction/chars-same-name-diff-mats.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -39,7 +41,7 @@ describe('Different characters with the same name from different materials', () 
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'A Midsummer Night\'s Dream',
@@ -58,7 +60,7 @@ describe('Different characters with the same name from different materials', () 
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Titus Andronicus',
@@ -77,7 +79,7 @@ describe('Different characters with the same name from different materials', () 
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'A Midsummer Night\'s Dream',
@@ -110,7 +112,7 @@ describe('Different characters with the same name from different materials', () 
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Titus Andronicus',
@@ -143,28 +145,28 @@ describe('Different characters with the same name from different materials', () 
 				]
 			});
 
-		demetriusCharacter1 = await chai.request(app)
+		demetriusCharacter1 = await request.execute(app)
 			.get(`/characters/${DEMETRIUS_CHARACTER_1_UUID}`);
 
-		demetriusCharacter2 = await chai.request(app)
+		demetriusCharacter2 = await request.execute(app)
 			.get(`/characters/${DEMETRIUS_CHARACTER_2_UUID}`);
 
-		aMidsummerNightsDreamMaterial = await chai.request(app)
+		aMidsummerNightsDreamMaterial = await request.execute(app)
 			.get(`/materials/${A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID}`);
 
-		titusAndronicusMaterial = await chai.request(app)
+		titusAndronicusMaterial = await request.execute(app)
 			.get(`/materials/${TITUS_ANDRONICUS_MATERIAL_UUID}`);
 
-		aMidsummerNightsDreamNovelloProduction = await chai.request(app)
+		aMidsummerNightsDreamNovelloProduction = await request.execute(app)
 			.get(`/productions/${A_MIDSUMMER_NIGHTS_DREAM_NOVELLO_PRODUCTION_UUID}`);
 
-		titusAndronicusGlobeProduction = await chai.request(app)
+		titusAndronicusGlobeProduction = await request.execute(app)
 			.get(`/productions/${TITUS_ANDRONICUS_GLOBE_PRODUCTION_UUID}`);
 
-		oscarPearcePerson = await chai.request(app)
+		oscarPearcePerson = await request.execute(app)
 			.get(`/people/${OSCAR_PEARCE_PERSON_UUID}`);
 
-		samAlexanderPerson = await chai.request(app)
+		samAlexanderPerson = await request.execute(app)
 			.get(`/people/${SAM_ALEXANDER_PERSON_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/chars-same-name-same-mat.test.js
+++ b/test-e2e/model-interaction/chars-same-name-same-mat.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -51,7 +53,7 @@ describe('Different characters with the same name from the same material', () =>
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Julius Caesar',
@@ -74,7 +76,7 @@ describe('Different characters with the same name from the same material', () =>
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Shakespeare\'s Romans',
@@ -96,7 +98,7 @@ describe('Different characters with the same name from the same material', () =>
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Julius Caesar',
@@ -134,7 +136,7 @@ describe('Different characters with the same name from the same material', () =>
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Julius Caesar',
@@ -171,7 +173,7 @@ describe('Different characters with the same name from the same material', () =>
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Henry VI, Part 2',
@@ -194,7 +196,7 @@ describe('Different characters with the same name from the same material', () =>
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Henry VI, Part 2',
@@ -232,46 +234,46 @@ describe('Different characters with the same name from the same material', () =>
 				]
 			});
 
-		cinnaCharacter1 = await chai.request(app)
+		cinnaCharacter1 = await request.execute(app)
 			.get(`/characters/${CINNA_CHARACTER_1_UUID}`);
 
-		cinnaCharacter2 = await chai.request(app)
+		cinnaCharacter2 = await request.execute(app)
 			.get(`/characters/${CINNA_CHARACTER_2_UUID}`);
 
-		volumniusCharacter = await chai.request(app)
+		volumniusCharacter = await request.execute(app)
 			.get(`/characters/${VOLUMNIUS_CHARACTER_UUID}`);
 
-		juliusCaesarMaterial = await chai.request(app)
+		juliusCaesarMaterial = await request.execute(app)
 			.get(`/materials/${JULIUS_CAESAR_MATERIAL_UUID}`);
 
-		juliusCaesarBarbicanProduction = await chai.request(app)
+		juliusCaesarBarbicanProduction = await request.execute(app)
 			.get(`/productions/${JULIUS_CAESAR_BARBICAN_PRODUCTION_UUID}`);
 
-		paulShearerPerson = await chai.request(app)
+		paulShearerPerson = await request.execute(app)
 			.get(`/people/${PAUL_SHEARER_PERSON_UUID}`);
 
-		leoWringerPerson = await chai.request(app)
+		leoWringerPerson = await request.execute(app)
 			.get(`/people/${LEO_WRINGER_PERSON_UUID}`);
 
-		richardPlantagenetDukeOfYorkCharacter = await chai.request(app)
+		richardPlantagenetDukeOfYorkCharacter = await request.execute(app)
 			.get(`/characters/${RICHARD_PLANTAGENET_DUKE_OF_YORK_CHARACTER_UUID}`);
 
-		richardPlantagenetCharacter = await chai.request(app)
+		richardPlantagenetCharacter = await request.execute(app)
 			.get(`/characters/${RICHARD_PLANTAGENET_CHARACTER_UUID}`);
 
-		jackCadeCharacter = await chai.request(app)
+		jackCadeCharacter = await request.execute(app)
 			.get(`/characters/${JACK_CADE_CHARACTER_UUID}`);
 
-		henryVIPart2Material = await chai.request(app)
+		henryVIPart2Material = await request.execute(app)
 			.get(`/materials/${HENRY_VI_PART_2_MATERIAL_UUID}`);
 
-		henryVIPart2CourtyardProduction = await chai.request(app)
+		henryVIPart2CourtyardProduction = await request.execute(app)
 			.get(`/productions/${HENRY_VI_PART_2_COURTYARD_PRODUCTION_UUID}`);
 
-		cliveWoodPerson = await chai.request(app)
+		cliveWoodPerson = await request.execute(app)
 			.get(`/people/${CLIVE_WOOD_PERSON_UUID}`);
 
-		jonathanSlingerPerson = await chai.request(app)
+		jonathanSlingerPerson = await request.execute(app)
 			.get(`/people/${JONATHAN_SLINGER_PERSON_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/festival-series-with-festivals.test.js
+++ b/test-e2e/model-interaction/festival-series-with-festivals.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -32,7 +34,7 @@ describe('Festival series with festivals', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/festivals')
 			.send({
 				name: '2008',
@@ -42,7 +44,7 @@ describe('Festival series with festivals', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/festivals')
 			.send({
 				name: '2009',
@@ -52,7 +54,7 @@ describe('Festival series with festivals', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/festivals')
 			.send({
 				name: '2010',
@@ -62,7 +64,7 @@ describe('Festival series with festivals', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/festivals')
 			.send({
 				name: '2008',
@@ -72,7 +74,7 @@ describe('Festival series with festivals', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/festivals')
 			.send({
 				name: '2009',
@@ -82,7 +84,7 @@ describe('Festival series with festivals', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/festivals')
 			.send({
 				name: '2010',
@@ -92,7 +94,7 @@ describe('Festival series with festivals', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/festivals')
 			.send({
 				name: '2008',
@@ -102,7 +104,7 @@ describe('Festival series with festivals', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/festivals')
 			.send({
 				name: '2009',
@@ -112,7 +114,7 @@ describe('Festival series with festivals', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/festivals')
 			.send({
 				name: '2010',
@@ -122,19 +124,19 @@ describe('Festival series with festivals', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/festivals')
 			.send({
 				name: 'The Complete Works'
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/festivals')
 			.send({
 				name: 'Globe to Globe'
 			});
 
-		edinburghInternationalFestivalFestivalSeries = await chai.request(app)
+		edinburghInternationalFestivalFestivalSeries = await request.execute(app)
 			.get(`/festival-serieses/${EDINBURGH_INTERNATIONAL_FESTIVAL_FESTIVAL_SERIES_UUID}`);
 
 	});
@@ -173,7 +175,7 @@ describe('Festival series with festivals', () => {
 
 		it('includes festival series', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/festival-serieses');
 
 			const expectedResponseBody = [
@@ -205,7 +207,7 @@ describe('Festival series with festivals', () => {
 
 		it('includes festivals and (if applicable) corresponding festival series', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/festivals');
 
 			const expectedResponseBody = [

--- a/test-e2e/model-interaction/festival-with-prods.test.js
+++ b/test-e2e/model-interaction/festival-with-prods.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -31,7 +33,7 @@ describe('Festival with multiple productions', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Antony and Cleopatra',
@@ -46,7 +48,7 @@ describe('Festival with multiple productions', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Julius Caesar',
@@ -61,7 +63,7 @@ describe('Festival with multiple productions', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Romeo and Juliet',
@@ -76,7 +78,7 @@ describe('Festival with multiple productions', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/festivals')
 			.send({
 				name: '2006',
@@ -85,7 +87,7 @@ describe('Festival with multiple productions', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Troilus and Cressida',
@@ -99,19 +101,19 @@ describe('Festival with multiple productions', () => {
 				}
 			});
 
-		theCompleteWorksFestival = await chai.request(app)
+		theCompleteWorksFestival = await request.execute(app)
 			.get(`/festivals/${THE_COMPLETE_WORKS_FESTIVAL_UUID}`);
 
-		romeoAndJulietRoyalShakespeareProduction = await chai.request(app)
+		romeoAndJulietRoyalShakespeareProduction = await request.execute(app)
 			.get(`/productions/${ROMEO_AND_JULIET_ROYAL_SHAKESPEARE_PRODUCTION_UUID}`);
 
-		antonyAndCleopatraSwanProduction = await chai.request(app)
+		antonyAndCleopatraSwanProduction = await request.execute(app)
 			.get(`/productions/${ANTONY_AND_CLEOPATRA_SWAN_PRODUCTION_UUID}`);
 
-		juliusCaesarRoyalShakespeareProduction = await chai.request(app)
+		juliusCaesarRoyalShakespeareProduction = await request.execute(app)
 			.get(`/productions/${JULIUS_CAESAR_ROYAL_SHAKESPEARE_PRODUCTION_UUID}`);
 
-		troilusAndCressidaKingsProduction = await chai.request(app)
+		troilusAndCressidaKingsProduction = await request.execute(app)
 			.get(`/productions/${TROILUS_AND_CRESSIDA_KINGS_PRODUCTION_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/mat-with-credited-entities.test.js
+++ b/test-e2e/model-interaction/mat-with-credited-entities.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -23,7 +25,7 @@ describe('Material with entities credited multiple times', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Xyzzy',
@@ -56,13 +58,13 @@ describe('Material with entities credited multiple times', () => {
 				]
 			});
 
-		material = await chai.request(app)
+		material = await request.execute(app)
 			.get(`/materials/${XYZZY_MATERIAL_UUID}`);
 
-		person = await chai.request(app)
+		person = await request.execute(app)
 			.get(`/people/${FERDINAND_FOO_PERSON_UUID}`);
 
-		company = await chai.request(app)
+		company = await request.execute(app)
 			.get(`/companies/${STAGECRAFT_LTD_COMPANY_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/mat-with-prods.test.js
+++ b/test-e2e/model-interaction/mat-with-prods.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -32,7 +34,7 @@ describe('Material with multiple productions', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Twelfth Night',
@@ -53,7 +55,7 @@ describe('Material with multiple productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Twelfth Night',
@@ -67,7 +69,7 @@ describe('Material with multiple productions', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Twelfth Night, or What You Will',
@@ -82,7 +84,7 @@ describe('Material with multiple productions', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Twelfth Night',
@@ -97,22 +99,22 @@ describe('Material with multiple productions', () => {
 				}
 			});
 
-		twelfthNightMaterial = await chai.request(app)
+		twelfthNightMaterial = await request.execute(app)
 			.get(`/materials/${TWELFTH_NIGHT_MATERIAL_UUID}`);
 
-		williamShakespearePerson = await chai.request(app)
+		williamShakespearePerson = await request.execute(app)
 			.get(`/people/${WILLIAM_SHAKESPEARE_PERSON_UUID}`);
 
-		theKingsMenCompany = await chai.request(app)
+		theKingsMenCompany = await request.execute(app)
 			.get(`/companies/${THE_KINGS_MEN_COMPANY_UUID}`);
 
-		twelfthNightGlobeProduction = await chai.request(app)
+		twelfthNightGlobeProduction = await request.execute(app)
 			.get(`/productions/${TWELFTH_NIGHT_GLOBE_PRODUCTION_UUID}`);
 
-		twelfthNightDonmarProduction = await chai.request(app)
+		twelfthNightDonmarProduction = await request.execute(app)
 			.get(`/productions/${TWELFTH_NIGHT_OR_WHAT_YOU_WILL_DONMAR_PRODUCTION_UUID}`);
 
-		twelfthNightNationalProduction = await chai.request(app)
+		twelfthNightNationalProduction = await request.execute(app)
 			.get(`/productions/${TWELFTH_NIGHT_NATIONAL_PRODUCTION_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/mat-with-rights-grantor.test.js
+++ b/test-e2e/model-interaction/mat-with-rights-grantor.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -30,7 +32,7 @@ describe('Material with rights grantor credits', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/venues')
 			.send({
 				name: 'Liverpool Everyman & Playhouse',
@@ -41,7 +43,7 @@ describe('Material with rights grantor credits', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Ladykillers',
@@ -59,7 +61,7 @@ describe('Material with rights grantor credits', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Ladykillers',
@@ -100,7 +102,7 @@ describe('Material with rights grantor credits', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Ladykillers',
@@ -115,7 +117,7 @@ describe('Material with rights grantor credits', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Ladykillers',
@@ -131,10 +133,10 @@ describe('Material with rights grantor credits', () => {
 				}
 			});
 
-		studioCanalCompany = await chai.request(app)
+		studioCanalCompany = await request.execute(app)
 			.get(`/companies/${STUDIOCANAL_COMPANY_UUID}`);
 
-		alisonMeesePerson = await chai.request(app)
+		alisonMeesePerson = await request.execute(app)
 			.get(`/people/${ALISON_MEESE_PERSON_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/mat-with-sub-mats-rights-grantor.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-mats-rights-grantor.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -41,7 +43,7 @@ describe('Material with sub-materials and rights grantor credits thereof', () =>
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/venues')
 			.send({
 				name: 'Birmingham Repertory Theatre',
@@ -52,7 +54,7 @@ describe('Material with sub-materials and rights grantor credits thereof', () =>
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Lion, the Witch and the Wardrobe',
@@ -70,7 +72,7 @@ describe('Material with sub-materials and rights grantor credits thereof', () =>
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Chronicles of Narnia',
@@ -94,7 +96,7 @@ describe('Material with sub-materials and rights grantor credits thereof', () =>
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Lion, the Witch and the Wardrobe',
@@ -135,7 +137,7 @@ describe('Material with sub-materials and rights grantor credits thereof', () =>
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Chronicles of Narnia',
@@ -169,7 +171,7 @@ describe('Material with sub-materials and rights grantor credits thereof', () =>
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Lion, the Witch and the Wardrobe',
@@ -185,7 +187,7 @@ describe('Material with sub-materials and rights grantor credits thereof', () =>
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Chronicles of Narnia',
@@ -206,7 +208,7 @@ describe('Material with sub-materials and rights grantor credits thereof', () =>
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Lion, the Witch and the Wardrobe',
@@ -222,7 +224,7 @@ describe('Material with sub-materials and rights grantor credits thereof', () =>
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Chronicles of Narnia',
@@ -243,7 +245,7 @@ describe('Material with sub-materials and rights grantor credits thereof', () =>
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Hoge',
@@ -277,7 +279,7 @@ describe('Material with sub-materials and rights grantor credits thereof', () =>
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Hoge',
@@ -291,7 +293,7 @@ describe('Material with sub-materials and rights grantor credits thereof', () =>
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Hoge',
@@ -310,16 +312,16 @@ describe('Material with sub-materials and rights grantor credits thereof', () =>
 				]
 			});
 
-		cSLewisSocietyCompany = await chai.request(app)
+		cSLewisSocietyCompany = await request.execute(app)
 			.get(`/companies/${C_S_LEWIS_SOCIETY_COMPANY_UUID}`);
 
-		sarahSeldenPerson = await chai.request(app)
+		sarahSeldenPerson = await request.execute(app)
 			.get(`/people/${SARAH_SELDEN_PERSON_UUID}`);
 
-		cinerightsLtdCompany = await chai.request(app)
+		cinerightsLtdCompany = await request.execute(app)
 			.get(`/companies/${CINERIGHTS_LTD_COMPANY_UUID}`);
 
-		talyseTataPerson = await chai.request(app)
+		talyseTataPerson = await request.execute(app)
 			.get(`/people/${TALYSE_TATA_PERSON_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/mat-with-sub-mats-source-mats.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-mats-source-mats.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -67,7 +69,7 @@ describe('Material with sub-materials and source materials thereof', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Bring Up the Bodies',
@@ -89,7 +91,7 @@ describe('Material with sub-materials and source materials thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Wolf Hall Trilogy',
@@ -117,7 +119,7 @@ describe('Material with sub-materials and source materials thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Bring Up the Bodies',
@@ -158,7 +160,7 @@ describe('Material with sub-materials and source materials thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Wolf Hall Trilogy',
@@ -196,7 +198,7 @@ describe('Material with sub-materials and source materials thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Bring Up the Bodies',
@@ -212,7 +214,7 @@ describe('Material with sub-materials and source materials thereof', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Wolf Hall Trilogy',
@@ -233,7 +235,7 @@ describe('Material with sub-materials and source materials thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Bring Up the Bodies',
@@ -249,7 +251,7 @@ describe('Material with sub-materials and source materials thereof', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Wolf Hall Trilogy',
@@ -270,7 +272,7 @@ describe('Material with sub-materials and source materials thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Life and Adventures of Nicholas Nickleby',
@@ -292,7 +294,7 @@ describe('Material with sub-materials and source materials thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Life and Adventures of Nicholas Nickleby: Part I',
@@ -324,7 +326,7 @@ describe('Material with sub-materials and source materials thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Life and Adventures of Nicholas Nickleby',
@@ -362,7 +364,7 @@ describe('Material with sub-materials and source materials thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Life and Adventures of Nicholas Nickleby: Part I',
@@ -377,7 +379,7 @@ describe('Material with sub-materials and source materials thereof', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Life and Adventures of Nicholas Nickleby',
@@ -398,7 +400,7 @@ describe('Material with sub-materials and source materials thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Waldo',
@@ -419,7 +421,7 @@ describe('Material with sub-materials and source materials thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Wibble',
@@ -449,7 +451,7 @@ describe('Material with sub-materials and source materials thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Wibble',
@@ -484,7 +486,7 @@ describe('Material with sub-materials and source materials thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Wibble',
@@ -514,7 +516,7 @@ describe('Material with sub-materials and source materials thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Wibble',
@@ -529,7 +531,7 @@ describe('Material with sub-materials and source materials thereof', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Wibble',
@@ -549,40 +551,40 @@ describe('Material with sub-materials and source materials thereof', () => {
 				]
 			});
 
-		bringUpTheBodiesNovelMaterial = await chai.request(app)
+		bringUpTheBodiesNovelMaterial = await request.execute(app)
 			.get(`/materials/${BRING_UP_THE_BODIES_NOVEL_MATERIAL_UUID}`);
 
-		bringUpTheBodiesPlayMaterial = await chai.request(app)
+		bringUpTheBodiesPlayMaterial = await request.execute(app)
 			.get(`/materials/${BRING_UP_THE_BODIES_PLAY_MATERIAL_UUID}`);
 
-		hilaryMantelPerson = await chai.request(app)
+		hilaryMantelPerson = await request.execute(app)
 			.get(`/people/${HILARY_MANTEL_PERSON_UUID}`);
 
-		mikePoultonPerson = await chai.request(app)
+		mikePoultonPerson = await request.execute(app)
 			.get(`/people/${MIKE_POULTON_PERSON_UUID}`);
 
-		theMantelGroupCompany = await chai.request(app)
+		theMantelGroupCompany = await request.execute(app)
 			.get(`/companies/${THE_MANTEL_GROUP_COMPANY_UUID}`);
 
-		royalShakespeareCompany = await chai.request(app)
+		royalShakespeareCompany = await request.execute(app)
 			.get(`/companies/${ROYAL_SHAKESPEARE_COMPANY_UUID}`);
 
-		bringUpTheBodiesSwanTheatreProduction = await chai.request(app)
+		bringUpTheBodiesSwanTheatreProduction = await request.execute(app)
 			.get(`/productions/${BRING_UP_THE_BODIES_SWAN_PRODUCTION_UUID}`);
 
-		thomasCromwellCharacter = await chai.request(app)
+		thomasCromwellCharacter = await request.execute(app)
 			.get(`/characters/${THOMAS_CROMWELL_CHARACTER_UUID}`);
 
-		theLifeAndAdventuresOfNicholasNicklebyNovelMaterial = await chai.request(app)
+		theLifeAndAdventuresOfNicholasNicklebyNovelMaterial = await request.execute(app)
 			.get(`/materials/${THE_LIFE_AND_ADVENTURES_OF_NICHOLAS_NICKLEBY_NOVEL_MATERIAL_UUID}`);
 
-		waldoMaterial = await chai.request(app)
+		waldoMaterial = await request.execute(app)
 			.get(`/materials/${WALDO_MATERIAL_UUID}`);
 
-		janeRoePerson = await chai.request(app)
+		janeRoePerson = await request.execute(app)
 			.get(`/people/${JANE_ROE_PERSON_UUID}`);
 
-		fictioneersLtdCompany = await chai.request(app)
+		fictioneersLtdCompany = await request.execute(app)
 			.get(`/companies/${FICTIONEERS_LTD_COMPANY_UUID}`);
 
 	});
@@ -1798,7 +1800,7 @@ describe('Material with sub-materials and source materials thereof', () => {
 
 		it('includes writers of the materials and their corresponding source material (with corresponding sur-material)', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/materials');
 
 			const expectedResponseBody = [

--- a/test-e2e/model-interaction/mat-with-sub-mats-subsequent-versions.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-mats-subsequent-versions.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -53,7 +55,7 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/venues')
 			.send({
 				name: 'Trafalgar Studios',
@@ -64,7 +66,7 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Agamemnon',
@@ -86,7 +88,7 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Oresteia',
@@ -114,7 +116,7 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Agamemnon',
@@ -152,7 +154,7 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Oresteia',
@@ -196,7 +198,7 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Agamemnon',
@@ -212,7 +214,7 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Oresteia',
@@ -233,7 +235,7 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Agamemnon',
@@ -249,7 +251,7 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Oresteia',
@@ -270,7 +272,7 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Ur-Plugh',
@@ -291,7 +293,7 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sub-Plugh',
@@ -328,7 +330,7 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sur-Plugh',
@@ -370,7 +372,7 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Plugh',
@@ -407,7 +409,7 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Plugh',
@@ -422,7 +424,7 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Plugh',
@@ -442,28 +444,28 @@ describe('Material with sub-materials and subsequent versions thereof', () => {
 				]
 			});
 
-		agamemnonOriginalVersionMaterial = await chai.request(app)
+		agamemnonOriginalVersionMaterial = await request.execute(app)
 			.get(`/materials/${AGAMEMNON_ORIGINAL_VERSION_MATERIAL_UUID}`);
 
-		agamemnonSubsequentVersionMaterial = await chai.request(app)
+		agamemnonSubsequentVersionMaterial = await request.execute(app)
 			.get(`/materials/${AGAMEMNON_SUBSEQUENT_VERSION_MATERIAL_UUID}`);
 
-		theOresteiaSubsequentVersionMaterial = await chai.request(app)
+		theOresteiaSubsequentVersionMaterial = await request.execute(app)
 			.get(`/materials/${THE_ORESTEIA_SUBSEQUENT_VERSION_MATERIAL_UUID}`);
 
-		aeschylusPerson = await chai.request(app)
+		aeschylusPerson = await request.execute(app)
 			.get(`/people/${AESCHYLUS_PERSON_UUID}`);
 
-		theFathersOfTragedyCompany = await chai.request(app)
+		theFathersOfTragedyCompany = await request.execute(app)
 			.get(`/companies/${THE_FATHERS_OF_TRAGEDY_COMPANY_UUID}`);
 
-		urPlughOriginalVersionMaterial = await chai.request(app)
+		urPlughOriginalVersionMaterial = await request.execute(app)
 			.get(`/materials/${UR_PLUGH_ORIGINAL_VERSION_MATERIAL_UUID}`);
 
-		francisFlobPerson = await chai.request(app)
+		francisFlobPerson = await request.execute(app)
 			.get(`/people/${FRANCIS_FLOB_PERSON_UUID}`);
 
-		curtainUpLtdCompany = await chai.request(app)
+		curtainUpLtdCompany = await request.execute(app)
 			.get(`/companies/${CURTAIN_UP_LTD_COMPANY_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/mat-with-sub-mats.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-mats.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -44,7 +46,7 @@ describe('Material with sub-materials', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Voyage',
@@ -75,7 +77,7 @@ describe('Material with sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Shipwreck',
@@ -106,7 +108,7 @@ describe('Material with sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Salvage',
@@ -137,7 +139,7 @@ describe('Material with sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Coast of Utopia',
@@ -179,7 +181,7 @@ describe('Material with sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Voyage',
@@ -194,7 +196,7 @@ describe('Material with sub-materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Coast of Utopia',
@@ -214,7 +216,7 @@ describe('Material with sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Garply',
@@ -235,7 +237,7 @@ describe('Material with sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sub-Garply',
@@ -249,7 +251,7 @@ describe('Material with sub-materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sur-Garply',
@@ -268,37 +270,37 @@ describe('Material with sub-materials', () => {
 				]
 			});
 
-		theCoastOfUtopiaMaterial = await chai.request(app)
+		theCoastOfUtopiaMaterial = await request.execute(app)
 			.get(`/materials/${THE_COAST_OF_UTOPIA_MATERIAL_UUID}`);
 
-		voyageMaterial = await chai.request(app)
+		voyageMaterial = await request.execute(app)
 			.get(`/materials/${VOYAGE_MATERIAL_UUID}`);
 
-		alexanderHerzenCharacter = await chai.request(app)
+		alexanderHerzenCharacter = await request.execute(app)
 			.get(`/characters/${ALEXANDER_HERZEN_CHARACTER_UUID}`);
 
-		ivanTurgunevCharacter = await chai.request(app)
+		ivanTurgunevCharacter = await request.execute(app)
 			.get(`/characters/${IVAN_TURGENEV_CHARACTER_UUID}`);
 
-		theCoastOfUtopiaOlivierProduction = await chai.request(app)
+		theCoastOfUtopiaOlivierProduction = await request.execute(app)
 			.get(`/productions/${THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID}`);
 
-		voyageOlivierProduction = await chai.request(app)
+		voyageOlivierProduction = await request.execute(app)
 			.get(`/productions/${VOYAGE_OLIVIER_PRODUCTION_UUID}`);
 
-		tomStoppardPerson = await chai.request(app)
+		tomStoppardPerson = await request.execute(app)
 			.get(`/people/${TOM_STOPPARD_PERSON_UUID}`);
 
-		theSträusslerGroupCompany = await chai.request(app)
+		theSträusslerGroupCompany = await request.execute(app)
 			.get(`/companies/${THE_STRÄUSSLER_GROUP_COMPANY_UUID}`);
 
-		garplyMaterial = await chai.request(app)
+		garplyMaterial = await request.execute(app)
 			.get(`/materials/${GARPLY_MATERIAL_UUID}`);
 
-		conorCorgePerson = await chai.request(app)
+		conorCorgePerson = await request.execute(app)
 			.get(`/people/${CONOR_CORGE_PERSON_UUID}`);
 
-		scribesLtdCompany = await chai.request(app)
+		scribesLtdCompany = await request.execute(app)
 			.get(`/companies/${SCRIBES_LTD_COMPANY_UUID}`);
 
 	});
@@ -1061,7 +1063,7 @@ describe('Material with sub-materials', () => {
 
 		it('includes materials and, where applicable, corresponding sur-material; will exclude sur-materials as these will be included via sub-material association', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/materials');
 
 			const expectedResponseBody = [

--- a/test-e2e/model-interaction/mat-with-sub-sub-mats-rights-grantor.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-sub-mats-rights-grantor.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -37,7 +39,7 @@ describe('Material with sub-sub-materials and rights grantor credits thereof', (
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Fellowship of the Ring',
@@ -55,7 +57,7 @@ describe('Material with sub-sub-materials and rights grantor credits thereof', (
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Lord of the Rings',
@@ -79,7 +81,7 @@ describe('Material with sub-sub-materials and rights grantor credits thereof', (
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Tolkien\'s Legendarium',
@@ -103,7 +105,7 @@ describe('Material with sub-sub-materials and rights grantor credits thereof', (
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Fellowship of the Ring',
@@ -144,7 +146,7 @@ describe('Material with sub-sub-materials and rights grantor credits thereof', (
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Lord of the Rings',
@@ -178,7 +180,7 @@ describe('Material with sub-sub-materials and rights grantor credits thereof', (
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Tolkien\'s Legendarium',
@@ -212,7 +214,7 @@ describe('Material with sub-sub-materials and rights grantor credits thereof', (
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Fellowship of the Ring',
@@ -228,7 +230,7 @@ describe('Material with sub-sub-materials and rights grantor credits thereof', (
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Lord of the Rings',
@@ -249,7 +251,7 @@ describe('Material with sub-sub-materials and rights grantor credits thereof', (
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Tolkien\'s Legendarium',
@@ -270,7 +272,7 @@ describe('Material with sub-sub-materials and rights grantor credits thereof', (
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Fellowship of the Ring',
@@ -286,7 +288,7 @@ describe('Material with sub-sub-materials and rights grantor credits thereof', (
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Lord of the Rings',
@@ -307,7 +309,7 @@ describe('Material with sub-sub-materials and rights grantor credits thereof', (
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Tolkien\'s Legendarium',
@@ -328,10 +330,10 @@ describe('Material with sub-sub-materials and rights grantor credits thereof', (
 				]
 			});
 
-		theTolkienEstateCompany = await chai.request(app)
+		theTolkienEstateCompany = await request.execute(app)
 			.get(`/companies/${THE_TOLKIEN_ESTATE_COMPANY_UUID}`);
 
-		baillieTolkienPerson = await chai.request(app)
+		baillieTolkienPerson = await request.execute(app)
 			.get(`/people/${BAILLIE_TOLKIEN_PERSON_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/mat-with-sub-sub-mats-source-mats.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-sub-mats-source-mats.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -45,7 +47,7 @@ describe('Material with sub-sub-materials and source materials thereof', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Genesis',
@@ -66,7 +68,7 @@ describe('Material with sub-sub-materials and source materials thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Old Testament',
@@ -92,7 +94,7 @@ describe('Material with sub-sub-materials and source materials thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Bible: King James Version',
@@ -118,7 +120,7 @@ describe('Material with sub-sub-materials and source materials thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Godblog',
@@ -157,7 +159,7 @@ describe('Material with sub-sub-materials and source materials thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Books of the Old Testament',
@@ -181,7 +183,7 @@ describe('Material with sub-sub-materials and source materials thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Sixty-Six Books',
@@ -205,7 +207,7 @@ describe('Material with sub-sub-materials and source materials thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Godblog',
@@ -220,7 +222,7 @@ describe('Material with sub-sub-materials and source materials thereof', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Books of the Old Testament',
@@ -240,7 +242,7 @@ describe('Material with sub-sub-materials and source materials thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sixty-Six Books',
@@ -260,7 +262,7 @@ describe('Material with sub-sub-materials and source materials thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Godblog',
@@ -275,7 +277,7 @@ describe('Material with sub-sub-materials and source materials thereof', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Books of the Old Testament',
@@ -295,7 +297,7 @@ describe('Material with sub-sub-materials and source materials thereof', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Sixty-Six Books',
@@ -315,31 +317,31 @@ describe('Material with sub-sub-materials and source materials thereof', () => {
 				]
 			});
 
-		genesisReligiousTextMaterial = await chai.request(app)
+		genesisReligiousTextMaterial = await request.execute(app)
 			.get(`/materials/${GENESIS_RELIGIOUS_TEXT_MATERIAL_UUID}`);
 
-		godblogPlayMaterial = await chai.request(app)
+		godblogPlayMaterial = await request.execute(app)
 			.get(`/materials/${GODBLOG_PLAY_MATERIAL_UUID}`);
 
-		theBooksOfTheOldTestamentPlaysMaterial = await chai.request(app)
+		theBooksOfTheOldTestamentPlaysMaterial = await request.execute(app)
 			.get(`/materials/${THE_BOOKS_OF_THE_OLD_TESTAMENT_PLAYS_MATERIAL_UUID}`);
 
-		richardBancroftPerson = await chai.request(app)
+		richardBancroftPerson = await request.execute(app)
 			.get(`/people/${RICHARD_BANCROFT_PERSON_UUID}`);
 
-		jeanetteWintersonPerson = await chai.request(app)
+		jeanetteWintersonPerson = await request.execute(app)
 			.get(`/people/${JEANETTE_WINTERSON_PERSON_UUID}`);
 
-		theCanterburyEditorsCompany = await chai.request(app)
+		theCanterburyEditorsCompany = await request.execute(app)
 			.get(`/companies/${THE_CANTERBURY_EDITORS_COMPANY_UUID}`);
 
-		onlyFruitsCompany = await chai.request(app)
+		onlyFruitsCompany = await request.execute(app)
 			.get(`/companies/${ONLY_FRUITS_COMPANY_UUID}`);
 
-		godblogBushTheatreProduction = await chai.request(app)
+		godblogBushTheatreProduction = await request.execute(app)
 			.get(`/productions/${GODBLOG_BUSH_PRODUCTION_UUID}`);
 
-		godCharacter = await chai.request(app)
+		godCharacter = await request.execute(app)
 			.get(`/characters/${GOD_CHARACTER_UUID}`);
 
 	});
@@ -1387,7 +1389,7 @@ describe('Material with sub-sub-materials and source materials thereof', () => {
 
 		it('includes writers of the materials and their corresponding source material (with corresponding sur-material)', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/materials');
 
 			const expectedResponseBody = [

--- a/test-e2e/model-interaction/mat-with-sub-sub-mats-subsequent-versions.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-sub-mats-subsequent-versions.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -42,7 +44,7 @@ describe('Material with sub-sub-materials and subsequent versions thereof', () =
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/venues')
 			.send({
 				name: 'Unicorn Theatre',
@@ -53,7 +55,7 @@ describe('Material with sub-sub-materials and subsequent versions thereof', () =
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Richard II',
@@ -75,7 +77,7 @@ describe('Material with sub-sub-materials and subsequent versions thereof', () =
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The First Henriad',
@@ -103,7 +105,7 @@ describe('Material with sub-sub-materials and subsequent versions thereof', () =
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Henriad',
@@ -131,7 +133,7 @@ describe('Material with sub-sub-materials and subsequent versions thereof', () =
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Richard II',
@@ -169,7 +171,7 @@ describe('Material with sub-sub-materials and subsequent versions thereof', () =
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The First Henriad',
@@ -213,7 +215,7 @@ describe('Material with sub-sub-materials and subsequent versions thereof', () =
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Henriad',
@@ -257,7 +259,7 @@ describe('Material with sub-sub-materials and subsequent versions thereof', () =
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Richard II',
@@ -273,7 +275,7 @@ describe('Material with sub-sub-materials and subsequent versions thereof', () =
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The First Henriad',
@@ -294,7 +296,7 @@ describe('Material with sub-sub-materials and subsequent versions thereof', () =
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Henriad',
@@ -315,7 +317,7 @@ describe('Material with sub-sub-materials and subsequent versions thereof', () =
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Richard II',
@@ -331,7 +333,7 @@ describe('Material with sub-sub-materials and subsequent versions thereof', () =
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The First Henriad',
@@ -352,7 +354,7 @@ describe('Material with sub-sub-materials and subsequent versions thereof', () =
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Henriad',
@@ -373,22 +375,22 @@ describe('Material with sub-sub-materials and subsequent versions thereof', () =
 				]
 			});
 
-		richardIIOriginalVersionMaterial = await chai.request(app)
+		richardIIOriginalVersionMaterial = await request.execute(app)
 			.get(`/materials/${RICHARD_II_ORIGINAL_VERSION_MATERIAL_UUID}`);
 
-		richardIISubsequentVersionMaterial = await chai.request(app)
+		richardIISubsequentVersionMaterial = await request.execute(app)
 			.get(`/materials/${RICHARD_II_SUBSEQUENT_VERSION_MATERIAL_UUID}`);
 
-		theFirstHenriadSubsequentVersionMaterial = await chai.request(app)
+		theFirstHenriadSubsequentVersionMaterial = await request.execute(app)
 			.get(`/materials/${THE_FIRST_HENRIAD_SUBSEQUENT_VERSION_MATERIAL_UUID}`);
 
-		theHenriadSubsequentVersionMaterial = await chai.request(app)
+		theHenriadSubsequentVersionMaterial = await request.execute(app)
 			.get(`/materials/${THE_HENRIAD_SUBSEQUENT_VERSION_MATERIAL_UUID}`);
 
-		williamShakespearePerson = await chai.request(app)
+		williamShakespearePerson = await request.execute(app)
 			.get(`/people/${WILLIAM_SHAKESPEARE_PERSON_UUID}`);
 
-		theKingsMenCompany = await chai.request(app)
+		theKingsMenCompany = await request.execute(app)
 			.get(`/companies/${THE_KINGS_MEN_COMPANY_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/mat-with-sub-sub-mats.test.js
+++ b/test-e2e/model-interaction/mat-with-sub-sub-mats.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -55,7 +57,7 @@ describe('Material with sub-sub-materials', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Bugles at the Gates of Jalalabad',
@@ -86,7 +88,7 @@ describe('Material with sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Durand\'s Line',
@@ -104,7 +106,7 @@ describe('Material with sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Campaign',
@@ -122,7 +124,7 @@ describe('Material with sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Part One — Invasions and Independence (1842-1930)',
@@ -142,7 +144,7 @@ describe('Material with sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Black Tulips',
@@ -160,7 +162,7 @@ describe('Material with sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Blood and Gifts',
@@ -178,7 +180,7 @@ describe('Material with sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Miniskirts of Kabul',
@@ -209,7 +211,7 @@ describe('Material with sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
@@ -229,7 +231,7 @@ describe('Material with sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Honey',
@@ -247,7 +249,7 @@ describe('Material with sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Night Is Darkest Before the Dawn',
@@ -278,7 +280,7 @@ describe('Material with sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'On the Side of the Angels',
@@ -296,7 +298,7 @@ describe('Material with sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Part Three — Enduring Freedom (1996-2009)',
@@ -316,7 +318,7 @@ describe('Material with sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Great Game: Afghanistan',
@@ -336,7 +338,7 @@ describe('Material with sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Bugles at the Gates of Jalalabad',
@@ -351,7 +353,7 @@ describe('Material with sub-sub-materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Part One — Invasions and Independence (1842-1930)',
@@ -371,7 +373,7 @@ describe('Material with sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Miniskirts of Kabul',
@@ -386,7 +388,7 @@ describe('Material with sub-sub-materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
@@ -406,7 +408,7 @@ describe('Material with sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Night Is Darkest Before the Dawn',
@@ -421,7 +423,7 @@ describe('Material with sub-sub-materials', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Part Three — Enduring Freedom (1996-2009)',
@@ -441,7 +443,7 @@ describe('Material with sub-sub-materials', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Great Game: Afghanistan',
@@ -467,31 +469,31 @@ describe('Material with sub-sub-materials', () => {
 				]
 			});
 
-		theGreatGameAfghanistanMaterial = await chai.request(app)
+		theGreatGameAfghanistanMaterial = await request.execute(app)
 			.get(`/materials/${THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID}`);
 
-		partOneInvasionsAndIndependenceMaterial = await chai.request(app)
+		partOneInvasionsAndIndependenceMaterial = await request.execute(app)
 			.get(`/materials/${PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID}`);
 
-		buglesAtTheGatesOfJalalabadMaterial = await chai.request(app)
+		buglesAtTheGatesOfJalalabadMaterial = await request.execute(app)
 			.get(`/materials/${BUGLES_AT_THE_GATES_OF_JALALABAD_MATERIAL_UUID}`);
 
-		barCharacter = await chai.request(app)
+		barCharacter = await request.execute(app)
 			.get(`/characters/${BAR_CHARACTER_UUID}`);
 
-		theGreatGameAfghanistanTricycleProduction = await chai.request(app)
+		theGreatGameAfghanistanTricycleProduction = await request.execute(app)
 			.get(`/productions/${THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID}`);
 
-		partOneInvasionsAndIndependenceTricycleProduction = await chai.request(app)
+		partOneInvasionsAndIndependenceTricycleProduction = await request.execute(app)
 			.get(`/productions/${PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID}`);
 
-		buglesAtTheGateOfJalalabadTricycleProduction = await chai.request(app)
+		buglesAtTheGateOfJalalabadTricycleProduction = await request.execute(app)
 			.get(`/productions/${BUGLES_AT_THE_GATES_OF_JALALABAD_TRICYCLE_PRODUCTION_UUID}`);
 
-		ferdinandFooPerson = await chai.request(app)
+		ferdinandFooPerson = await request.execute(app)
 			.get(`/people/${FERDINAND_FOO_PERSON_UUID}`);
 
-		fictioneersLtdCompany = await chai.request(app)
+		fictioneersLtdCompany = await request.execute(app)
 			.get(`/companies/${FICTIONEERS_LTD_COMPANY_UUID}`);
 
 	});
@@ -1440,7 +1442,7 @@ describe('Material with sub-sub-materials', () => {
 
 		it('includes materials with corresponding sur-material and sur-sur-materials; will exclude sur-materials and sur-sur-materials as these will be included via sub-material and sub-sub-material associations', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/materials');
 
 			const expectedResponseBody = [

--- a/test-e2e/model-interaction/mat-with-subsequent-versions.test.js
+++ b/test-e2e/model-interaction/mat-with-subsequent-versions.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -46,7 +48,7 @@ describe('Material with subsequent versions', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/venues')
 			.send({
 				name: 'Barbican Centre',
@@ -57,7 +59,7 @@ describe('Material with subsequent versions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/venues')
 			.send({
 				name: 'National Theatre',
@@ -68,7 +70,7 @@ describe('Material with subsequent versions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Peer Gynt',
@@ -99,7 +101,7 @@ describe('Material with subsequent versions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Peer Gynt',
@@ -142,7 +144,7 @@ describe('Material with subsequent versions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Peer Gynt',
@@ -200,7 +202,7 @@ describe('Material with subsequent versions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Ghosts',
@@ -222,7 +224,7 @@ describe('Material with subsequent versions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Ghosts',
@@ -271,7 +273,7 @@ describe('Material with subsequent versions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Peer Gynt',
@@ -287,7 +289,7 @@ describe('Material with subsequent versions', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Peer Gynt',
@@ -302,7 +304,7 @@ describe('Material with subsequent versions', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Ghosts',
@@ -318,28 +320,28 @@ describe('Material with subsequent versions', () => {
 				}
 			});
 
-		peerGyntOriginalVersionMaterial = await chai.request(app)
+		peerGyntOriginalVersionMaterial = await request.execute(app)
 			.get(`/materials/${PEER_GYNT_ORIGINAL_VERSION_MATERIAL_UUID}`);
 
-		peerGyntSubsequentVersion2Material = await chai.request(app)
+		peerGyntSubsequentVersion2Material = await request.execute(app)
 			.get(`/materials/${PEER_GYNT_SUBSEQUENT_VERSION_2_MATERIAL_UUID}`);
 
-		henrikIbsenPerson = await chai.request(app)
+		henrikIbsenPerson = await request.execute(app)
 			.get(`/people/${HENRIK_IBSEN_PERSON_UUID}`);
 
-		gerryBammanPerson = await chai.request(app)
+		gerryBammanPerson = await request.execute(app)
 			.get(`/people/${GERRY_BAMMAN_PERSON_UUID}`);
 
-		ibsenTheatreCompany = await chai.request(app)
+		ibsenTheatreCompany = await request.execute(app)
 			.get(`/companies/${IBSEN_THEATRE_COMPANY_UUID}`);
 
-		bammanTheatreCompany = await chai.request(app)
+		bammanTheatreCompany = await request.execute(app)
 			.get(`/companies/${BAMMAN_THEATRE_COMPANY_UUID}`);
 
-		peerGyntCharacter = await chai.request(app)
+		peerGyntCharacter = await request.execute(app)
 			.get(`/characters/${PEER_GYNT_CHARACTER_UUID}`);
 
-		peerGyntBarbicanProduction = await chai.request(app)
+		peerGyntBarbicanProduction = await request.execute(app)
 			.get(`/productions/${PEER_GYNT_BARBICAN_PRODUCTION_UUID}`);
 
 	});
@@ -1558,7 +1560,7 @@ describe('Material with subsequent versions', () => {
 
 		it('includes writers', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/materials');
 
 			const expectedResponseBody = [

--- a/test-e2e/model-interaction/mats-with-source-mat.test.js
+++ b/test-e2e/model-interaction/mats-with-source-mat.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -60,7 +62,7 @@ describe('Materials with source material', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/venues')
 			.send({
 				name: 'Royal Shakespeare Theatre',
@@ -71,7 +73,7 @@ describe('Materials with source material', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'A Midsummer Night\'s Dream',
@@ -92,7 +94,7 @@ describe('Materials with source material', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Donkey Show',
@@ -122,7 +124,7 @@ describe('Materials with source material', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Indian Boy',
@@ -161,7 +163,7 @@ describe('Materials with source material', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Shakespeare\'s Villains',
@@ -204,7 +206,7 @@ describe('Materials with source material', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'A Moorish Captain',
@@ -226,7 +228,7 @@ describe('Materials with source material', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Othello',
@@ -266,7 +268,7 @@ describe('Materials with source material', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'A Midsummer Night\'s Dream',
@@ -281,7 +283,7 @@ describe('Materials with source material', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Donkey Show',
@@ -296,7 +298,7 @@ describe('Materials with source material', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Indian Boy',
@@ -311,7 +313,7 @@ describe('Materials with source material', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Shakespeare\'s Villains',
@@ -326,7 +328,7 @@ describe('Materials with source material', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Othello',
@@ -341,52 +343,52 @@ describe('Materials with source material', () => {
 				}
 			});
 
-		aMidsummerNightsDreamMaterial = await chai.request(app)
+		aMidsummerNightsDreamMaterial = await request.execute(app)
 			.get(`/materials/${A_MIDSUMMER_NIGHTS_DREAM_MATERIAL_UUID}`);
 
-		theIndianBoyMaterial = await chai.request(app)
+		theIndianBoyMaterial = await request.execute(app)
 			.get(`/materials/${THE_INDIAN_BOY_MATERIAL_UUID}`);
 
-		shakespearesVillainsMaterial = await chai.request(app)
+		shakespearesVillainsMaterial = await request.execute(app)
 			.get(`/materials/${SHAKESPEARES_VILLAINS_MATERIAL_UUID}`);
 
-		aMoorishCaptainMaterial = await chai.request(app)
+		aMoorishCaptainMaterial = await request.execute(app)
 			.get(`/materials/${A_MOORISH_CAPTAIN_MATERIAL_UUID}`);
 
-		othelloMaterial = await chai.request(app)
+		othelloMaterial = await request.execute(app)
 			.get(`/materials/${OTHELLO_MATERIAL_UUID}`);
 
-		williamShakespearePerson = await chai.request(app)
+		williamShakespearePerson = await request.execute(app)
 			.get(`/people/${WILLIAM_SHAKESPEARE_PERSON_UUID}`);
 
-		ronaMunroPerson = await chai.request(app)
+		ronaMunroPerson = await request.execute(app)
 			.get(`/people/${RONA_MUNRO_PERSON_UUID}`);
 
-		stevenBerkoffPerson = await chai.request(app)
+		stevenBerkoffPerson = await request.execute(app)
 			.get(`/people/${STEVEN_BERKOFF_PERSON_UUID}`);
 
-		theKingsMenCompany = await chai.request(app)
+		theKingsMenCompany = await request.execute(app)
 			.get(`/companies/${THE_KINGS_MEN_COMPANY_UUID}`);
 
-		royalShakespeareCompany = await chai.request(app)
+		royalShakespeareCompany = await request.execute(app)
 			.get(`/companies/${ROYAL_SHAKESPEARE_COMPANY_UUID}`);
 
-		eastProductionsCompany = await chai.request(app)
+		eastProductionsCompany = await request.execute(app)
 			.get(`/companies/${EAST_PRODUCTIONS_COMPANY_UUID}`);
 
-		theIndianBoyRoyalShakespeareTheatreProduction = await chai.request(app)
+		theIndianBoyRoyalShakespeareTheatreProduction = await request.execute(app)
 			.get(`/productions/${THE_INDIAN_BOY_ROYAL_SHAKESPEARE_PRODUCTION_UUID}`);
 
-		shakespearesVillainsTheatreRoyalHaymarketProduction = await chai.request(app)
+		shakespearesVillainsTheatreRoyalHaymarketProduction = await request.execute(app)
 			.get(`/productions/${SHAKESPEARES_VILLAINS_THEATRE_ROYAL_HAYMARKET_PRODUCTION_UUID}`);
 
-		othelloDonmarWarehouseProduction = await chai.request(app)
+		othelloDonmarWarehouseProduction = await request.execute(app)
 			.get(`/productions/${OTHELLO_DONMAR_WAREHOUSE_PRODUCTION_UUID}`);
 
-		theIndianBoyCharacter = await chai.request(app)
+		theIndianBoyCharacter = await request.execute(app)
 			.get(`/characters/${THE_INDIAN_BOY_CHARACTER_UUID}`);
 
-		iagoCharacter = await chai.request(app)
+		iagoCharacter = await request.execute(app)
 			.get(`/characters/${IAGO_CHARACTER_UUID}`);
 
 	});
@@ -2117,7 +2119,7 @@ describe('Materials with source material', () => {
 
 		it('includes writers of the materials and their corresponding source material', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/materials');
 
 			const expectedResponseBody = [

--- a/test-e2e/model-interaction/multi-tiered-mat-prod-credit-ordering.test.js
+++ b/test-e2e/model-interaction/multi-tiered-mat-prod-credit-ordering.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -66,7 +68,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Bugles at the Gates of Jalalabad',
@@ -83,7 +85,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Durand\'s Line',
@@ -100,7 +102,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Campaign',
@@ -117,7 +119,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Part One — Invasions and Independence (1842-1930)',
@@ -145,7 +147,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Black Tulips',
@@ -162,7 +164,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Blood and Gifts',
@@ -179,7 +181,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Miniskirts of Kabul',
@@ -196,7 +198,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
@@ -224,7 +226,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Honey',
@@ -241,7 +243,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Night Is Darkest Before the Dawn',
@@ -258,7 +260,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'On the Side of the Angels',
@@ -275,7 +277,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Part Three — Enduring Freedom (1996-2009)',
@@ -303,7 +305,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Great Game: Afghanistan',
@@ -331,7 +333,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Bugles at the Gates of Jalalabad',
@@ -412,7 +414,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Durand\'s Line',
@@ -493,7 +495,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Campaign',
@@ -574,7 +576,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Part One — Invasions and Independence (1842-1930)',
@@ -666,7 +668,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Black Tulips',
@@ -747,7 +749,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Blood and Gifts',
@@ -828,7 +830,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Miniskirts of Kabul',
@@ -909,7 +911,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
@@ -1001,7 +1003,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Honey',
@@ -1082,7 +1084,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Night Is Darkest Before the Dawn',
@@ -1163,7 +1165,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'On the Side of the Angels',
@@ -1244,7 +1246,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Part Three — Enduring Freedom (1996-2009)',
@@ -1336,7 +1338,7 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Great Game: Afghanistan',
@@ -1428,37 +1430,37 @@ describe('Ordering of multi-tiered materials/productions credits', () => {
 				]
 			});
 
-		nicolasKentPerson = await chai.request(app)
+		nicolasKentPerson = await request.execute(app)
 			.get(`/people/${NICOLAS_KENT_PERSON_UUID}`);
 
-		tricycleTheatreCompany = await chai.request(app)
+		tricycleTheatreCompany = await request.execute(app)
 			.get(`/companies/${TRICYCLE_THEATRE_COMPANY_UUID}`);
 
-		zoëIngenhaagPerson = await chai.request(app)
+		zoëIngenhaagPerson = await request.execute(app)
 			.get(`/people/${ZOË_INGENHAAG_PERSON_UUID}`);
 
-		rickWardenPerson = await chai.request(app)
+		rickWardenPerson = await request.execute(app)
 			.get(`/people/${RICK_WARDEN_PERSON_UUID}`);
 
-		howardHarrisonPerson = await chai.request(app)
+		howardHarrisonPerson = await request.execute(app)
 			.get(`/people/${HOWARD_HARRISON_PERSON_UUID}`);
 
-		lightingDesignLtdCompany = await chai.request(app)
+		lightingDesignLtdCompany = await request.execute(app)
 			.get(`/companies/${LIGHTING_DESIGN_LTD_COMPANY_UUID}`);
 
-		jackKnowlesPerson = await chai.request(app)
+		jackKnowlesPerson = await request.execute(app)
 			.get(`/people/${JACK_KNOWLES_PERSON_UUID}`);
 
-		lizzieChapmanPerson = await chai.request(app)
+		lizzieChapmanPerson = await request.execute(app)
 			.get(`/people/${LIZZIE_CHAPMAN_PERSON_UUID}`);
 
-		stageManagementLtdCompany = await chai.request(app)
+		stageManagementLtdCompany = await request.execute(app)
 			.get(`/companies/${STAGE_MANAGEMENT_LTD_COMPANY_UUID}`);
 
-		charlottePadghamPerson = await chai.request(app)
+		charlottePadghamPerson = await request.execute(app)
 			.get(`/people/${CHARLOTTE_PADGHAM_PERSON_UUID}`);
 
-		barCharacter = await chai.request(app)
+		barCharacter = await request.execute(app)
 			.get(`/characters/${BAR_CHARACTER_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/prod-with-sub-prods.test.js
+++ b/test-e2e/model-interaction/prod-with-sub-prods.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -91,7 +93,7 @@ describe('Production with sub-productions', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/venues')
 			.send({
 				name: 'National Theatre',
@@ -102,7 +104,7 @@ describe('Production with sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/festivals')
 			.send({
 				name: '2002',
@@ -111,7 +113,7 @@ describe('Production with sub-productions', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Voyage',
@@ -141,7 +143,7 @@ describe('Production with sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Shipwreck',
@@ -171,7 +173,7 @@ describe('Production with sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Salvage',
@@ -201,7 +203,7 @@ describe('Production with sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Coast of Utopia',
@@ -242,7 +244,7 @@ describe('Production with sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Voyage',
@@ -342,7 +344,7 @@ describe('Production with sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Shipwreck',
@@ -442,7 +444,7 @@ describe('Production with sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Salvage',
@@ -542,7 +544,7 @@ describe('Production with sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Coast of Utopia',
@@ -653,7 +655,7 @@ describe('Production with sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Voyage',
@@ -672,7 +674,7 @@ describe('Production with sub-productions', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Shipwreck',
@@ -691,7 +693,7 @@ describe('Production with sub-productions', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Salvage',
@@ -710,7 +712,7 @@ describe('Production with sub-productions', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Coast of Utopia',
@@ -739,79 +741,79 @@ describe('Production with sub-productions', () => {
 				]
 			});
 
-		theCoastOfUtopiaOlivierProduction = await chai.request(app)
+		theCoastOfUtopiaOlivierProduction = await request.execute(app)
 			.get(`/productions/${THE_COAST_OF_UTOPIA_OLIVIER_PRODUCTION_UUID}`);
 
-		voyageOlivierProduction = await chai.request(app)
+		voyageOlivierProduction = await request.execute(app)
 			.get(`/productions/${VOYAGE_OLIVIER_PRODUCTION_UUID}`);
 
-		theCoastOfUtopiaVivianBeaumontProduction = await chai.request(app)
+		theCoastOfUtopiaVivianBeaumontProduction = await request.execute(app)
 			.get(`/productions/${THE_COAST_OF_UTOPIA_VIVIAN_BEAUMONT_PRODUCTION_UUID}`);
 
-		voyageVivianBeaumontProduction = await chai.request(app)
+		voyageVivianBeaumontProduction = await request.execute(app)
 			.get(`/productions/${VOYAGE_VIVIAN_BEAUMONT_PRODUCTION_UUID}`);
 
-		theCoastOfUtopiaMaterial = await chai.request(app)
+		theCoastOfUtopiaMaterial = await request.execute(app)
 			.get(`/materials/${THE_COAST_OF_UTOPIA_MATERIAL_UUID}`);
 
-		voyageMaterial = await chai.request(app)
+		voyageMaterial = await request.execute(app)
 			.get(`/materials/${VOYAGE_MATERIAL_UUID}`);
 
-		tomStoppardJrPerson = await chai.request(app)
+		tomStoppardJrPerson = await request.execute(app)
 			.get(`/people/${TOM_STOPPARD_JR_PERSON_UUID}`);
 
-		theSubSträusslerGroupCompany = await chai.request(app)
+		theSubSträusslerGroupCompany = await request.execute(app)
 			.get(`/companies/${THE_SUB_STRÄUSSLER_GROUP_COMPANY_UUID}`);
 
-		nationalTheatreVenue = await chai.request(app)
+		nationalTheatreVenue = await request.execute(app)
 			.get(`/venues/${NATIONAL_THEATRE_VENUE_UUID}`);
 
-		olivierTheatreVenue = await chai.request(app)
+		olivierTheatreVenue = await request.execute(app)
 			.get(`/venues/${OLIVIER_THEATRE_VENUE_UUID}`);
 
-		stoppardSeason = await chai.request(app)
+		stoppardSeason = await request.execute(app)
 			.get(`/seasons/${STOPPARD_SEASON_UUID}`);
 
-		stoppardFestival2002 = await chai.request(app)
+		stoppardFestival2002 = await request.execute(app)
 			.get(`/festivals/${STOPPARD_FESTIVAL_2002_FESTIVAL_UUID}`);
 
-		trevorNunnJrPerson = await chai.request(app)
+		trevorNunnJrPerson = await request.execute(app)
 			.get(`/people/${TREVOR_NUNN_JR_PERSON_UUID}`);
 
-		subNationalTheatreCompany = await chai.request(app)
+		subNationalTheatreCompany = await request.execute(app)
 			.get(`/companies/${SUB_NATIONAL_THEATRE_COMPANY_UUID}`);
 
-		nickStarrJrPerson = await chai.request(app)
+		nickStarrJrPerson = await request.execute(app)
 			.get(`/people/${NICK_STARR_JR_PERSON_UUID}`);
 
-		stephenDillaneJrPerson = await chai.request(app)
+		stephenDillaneJrPerson = await request.execute(app)
 			.get(`/people/${STEPHEN_DILLANE_JR_PERSON_UUID}`);
 
-		stevenEdisJrPerson = await chai.request(app)
+		stevenEdisJrPerson = await request.execute(app)
 			.get(`/people/${STEVEN_EDIS_JR_PERSON_UUID}`);
 
-		subMusicalDirectionLtdCompany = await chai.request(app)
+		subMusicalDirectionLtdCompany = await request.execute(app)
 			.get(`/companies/${SUB_MUSICAL_DIRECTION_LTD_COMPANY_UUID}`);
 
-		markBousieJrPerson = await chai.request(app)
+		markBousieJrPerson = await request.execute(app)
 			.get(`/people/${MARK_BOUSIE_JR_PERSON_UUID}`);
 
-		fionaBardsleyJrPerson = await chai.request(app)
+		fionaBardsleyJrPerson = await request.execute(app)
 			.get(`/people/${FIONA_BARDSLEY_JR_PERSON_UUID}`);
 
-		subStageManagementLtdCompany = await chai.request(app)
+		subStageManagementLtdCompany = await request.execute(app)
 			.get(`/companies/${SUB_STAGE_MANAGEMENT_LTD_COMPANY_UUID}`);
 
-		sueMillinJrPerson = await chai.request(app)
+		sueMillinJrPerson = await request.execute(app)
 			.get(`/people/${SUE_MILLIN_JR_PERSON_UUID}`);
 
-		theSubGuardianCompany = await chai.request(app)
+		theSubGuardianCompany = await request.execute(app)
 			.get(`/companies/${THE_SUB_GUARDIAN_COMPANY_UUID}`);
 
-		michaelBillingtonJrPerson = await chai.request(app)
+		michaelBillingtonJrPerson = await request.execute(app)
 			.get(`/people/${MICHAEL_BILLINGTON_JR_PERSON_UUID}`);
 
-		alexanderHerzenJrCharacter = await chai.request(app)
+		alexanderHerzenJrCharacter = await request.execute(app)
 			.get(`/characters/${ALEXANDER_HERZEN_JR_CHARACTER_UUID}`);
 
 	});
@@ -4274,7 +4276,7 @@ describe('Production with sub-productions', () => {
 
 		it('includes productions and corresponding sur-productions; will exclude sur-productions as these will be included via their sub-productions', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/productions');
 
 			const expectedResponseBody = [

--- a/test-e2e/model-interaction/prod-with-sub-sub-prods.test.js
+++ b/test-e2e/model-interaction/prod-with-sub-sub-prods.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -136,7 +138,7 @@ describe('Production with sub-sub-productions', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/venues')
 			.send({
 				name: 'Berkeley Repertory Theatre',
@@ -147,7 +149,7 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/festivals')
 			.send({
 				name: '2009',
@@ -156,7 +158,7 @@ describe('Production with sub-sub-productions', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Bugles at the Gates of Jalalabad',
@@ -186,7 +188,7 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Durand\'s Line',
@@ -216,7 +218,7 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Campaign',
@@ -246,7 +248,7 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Part One — Invasions and Independence (1842-1930)',
@@ -287,7 +289,7 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Black Tulips',
@@ -317,7 +319,7 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Blood and Gifts',
@@ -347,7 +349,7 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Miniskirts of Kabul',
@@ -377,7 +379,7 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
@@ -418,7 +420,7 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Honey',
@@ -448,7 +450,7 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Night Is Darkest Before the Dawn',
@@ -478,7 +480,7 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'On the Side of the Angels',
@@ -508,7 +510,7 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Part Three — Enduring Freedom (1996-2009)',
@@ -549,7 +551,7 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'The Great Game: Afghanistan',
@@ -590,7 +592,7 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Bugles at the Gates of Jalalabad',
@@ -690,7 +692,7 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Durand\'s Line',
@@ -790,7 +792,7 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Campaign',
@@ -890,7 +892,7 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Part One — Invasions and Independence (1842-1930)',
@@ -1001,7 +1003,7 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Black Tulips',
@@ -1101,7 +1103,7 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Blood and Gifts',
@@ -1201,7 +1203,7 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Miniskirts of Kabul',
@@ -1301,7 +1303,7 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
@@ -1412,7 +1414,7 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Honey',
@@ -1512,7 +1514,7 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Night Is Darkest Before the Dawn',
@@ -1612,7 +1614,7 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'On the Side of the Angels',
@@ -1712,7 +1714,7 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Part Three — Enduring Freedom (1996-2009)',
@@ -1823,7 +1825,7 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Great Game: Afghanistan',
@@ -1934,7 +1936,7 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Bugles at the Gates of Jalalabad',
@@ -1953,7 +1955,7 @@ describe('Production with sub-sub-productions', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Durand\'s Line',
@@ -1972,7 +1974,7 @@ describe('Production with sub-sub-productions', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Campaign',
@@ -1991,7 +1993,7 @@ describe('Production with sub-sub-productions', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Part One — Invasions and Independence (1842-1930)',
@@ -2021,7 +2023,7 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Black Tulips',
@@ -2040,7 +2042,7 @@ describe('Production with sub-sub-productions', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Blood and Gifts',
@@ -2059,7 +2061,7 @@ describe('Production with sub-sub-productions', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Miniskirts of Kabul',
@@ -2078,7 +2080,7 @@ describe('Production with sub-sub-productions', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Part Two — Communism, the Mujahideen and the Taliban (1979-1996)',
@@ -2108,7 +2110,7 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Honey',
@@ -2127,7 +2129,7 @@ describe('Production with sub-sub-productions', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Night Is Darkest Before the Dawn',
@@ -2146,7 +2148,7 @@ describe('Production with sub-sub-productions', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'On the Side of the Angels',
@@ -2165,7 +2167,7 @@ describe('Production with sub-sub-productions', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Part Three — Enduring Freedom (1996-2009)',
@@ -2195,7 +2197,7 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'The Great Game: Afghanistan',
@@ -2225,88 +2227,88 @@ describe('Production with sub-sub-productions', () => {
 				]
 			});
 
-		theGreatGameAfghanistanRodaProduction = await chai.request(app)
+		theGreatGameAfghanistanRodaProduction = await request.execute(app)
 			.get(`/productions/${THE_GREAT_GAME_AFGHANISTAN_RODA_PRODUCTION_UUID}`);
 
-		partOneInvasionsAndIndependenceRodaProduction = await chai.request(app)
+		partOneInvasionsAndIndependenceRodaProduction = await request.execute(app)
 			.get(`/productions/${PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_RODA_PRODUCTION_UUID}`);
 
-		buglesAtTheGatesOfJalalabadRodaProduction = await chai.request(app)
+		buglesAtTheGatesOfJalalabadRodaProduction = await request.execute(app)
 			.get(`/productions/${BUGLES_AT_THE_GATES_OF_JALALABAD_RODA_PRODUCTION_UUID}`);
 
-		theGreatGameAfghanistanTricycleProduction = await chai.request(app)
+		theGreatGameAfghanistanTricycleProduction = await request.execute(app)
 			.get(`/productions/${THE_GREAT_GAME_AFGHANISTAN_TRICYCLE_PRODUCTION_UUID}`);
 
-		partOneInvasionsAndIndependenceTricycleProduction = await chai.request(app)
+		partOneInvasionsAndIndependenceTricycleProduction = await request.execute(app)
 			.get(`/productions/${PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_TRICYCLE_PRODUCTION_UUID}`);
 
-		buglesAtTheGatesOfJalalabadTricycleProduction = await chai.request(app)
+		buglesAtTheGatesOfJalalabadTricycleProduction = await request.execute(app)
 			.get(`/productions/${BUGLES_AT_THE_GATES_OF_JALALABAD_TRICYCLE_PRODUCTION_UUID}`);
 
-		theGreatGameAfghanistanMaterial = await chai.request(app)
+		theGreatGameAfghanistanMaterial = await request.execute(app)
 			.get(`/materials/${THE_GREAT_GAME_AFGHANISTAN_MATERIAL_UUID}`);
 
-		partOneInvasionsAndIndependenceMaterial = await chai.request(app)
+		partOneInvasionsAndIndependenceMaterial = await request.execute(app)
 			.get(`/materials/${PART_ONE_INVASIONS_AND_INDEPENDENCE_1842_1930_MATERIAL_UUID}`);
 
-		buglesAtTheGatesOfJalalabadMaterial = await chai.request(app)
+		buglesAtTheGatesOfJalalabadMaterial = await request.execute(app)
 			.get(`/materials/${BUGLES_AT_THE_GATES_OF_JALALABAD_MATERIAL_UUID}`);
 
-		ferdinandFooJrPerson = await chai.request(app)
+		ferdinandFooJrPerson = await request.execute(app)
 			.get(`/people/${FERDINAND_FOO_JR_PERSON_UUID}`);
 
-		subInkistsLtdCompany = await chai.request(app)
+		subInkistsLtdCompany = await request.execute(app)
 			.get(`/companies/${SUB_INKISTS_LTD_COMPANY_UUID}`);
 
-		berkeleyRepertoryTheatreVenue = await chai.request(app)
+		berkeleyRepertoryTheatreVenue = await request.execute(app)
 			.get(`/venues/${BERKELEY_REPERTORY_THEATRE_VENUE_UUID}`);
 
-		rodaTheatreVenue = await chai.request(app)
+		rodaTheatreVenue = await request.execute(app)
 			.get(`/venues/${RODA_THEATRE_VENUE_UUID}`);
 
-		afghanHistorySeason = await chai.request(app)
+		afghanHistorySeason = await request.execute(app)
 			.get(`/seasons/${AFGHAN_HISTORY_SEASON_UUID}`);
 
-		afghanHistoryFestival2009 = await chai.request(app)
+		afghanHistoryFestival2009 = await request.execute(app)
 			.get(`/festivals/${AFGHAN_HISTORY_FESTIVAL_2009_FESTIVAL_UUID}`);
 
-		nicolasKentJrPerson = await chai.request(app)
+		nicolasKentJrPerson = await request.execute(app)
 			.get(`/people/${NICOLAS_KENT_JR_PERSON_UUID}`);
 
-		subTricycleTheatreCompany = await chai.request(app)
+		subTricycleTheatreCompany = await request.execute(app)
 			.get(`/companies/${SUB_TRICYCLE_THEATRE_COMPANY_UUID}`);
 
-		zoëIngenhaagJrPerson = await chai.request(app)
+		zoëIngenhaagJrPerson = await request.execute(app)
 			.get(`/people/${ZOË_INGENHAAG_JR_PERSON_UUID}`);
 
-		rickWardenJrPerson = await chai.request(app)
+		rickWardenJrPerson = await request.execute(app)
 			.get(`/people/${RICK_WARDEN_JR_PERSON_UUID}`);
 
-		howardHarrisonJrPerson = await chai.request(app)
+		howardHarrisonJrPerson = await request.execute(app)
 			.get(`/people/${HOWARD_HARRISON_JR_PERSON_UUID}`);
 
-		subLightingDesignLtdCompany = await chai.request(app)
+		subLightingDesignLtdCompany = await request.execute(app)
 			.get(`/companies/${SUB_LIGHTING_DESIGN_LTD_COMPANY_UUID}`);
 
-		jackKnowlesJrPerson = await chai.request(app)
+		jackKnowlesJrPerson = await request.execute(app)
 			.get(`/people/${JACK_KNOWLES_JR_PERSON_UUID}`);
 
-		lizzieChapmanJrPerson = await chai.request(app)
+		lizzieChapmanJrPerson = await request.execute(app)
 			.get(`/people/${LIZZIE_CHAPMAN_JR_PERSON_UUID}`);
 
-		subStageManagementLtdCompany = await chai.request(app)
+		subStageManagementLtdCompany = await request.execute(app)
 			.get(`/companies/${SUB_STAGE_MANAGEMENT_LTD_COMPANY_UUID}`);
 
-		charlottePadghamJrPerson = await chai.request(app)
+		charlottePadghamJrPerson = await request.execute(app)
 			.get(`/people/${CHARLOTTE_PADGHAM_JR_PERSON_UUID}`);
 
-		theSubGuardianCompany = await chai.request(app)
+		theSubGuardianCompany = await request.execute(app)
 			.get(`/companies/${THE_SUB_GUARDIAN_COMPANY_UUID}`);
 
-		michaelBillingtonJrPerson = await chai.request(app)
+		michaelBillingtonJrPerson = await request.execute(app)
 			.get(`/people/${MICHAEL_BILLINGTON_JR_PERSON_UUID}`);
 
-		barJrCharacter = await chai.request(app)
+		barJrCharacter = await request.execute(app)
 			.get(`/characters/${BAR_JR_CHARACTER_UUID}`);
 
 	});
@@ -14147,7 +14149,7 @@ describe('Production with sub-sub-productions', () => {
 
 		it('includes productions and corresponding sur-productions and sur-sur-productions; will exclude sur-productions as these will be included via their sub-productions', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/productions');
 
 			const expectedResponseBody = [

--- a/test-e2e/model-interaction/prods-with-creative-team.test.js
+++ b/test-e2e/model-interaction/prods-with-creative-team.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -54,7 +56,7 @@ describe('Productions with creative team', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/venues')
 			.send({
 				name: 'National Theatre',
@@ -71,7 +73,7 @@ describe('Productions with creative team', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Julius Caesar',
@@ -156,7 +158,7 @@ describe('Productions with creative team', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Mother Courage and Her Children',
@@ -246,7 +248,7 @@ describe('Productions with creative team', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Happy Days',
@@ -330,7 +332,7 @@ describe('Productions with creative team', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Richard II',
@@ -389,37 +391,37 @@ describe('Productions with creative team', () => {
 				]
 			});
 
-		juliusCaesarBarbicanProduction = await chai.request(app)
+		juliusCaesarBarbicanProduction = await request.execute(app)
 			.get(`/productions/${JULIUS_CAESAR_BARBICAN_PRODUCTION_UUID}`);
 
-		motherCourageAndHerChildrenOlivierProduction = await chai.request(app)
+		motherCourageAndHerChildrenOlivierProduction = await request.execute(app)
 			.get(`/productions/${MOTHER_COURAGE_AND_HER_CHILDREN_OLIVIER_PRODUCTION_UUID}`);
 
-		happyDaysLytteltonProduction = await chai.request(app)
+		happyDaysLytteltonProduction = await request.execute(app)
 			.get(`/productions/${HAPPY_DAYS_LYTTELTON_PRODUCTION_UUID}`);
 
-		richardIICottesloeProduction = await chai.request(app)
+		richardIICottesloeProduction = await request.execute(app)
 			.get(`/productions/${RICHARD_II_COTTESLOE_PRODUCTION_UUID}`);
 
-		deborahWarnerPerson = await chai.request(app)
+		deborahWarnerPerson = await request.execute(app)
 			.get(`/people/${DEBORAH_WARNER_PERSON_UUID}`);
 
-		ninaDunnPerson = await chai.request(app)
+		ninaDunnPerson = await request.execute(app)
 			.get(`/people/${NINA_DUNN_PERSON_UUID}`);
 
-		leoWarnerPerson = await chai.request(app)
+		leoWarnerPerson = await request.execute(app)
 			.get(`/people/${LEO_WARNER_PERSON_UUID}`);
 
-		annaJamesonPerson = await chai.request(app)
+		annaJamesonPerson = await request.execute(app)
 			.get(`/people/${ANNA_JAMESON_PERSON_UUID}`);
 
-		autographCompany = await chai.request(app)
+		autographCompany = await request.execute(app)
 			.get(`/companies/${AUTOGRAPH_COMPANY_UUID}`);
 
-		mesmerCompany = await chai.request(app)
+		mesmerCompany = await request.execute(app)
 			.get(`/companies/${MESMER_COMPANY_UUID}`);
 
-		fiftyNineProductionsCompany = await chai.request(app)
+		fiftyNineProductionsCompany = await request.execute(app)
 			.get(`/companies/${FIFTY_NINE_PRODUCTIONS_COMPANY_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/prods-with-crew.test.js
+++ b/test-e2e/model-interaction/prods-with-crew.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -54,7 +56,7 @@ describe('Productions with crew', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/venues')
 			.send({
 				name: 'National Theatre',
@@ -71,7 +73,7 @@ describe('Productions with crew', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Waste',
@@ -156,7 +158,7 @@ describe('Productions with crew', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Much Ado About Nothing',
@@ -246,7 +248,7 @@ describe('Productions with crew', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Phèdre',
@@ -330,7 +332,7 @@ describe('Productions with crew', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Pains of Youth',
@@ -389,37 +391,37 @@ describe('Productions with crew', () => {
 				]
 			});
 
-		wasteAlmeidaProduction = await chai.request(app)
+		wasteAlmeidaProduction = await request.execute(app)
 			.get(`/productions/${WASTE_ALMEIDA_PRODUCTION_UUID}`);
 
-		muchAdoAboutNothingOlivierProduction = await chai.request(app)
+		muchAdoAboutNothingOlivierProduction = await request.execute(app)
 			.get(`/productions/${MUCH_ADO_ABOUT_NOTHING_OLIVIER_PRODUCTION_UUID}`);
 
-		phèdreLytteltonProduction = await chai.request(app)
+		phèdreLytteltonProduction = await request.execute(app)
 			.get(`/productions/${PHÈDRE_LYTTELTON_PRODUCTION_UUID}`);
 
-		painsOfYouthCottesloeProduction = await chai.request(app)
+		painsOfYouthCottesloeProduction = await request.execute(app)
 			.get(`/productions/${PAINS_OF_YOUTH_COTTESLOE_PRODUCTION_UUID}`);
 
-		tariqHussainPerson = await chai.request(app)
+		tariqHussainPerson = await request.execute(app)
 			.get(`/people/${TARIQ_HUSSAIN_PERSON_UUID}`);
 
-		cassKirchnerPerson = await chai.request(app)
+		cassKirchnerPerson = await request.execute(app)
 			.get(`/people/${CASS_KIRCHNER_PERSON_UUID}`);
 
-		saraGunterPerson = await chai.request(app)
+		saraGunterPerson = await request.execute(app)
 			.get(`/people/${SARA_GUNTER_PERSON_UUID}`);
 
-		peterGregoryPerson = await chai.request(app)
+		peterGregoryPerson = await request.execute(app)
 			.get(`/people/${PETER_GREGORY_PERSON_UUID}`);
 
-		stagecraftLtdCompany = await chai.request(app)
+		stagecraftLtdCompany = await request.execute(app)
 			.get(`/companies/${STAGECRAFT_LTD_COMPANY_UUID}`);
 
-		crewDeputiesLtdCompany = await chai.request(app)
+		crewDeputiesLtdCompany = await request.execute(app)
 			.get(`/companies/${CREW_DEPUTIES_LTD_COMPANY_UUID}`);
 
-		crewAssistantsLtdCompany = await chai.request(app)
+		crewAssistantsLtdCompany = await request.execute(app)
 			.get(`/companies/${CREW_ASSISTANTS_LTD_COMPANY_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/prods-with-producers.test.js
+++ b/test-e2e/model-interaction/prods-with-producers.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -54,7 +56,7 @@ describe('Productions with producers', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/venues')
 			.send({
 				name: 'Royal Court Theatre',
@@ -71,7 +73,7 @@ describe('Productions with producers', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Hangmen',
@@ -155,7 +157,7 @@ describe('Productions with producers', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'White Pearl',
@@ -239,7 +241,7 @@ describe('Productions with producers', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Pah-La',
@@ -329,7 +331,7 @@ describe('Productions with producers', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Lights Out',
@@ -387,37 +389,37 @@ describe('Productions with producers', () => {
 				]
 			});
 
-		hangmenWyndhamsProduction = await chai.request(app)
+		hangmenWyndhamsProduction = await request.execute(app)
 			.get(`/productions/${HANGMEN_WYNDHAMS_PRODUCTION_UUID}`);
 
-		whitePearlJerwoodTheatreDownstairsProduction = await chai.request(app)
+		whitePearlJerwoodTheatreDownstairsProduction = await request.execute(app)
 			.get(`/productions/${WHITE_PEARL_JERWOOD_THEATRE_DOWNSTAIRS_PRODUCTION_UUID}`);
 
-		pahLaJerwoodTheatreUpstairsProduction = await chai.request(app)
+		pahLaJerwoodTheatreUpstairsProduction = await request.execute(app)
 			.get(`/productions/${PAH_LA_JERWOOD_THEATRE_UPSTAIRS_PRODUCTION_UUID}`);
 
-		lightsOutTheSiteProduction = await chai.request(app)
+		lightsOutTheSiteProduction = await request.execute(app)
 			.get(`/productions/${LIGHTS_OUT_THE_SITE_PRODUCTION_UUID}`);
 
-		robertFoxPerson = await chai.request(app)
+		robertFoxPerson = await request.execute(app)
 			.get(`/people/${ROBERT_FOX_PERSON_UUID}`);
 
-		ericAbrahamPerson = await chai.request(app)
+		ericAbrahamPerson = await request.execute(app)
 			.get(`/people/${ERIC_ABRAHAM_PERSON_UUID}`);
 
-		matthewByamShawPerson = await chai.request(app)
+		matthewByamShawPerson = await request.execute(app)
 			.get(`/people/${MATTHEW_BYAM_SHAW_PERSON_UUID}`);
 
-		rogerChapmanPerson = await chai.request(app)
+		rogerChapmanPerson = await request.execute(app)
 			.get(`/people/${ROGER_CHAPMAN_PERSON_UUID}`);
 
-		soniaFriedmanProductionsCompany = await chai.request(app)
+		soniaFriedmanProductionsCompany = await request.execute(app)
 			.get(`/companies/${SONIA_FRIEDMAN_PRODUCTIONS_COMPANY_UUID}`);
 
-		royalCourtTheatreCompany = await chai.request(app)
+		royalCourtTheatreCompany = await request.execute(app)
 			.get(`/companies/${ROYAL_COURT_THEATRE_COMPANY_UUID}`);
 
-		playfulProductionsCompany = await chai.request(app)
+		playfulProductionsCompany = await request.execute(app)
 			.get(`/companies/${PLAYFUL_PRODUCTIONS_COMPANY_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/prods-with-reviews.test.js
+++ b/test-e2e/model-interaction/prods-with-reviews.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -33,7 +35,7 @@ describe('Productions with reviews', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/venues')
 			.send({
 				name: 'National Theatre',
@@ -44,7 +46,7 @@ describe('Productions with reviews', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Long Day\'s Journey Into Night',
@@ -88,7 +90,7 @@ describe('Productions with reviews', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Nye',
@@ -132,7 +134,7 @@ describe('Productions with reviews', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Harry Clarke',
@@ -176,13 +178,13 @@ describe('Productions with reviews', () => {
 				]
 			});
 
-		aLongDaysJourneyIntoNightWyndhamsProduction = await chai.request(app)
+		aLongDaysJourneyIntoNightWyndhamsProduction = await request.execute(app)
 			.get(`/productions/${LONG_DAYS_JOURNEY_INTO_NIGHT_WYNDHAMS_PRODUCTION_UUID}`);
 
-		financialTimesCompany = await chai.request(app)
+		financialTimesCompany = await request.execute(app)
 			.get(`/companies/${FINANCIAL_TIMES_COMPANY_UUID}`);
 
-		sarahHemmingPerson = await chai.request(app)
+		sarahHemmingPerson = await request.execute(app)
 			.get(`/people/${SARAH_HEMMING_PERSON_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/roles-with-alternating-cast.test.js
+++ b/test-e2e/model-interaction/roles-with-alternating-cast.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -35,7 +37,7 @@ describe('Roles with alternating cast', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'True West',
@@ -53,7 +55,7 @@ describe('Roles with alternating cast', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'True West',
@@ -96,7 +98,7 @@ describe('Roles with alternating cast', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'True West',
@@ -139,28 +141,28 @@ describe('Roles with alternating cast', () => {
 				]
 			});
 
-		austinCharacter = await chai.request(app)
+		austinCharacter = await request.execute(app)
 			.get(`/characters/${AUSTIN_CHARACTER_UUID}`);
 
-		leeCharacter = await chai.request(app)
+		leeCharacter = await request.execute(app)
 			.get(`/characters/${LEE_CHARACTER_UUID}`);
 
-		trueWestCrucibleProduction = await chai.request(app)
+		trueWestCrucibleProduction = await request.execute(app)
 			.get(`/productions/${TRUE_WEST_CRUCIBLE_PRODUCTION_UUID}`);
 
-		trueWestVaudevilleProduction = await chai.request(app)
+		trueWestVaudevilleProduction = await request.execute(app)
 			.get(`/productions/${TRUE_WEST_VAUDEVILLE_PRODUCTION_UUID}`);
 
-		nigelHarmanPerson = await chai.request(app)
+		nigelHarmanPerson = await request.execute(app)
 			.get(`/people/${NIGEL_HARMAN_PERSON_UUID}`);
 
-		johnLightPerson = await chai.request(app)
+		johnLightPerson = await request.execute(app)
 			.get(`/people/${JOHN_LIGHT_PERSON_UUID}`);
 
-		kitHaringtonPerson = await chai.request(app)
+		kitHaringtonPerson = await request.execute(app)
 			.get(`/people/${KIT_HARINGTON_PERSON_UUID}`);
 
-		johnnyFlynnPerson = await chai.request(app)
+		johnnyFlynnPerson = await request.execute(app)
 			.get(`/people/${JOHNNY_FLYNN_PERSON_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/season-with-prods.test.js
+++ b/test-e2e/model-interaction/season-with-prods.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -26,7 +28,7 @@ describe('Season with multiple productions', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Seize the Day',
@@ -41,7 +43,7 @@ describe('Season with multiple productions', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Detaining Justice',
@@ -56,7 +58,7 @@ describe('Season with multiple productions', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Category B',
@@ -71,16 +73,16 @@ describe('Season with multiple productions', () => {
 				}
 			});
 
-		notBlackAndWhiteSeason = await chai.request(app)
+		notBlackAndWhiteSeason = await request.execute(app)
 			.get(`/seasons/${NOT_BLACK_AND_WHITE_SEASON_UUID}`);
 
-		categoryBTricycleProduction = await chai.request(app)
+		categoryBTricycleProduction = await request.execute(app)
 			.get(`/productions/${CATEGORY_B_TRICYCLE_PRODUCTION_UUID}`);
 
-		seizeTheDayTricycleProduction = await chai.request(app)
+		seizeTheDayTricycleProduction = await request.execute(app)
 			.get(`/productions/${SEIZE_THE_DAY_TRICYCLE_PRODUCTION_UUID}`);
 
-		detainingJusticeTricycleProduction = await chai.request(app)
+		detainingJusticeTricycleProduction = await request.execute(app)
 			.get(`/productions/${DETAINING_JUSTICE_TRICYCLE_PRODUCTION_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/venue-with-prods.test.js
+++ b/test-e2e/model-interaction/venue-with-prods.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -25,7 +27,7 @@ describe('Venue with multiple productions', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'A Streetcar Named Desire',
@@ -37,7 +39,7 @@ describe('Venue with multiple productions', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Life is a Dream',
@@ -49,7 +51,7 @@ describe('Venue with multiple productions', () => {
 				}
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Red',
@@ -61,16 +63,16 @@ describe('Venue with multiple productions', () => {
 				}
 			});
 
-		donmarWarehouseVenue = await chai.request(app)
+		donmarWarehouseVenue = await request.execute(app)
 			.get(`/venues/${DONMAR_WAREHOUSE_VENUE_UUID}`);
 
-		streetcarNamedDesireDonmarProduction = await chai.request(app)
+		streetcarNamedDesireDonmarProduction = await request.execute(app)
 			.get(`/productions/${A_STREETCAR_NAMED_DESIRE_DONMAR_PRODUCTION_UUID}`);
 
-		lifeIsADreamDonmarProduction = await chai.request(app)
+		lifeIsADreamDonmarProduction = await request.execute(app)
 			.get(`/productions/${LIFE_IS_A_DREAM_DONMAR_PRODUCTION_UUID}`);
 
-		redDonmarProduction = await chai.request(app)
+		redDonmarProduction = await request.execute(app)
 			.get(`/productions/${RED_DONMAR_PRODUCTION_UUID}`);
 
 	});

--- a/test-e2e/model-interaction/venue-with-sub-venues.test.js
+++ b/test-e2e/model-interaction/venue-with-sub-venues.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -37,7 +39,7 @@ describe('Venue with sub-venues', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/venues')
 			.send({
 				name: 'National Theatre',
@@ -54,7 +56,7 @@ describe('Venue with sub-venues', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Mother Courage and Her Children',
@@ -69,7 +71,7 @@ describe('Venue with sub-venues', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Richard II',
@@ -84,7 +86,7 @@ describe('Venue with sub-venues', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Mother Courage and Her Children',
@@ -109,7 +111,7 @@ describe('Venue with sub-venues', () => {
 				]
 			});
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/productions')
 			.send({
 				name: 'Richard II',
@@ -134,31 +136,31 @@ describe('Venue with sub-venues', () => {
 				]
 			});
 
-		nationalTheatreVenue = await chai.request(app)
+		nationalTheatreVenue = await request.execute(app)
 			.get(`/venues/${NATIONAL_THEATRE_VENUE_UUID}`);
 
-		olivierTheatreVenue = await chai.request(app)
+		olivierTheatreVenue = await request.execute(app)
 			.get(`/venues/${OLIVIER_THEATRE_VENUE_UUID}`);
 
-		motherCourageCharacter = await chai.request(app)
+		motherCourageCharacter = await request.execute(app)
 			.get(`/characters/${MOTHER_COURAGE_CHARACTER_UUID}`);
 
-		kingRichardIICharacter = await chai.request(app)
+		kingRichardIICharacter = await request.execute(app)
 			.get(`/characters/${KING_RICHARD_II_CHARACTER_UUID}`);
 
-		motherCourageAndHerChildrenMaterial = await chai.request(app)
+		motherCourageAndHerChildrenMaterial = await request.execute(app)
 			.get(`/materials/${MOTHER_COURAGE_AND_HER_CHILDREN_MATERIAL_UUID}`);
 
-		richardIIMaterial = await chai.request(app)
+		richardIIMaterial = await request.execute(app)
 			.get(`/materials/${RICHARD_II_MATERIAL_UUID}`);
 
-		motherCourageAndHerChildrenOlivierProduction = await chai.request(app)
+		motherCourageAndHerChildrenOlivierProduction = await request.execute(app)
 			.get(`/productions/${MOTHER_COURAGE_AND_HER_CHILDREN_OLIVIER_PRODUCTION_UUID}`);
 
-		richardIINationalProduction = await chai.request(app)
+		richardIINationalProduction = await request.execute(app)
 			.get(`/productions/${RICHARD_II_NATIONAL_PRODUCTION_UUID}`);
 
-		fionaShawPerson = await chai.request(app)
+		fionaShawPerson = await request.execute(app)
 			.get(`/people/${FIONA_SHAW_PERSON_UUID}`);
 
 	});
@@ -521,7 +523,7 @@ describe('Venue with sub-venues', () => {
 
 		it('includes venue and corresponding sub-venues', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/venues');
 
 			const expectedResponseBody = [
@@ -560,7 +562,7 @@ describe('Venue with sub-venues', () => {
 
 		it('includes venue and (if applicable) corresponding sur-venue', async () => {
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.get('/productions');
 
 			const expectedResponseBody = [

--- a/test-e2e/model-interaction/wri-groups-grouping.test.js
+++ b/test-e2e/model-interaction/wri-groups-grouping.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidToCountMapClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -22,7 +24,7 @@ describe('Nameless writer groups grouping', () => {
 
 		await purgeDatabase();
 
-		await chai.request(app)
+		await request.execute(app)
 			.post('/materials')
 			.send({
 				name: 'Xyzzy',
@@ -53,7 +55,7 @@ describe('Nameless writer groups grouping', () => {
 				]
 			});
 
-		material = await chai.request(app)
+		material = await request.execute(app)
 			.get(`/materials/${XYZZY_MATERIAL_UUID}`);
 
 	});

--- a/test-e2e/non-existent-instances/award-ceremonies-api.test.js
+++ b/test-e2e/non-existent-instances/award-ceremonies-api.test.js
@@ -1,8 +1,10 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -22,7 +24,7 @@ describe('Non-existent instances: Award ceremonies API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.get(`/award-ceremonies/${NON_EXISTENT_AWARD_CEREMONY_UUID}/edit`);
 
 				expect(response).to.have.status(404);
@@ -36,7 +38,7 @@ describe('Non-existent instances: Award ceremonies API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/award-ceremonies/${NON_EXISTENT_AWARD_CEREMONY_UUID}`)
 					.send({ name: '2020' });
 
@@ -51,7 +53,7 @@ describe('Non-existent instances: Award ceremonies API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.get(`/award-ceremonies/${NON_EXISTENT_AWARD_CEREMONY_UUID}`);
 
 				expect(response).to.have.status(404);
@@ -65,7 +67,7 @@ describe('Non-existent instances: Award ceremonies API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.delete(`/award-ceremonies/${NON_EXISTENT_AWARD_CEREMONY_UUID}`);
 
 				expect(response).to.have.status(404);

--- a/test-e2e/non-existent-instances/awards-api.test.js
+++ b/test-e2e/non-existent-instances/awards-api.test.js
@@ -1,8 +1,10 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -22,7 +24,7 @@ describe('Non-existent instances: Awards API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.get(`/awards/${NON_EXISTENT_AWARD_UUID}/edit`);
 
 				expect(response).to.have.status(404);
@@ -36,7 +38,7 @@ describe('Non-existent instances: Awards API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/awards/${NON_EXISTENT_AWARD_UUID}`)
 					.send({ name: 'Laurence Olivier Awards' });
 
@@ -51,7 +53,7 @@ describe('Non-existent instances: Awards API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.get(`/awards/${NON_EXISTENT_AWARD_UUID}`);
 
 				expect(response).to.have.status(404);
@@ -65,7 +67,7 @@ describe('Non-existent instances: Awards API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.delete(`/awards/${NON_EXISTENT_AWARD_UUID}`);
 
 				expect(response).to.have.status(404);

--- a/test-e2e/non-existent-instances/characters-api.test.js
+++ b/test-e2e/non-existent-instances/characters-api.test.js
@@ -1,8 +1,10 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -22,7 +24,7 @@ describe('Non-existent instances: Characters API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.get(`/characters/${NON_EXISTENT_CHARACTER_UUID}/edit`);
 
 				expect(response).to.have.status(404);
@@ -36,7 +38,7 @@ describe('Non-existent instances: Characters API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/characters/${NON_EXISTENT_CHARACTER_UUID}`)
 					.send({ name: 'Juliet' });
 
@@ -51,7 +53,7 @@ describe('Non-existent instances: Characters API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.get(`/characters/${NON_EXISTENT_CHARACTER_UUID}`);
 
 				expect(response).to.have.status(404);
@@ -65,7 +67,7 @@ describe('Non-existent instances: Characters API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.delete(`/characters/${NON_EXISTENT_CHARACTER_UUID}`);
 
 				expect(response).to.have.status(404);

--- a/test-e2e/non-existent-instances/companies-api.test.js
+++ b/test-e2e/non-existent-instances/companies-api.test.js
@@ -1,8 +1,10 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -22,7 +24,7 @@ describe('Non-existent instances: Companies API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.get(`/companies/${NON_EXISTENT_COMPANY_UUID}/edit`);
 
 				expect(response).to.have.status(404);
@@ -36,7 +38,7 @@ describe('Non-existent instances: Companies API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/companies/${NON_EXISTENT_COMPANY_UUID}`)
 					.send({ name: 'Royal Shakespeare Company' });
 
@@ -51,7 +53,7 @@ describe('Non-existent instances: Companies API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.get(`/companies/${NON_EXISTENT_COMPANY_UUID}`);
 
 				expect(response).to.have.status(404);
@@ -65,7 +67,7 @@ describe('Non-existent instances: Companies API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.delete(`/companies/${NON_EXISTENT_COMPANY_UUID}`);
 
 				expect(response).to.have.status(404);

--- a/test-e2e/non-existent-instances/festival-serieses-api.test.js
+++ b/test-e2e/non-existent-instances/festival-serieses-api.test.js
@@ -1,8 +1,10 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -22,7 +24,7 @@ describe('Non-existent instances: Festival Serieses API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.get(`/festival-serieses/${NON_EXISTENT_FESTIVAL_SERIES_UUID}/edit`);
 
 				expect(response).to.have.status(404);
@@ -36,7 +38,7 @@ describe('Non-existent instances: Festival Serieses API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/festival-serieses/${NON_EXISTENT_FESTIVAL_SERIES_UUID}`)
 					.send({ name: 'Edinburgh International Festival' });
 
@@ -51,7 +53,7 @@ describe('Non-existent instances: Festival Serieses API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.get(`/festival-serieses/${NON_EXISTENT_FESTIVAL_SERIES_UUID}`);
 
 				expect(response).to.have.status(404);
@@ -65,7 +67,7 @@ describe('Non-existent instances: Festival Serieses API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.delete(`/festival-serieses/${NON_EXISTENT_FESTIVAL_SERIES_UUID}`);
 
 				expect(response).to.have.status(404);

--- a/test-e2e/non-existent-instances/festivals-api.test.js
+++ b/test-e2e/non-existent-instances/festivals-api.test.js
@@ -1,8 +1,10 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -22,7 +24,7 @@ describe('Non-existent instances: Festivals API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.get(`/festivals/${NON_EXISTENT_FESTIVAL_UUID}/edit`);
 
 				expect(response).to.have.status(404);
@@ -36,7 +38,7 @@ describe('Non-existent instances: Festivals API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/festivals/${NON_EXISTENT_FESTIVAL_UUID}`)
 					.send({ name: 'The Complete Works' });
 
@@ -51,7 +53,7 @@ describe('Non-existent instances: Festivals API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.get(`/festivals/${NON_EXISTENT_FESTIVAL_UUID}`);
 
 				expect(response).to.have.status(404);
@@ -65,7 +67,7 @@ describe('Non-existent instances: Festivals API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.delete(`/festivals/${NON_EXISTENT_FESTIVAL_UUID}`);
 
 				expect(response).to.have.status(404);

--- a/test-e2e/non-existent-instances/materials-api.test.js
+++ b/test-e2e/non-existent-instances/materials-api.test.js
@@ -1,8 +1,10 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -22,7 +24,7 @@ describe('Non-existent instances: Materials API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.get(`/materials/${NON_EXISTENT_MATERIAL_UUID}/edit`);
 
 				expect(response).to.have.status(404);
@@ -36,7 +38,7 @@ describe('Non-existent instances: Materials API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/materials/${NON_EXISTENT_MATERIAL_UUID}`)
 					.send({ name: 'The Cherry Orchard' });
 
@@ -51,7 +53,7 @@ describe('Non-existent instances: Materials API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.get(`/materials/${NON_EXISTENT_MATERIAL_UUID}`);
 
 				expect(response).to.have.status(404);
@@ -65,7 +67,7 @@ describe('Non-existent instances: Materials API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.delete(`/materials/${NON_EXISTENT_MATERIAL_UUID}`);
 
 				expect(response).to.have.status(404);

--- a/test-e2e/non-existent-instances/people-api.test.js
+++ b/test-e2e/non-existent-instances/people-api.test.js
@@ -1,8 +1,10 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -22,7 +24,7 @@ describe('Non-existent instances: People API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.get(`/people/${NON_EXISTENT_PERSON_UUID}/edit`);
 
 				expect(response).to.have.status(404);
@@ -36,7 +38,7 @@ describe('Non-existent instances: People API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/people/${NON_EXISTENT_PERSON_UUID}`)
 					.send({ name: 'Patrick Stewart' });
 
@@ -51,7 +53,7 @@ describe('Non-existent instances: People API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.get(`/people/${NON_EXISTENT_PERSON_UUID}`);
 
 				expect(response).to.have.status(404);
@@ -65,7 +67,7 @@ describe('Non-existent instances: People API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.delete(`/people/${NON_EXISTENT_PERSON_UUID}`);
 
 				expect(response).to.have.status(404);

--- a/test-e2e/non-existent-instances/productions-api.test.js
+++ b/test-e2e/non-existent-instances/productions-api.test.js
@@ -1,8 +1,10 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -22,7 +24,7 @@ describe('Non-existent instances: Productions API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.get(`/productions/${NON_EXISTENT_PRODUCTION_UUID}/edit`);
 
 				expect(response).to.have.status(404);
@@ -36,7 +38,7 @@ describe('Non-existent instances: Productions API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/productions/${NON_EXISTENT_PRODUCTION_UUID}`)
 					.send({
 						name: 'The Tempest'
@@ -53,7 +55,7 @@ describe('Non-existent instances: Productions API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.get(`/productions/${NON_EXISTENT_PRODUCTION_UUID}`);
 
 				expect(response).to.have.status(404);
@@ -67,7 +69,7 @@ describe('Non-existent instances: Productions API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.delete(`/productions/${NON_EXISTENT_PRODUCTION_UUID}`);
 
 				expect(response).to.have.status(404);

--- a/test-e2e/non-existent-instances/seasons-api.test.js
+++ b/test-e2e/non-existent-instances/seasons-api.test.js
@@ -1,8 +1,10 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -22,7 +24,7 @@ describe('Non-existent instances: Seasons API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.get(`/seasons/${NON_EXISTENT_SEASON_UUID}/edit`);
 
 				expect(response).to.have.status(404);
@@ -36,7 +38,7 @@ describe('Non-existent instances: Seasons API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/seasons/${NON_EXISTENT_SEASON_UUID}`)
 					.send({ name: 'Not Black and White' });
 
@@ -51,7 +53,7 @@ describe('Non-existent instances: Seasons API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.get(`/seasons/${NON_EXISTENT_SEASON_UUID}`);
 
 				expect(response).to.have.status(404);
@@ -65,7 +67,7 @@ describe('Non-existent instances: Seasons API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.delete(`/seasons/${NON_EXISTENT_SEASON_UUID}`);
 
 				expect(response).to.have.status(404);

--- a/test-e2e/non-existent-instances/venues-api.test.js
+++ b/test-e2e/non-existent-instances/venues-api.test.js
@@ -1,8 +1,10 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { purgeDatabase } from '../test-helpers/neo4j/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -22,7 +24,7 @@ describe('Non-existent instances: Venues API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.get(`/venues/${NON_EXISTENT_VENUE_UUID}/edit`);
 
 				expect(response).to.have.status(404);
@@ -36,7 +38,7 @@ describe('Non-existent instances: Venues API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.put(`/venues/${NON_EXISTENT_VENUE_UUID}`)
 					.send({ name: 'Almeida Theatre' });
 
@@ -51,7 +53,7 @@ describe('Non-existent instances: Venues API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.get(`/venues/${NON_EXISTENT_VENUE_UUID}`);
 
 				expect(response).to.have.status(404);
@@ -65,7 +67,7 @@ describe('Non-existent instances: Venues API', () => {
 
 			it('responds with 404 Not Found error', async () => {
 
-				const response = await chai.request(app)
+				const response = await request.execute(app)
 					.delete(`/venues/${NON_EXISTENT_VENUE_UUID}`);
 
 				expect(response).to.have.status(404);

--- a/test-e2e/uniqueness-in-db/award-ceremonies-api.test.js
+++ b/test-e2e/uniqueness-in-db/award-ceremonies-api.test.js
@@ -1,8 +1,10 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { countNodesWithLabel, createNode, purgeDatabase } from '../test-helpers/neo4j/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -42,7 +44,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 
 			expect(await countNodesWithLabel('Award')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2020',
@@ -61,7 +63,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 
 			expect(await countNodesWithLabel('Award')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2020',
@@ -81,7 +83,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 
 			expect(await countNodesWithLabel('Award')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2020',
@@ -100,7 +102,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 
 			expect(await countNodesWithLabel('Award')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TWENTY_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2020',
@@ -152,7 +154,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2010',
@@ -182,7 +184,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2010',
@@ -213,7 +215,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2010',
@@ -243,7 +245,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2010',
@@ -322,7 +324,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 
 			expect(await countNodesWithLabel('Company')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2010',
@@ -353,7 +355,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 
 			expect(await countNodesWithLabel('Company')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2010',
@@ -385,7 +387,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 
 			expect(await countNodesWithLabel('Company')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2010',
@@ -416,7 +418,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 
 			expect(await countNodesWithLabel('Company')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2010',
@@ -480,7 +482,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2010',
@@ -516,7 +518,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2010',
@@ -553,7 +555,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2010',
@@ -589,7 +591,7 @@ describe('Uniqueness in database: Award ceremonies API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/award-ceremonies/${TWO_THOUSAND_AND_TEN_AWARD_CEREMONY_UUID}`)
 				.send({
 					name: '2010',

--- a/test-e2e/uniqueness-in-db/awards-api.test.js
+++ b/test-e2e/uniqueness-in-db/awards-api.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { countNodesWithLabel, purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidCounterClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -30,7 +32,7 @@ describe('Uniqueness in database: Awards API', () => {
 
 		expect(await countNodesWithLabel('Award')).to.equal(0);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.post('/awards')
 			.send({
 				name: 'Critics\' Circle Theatre Awards'
@@ -54,7 +56,7 @@ describe('Uniqueness in database: Awards API', () => {
 
 		expect(await countNodesWithLabel('Award')).to.equal(1);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.post('/awards')
 			.send({
 				name: 'Critics\' Circle Theatre Awards'
@@ -85,7 +87,7 @@ describe('Uniqueness in database: Awards API', () => {
 
 		expect(await countNodesWithLabel('Award')).to.equal(1);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.post('/awards')
 			.send({
 				name: 'Critics\' Circle Theatre Awards',
@@ -110,7 +112,7 @@ describe('Uniqueness in database: Awards API', () => {
 
 		expect(await countNodesWithLabel('Award')).to.equal(2);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.put(`/awards/${AWARD_1_UUID}`)
 			.send({
 				name: 'Critics\' Circle Theatre Awards',
@@ -143,7 +145,7 @@ describe('Uniqueness in database: Awards API', () => {
 
 		expect(await countNodesWithLabel('Award')).to.equal(2);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.put(`/awards/${AWARD_1_UUID}`)
 			.send({
 				name: 'Critics\' Circle Theatre Awards',
@@ -168,7 +170,7 @@ describe('Uniqueness in database: Awards API', () => {
 
 		expect(await countNodesWithLabel('Award')).to.equal(2);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.put(`/awards/${AWARD_2_UUID}`)
 			.send({
 				name: 'Critics\' Circle Theatre Awards'

--- a/test-e2e/uniqueness-in-db/characters-api.test.js
+++ b/test-e2e/uniqueness-in-db/characters-api.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { countNodesWithLabel, purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidCounterClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -30,7 +32,7 @@ describe('Uniqueness in database: Characters API', () => {
 
 		expect(await countNodesWithLabel('Character')).to.equal(0);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.post('/characters')
 			.send({
 				name: 'Demetrius'
@@ -54,7 +56,7 @@ describe('Uniqueness in database: Characters API', () => {
 
 		expect(await countNodesWithLabel('Character')).to.equal(1);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.post('/characters')
 			.send({
 				name: 'Demetrius'
@@ -85,7 +87,7 @@ describe('Uniqueness in database: Characters API', () => {
 
 		expect(await countNodesWithLabel('Character')).to.equal(1);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.post('/characters')
 			.send({
 				name: 'Demetrius',
@@ -110,7 +112,7 @@ describe('Uniqueness in database: Characters API', () => {
 
 		expect(await countNodesWithLabel('Character')).to.equal(2);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.put(`/characters/${CHARACTER_1_UUID}`)
 			.send({
 				name: 'Demetrius',
@@ -143,7 +145,7 @@ describe('Uniqueness in database: Characters API', () => {
 
 		expect(await countNodesWithLabel('Character')).to.equal(2);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.put(`/characters/${CHARACTER_1_UUID}`)
 			.send({
 				name: 'Demetrius',
@@ -168,7 +170,7 @@ describe('Uniqueness in database: Characters API', () => {
 
 		expect(await countNodesWithLabel('Character')).to.equal(2);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.put(`/characters/${CHARACTER_2_UUID}`)
 			.send({
 				name: 'Demetrius'

--- a/test-e2e/uniqueness-in-db/companies-api.test.js
+++ b/test-e2e/uniqueness-in-db/companies-api.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { countNodesWithLabel, purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidCounterClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -30,7 +32,7 @@ describe('Uniqueness in database: Companies API', () => {
 
 		expect(await countNodesWithLabel('Company')).to.equal(0);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.post('/companies')
 			.send({
 				name: 'Gate Theatre Company'
@@ -54,7 +56,7 @@ describe('Uniqueness in database: Companies API', () => {
 
 		expect(await countNodesWithLabel('Company')).to.equal(1);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.post('/companies')
 			.send({
 				name: 'Gate Theatre Company'
@@ -85,7 +87,7 @@ describe('Uniqueness in database: Companies API', () => {
 
 		expect(await countNodesWithLabel('Company')).to.equal(1);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.post('/companies')
 			.send({
 				name: 'Gate Theatre Company',
@@ -110,7 +112,7 @@ describe('Uniqueness in database: Companies API', () => {
 
 		expect(await countNodesWithLabel('Company')).to.equal(2);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.put(`/companies/${COMPANY_1_UUID}`)
 			.send({
 				name: 'Gate Theatre Company',
@@ -143,7 +145,7 @@ describe('Uniqueness in database: Companies API', () => {
 
 		expect(await countNodesWithLabel('Company')).to.equal(2);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.put(`/companies/${COMPANY_1_UUID}`)
 			.send({
 				name: 'Gate Theatre Company',
@@ -168,7 +170,7 @@ describe('Uniqueness in database: Companies API', () => {
 
 		expect(await countNodesWithLabel('Company')).to.equal(2);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.put(`/companies/${COMPANY_2_UUID}`)
 			.send({
 				name: 'Gate Theatre Company'

--- a/test-e2e/uniqueness-in-db/festival-serieses-api.test.js
+++ b/test-e2e/uniqueness-in-db/festival-serieses-api.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { countNodesWithLabel, purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidCounterClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -30,7 +32,7 @@ describe('Uniqueness in database: Festival Serieses API', () => {
 
 		expect(await countNodesWithLabel('FestivalSeries')).to.equal(0);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.post('/festival-serieses')
 			.send({
 				name: 'Connections'
@@ -54,7 +56,7 @@ describe('Uniqueness in database: Festival Serieses API', () => {
 
 		expect(await countNodesWithLabel('FestivalSeries')).to.equal(1);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.post('/festival-serieses')
 			.send({
 				name: 'Connections'
@@ -85,7 +87,7 @@ describe('Uniqueness in database: Festival Serieses API', () => {
 
 		expect(await countNodesWithLabel('FestivalSeries')).to.equal(1);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.post('/festival-serieses')
 			.send({
 				name: 'Connections',
@@ -110,7 +112,7 @@ describe('Uniqueness in database: Festival Serieses API', () => {
 
 		expect(await countNodesWithLabel('FestivalSeries')).to.equal(2);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.put(`/festival-serieses/${FESTIVAL_SERIES_1_UUID}`)
 			.send({
 				name: 'Connections',
@@ -143,7 +145,7 @@ describe('Uniqueness in database: Festival Serieses API', () => {
 
 		expect(await countNodesWithLabel('FestivalSeries')).to.equal(2);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.put(`/festival-serieses/${FESTIVAL_SERIES_1_UUID}`)
 			.send({
 				name: 'Connections',
@@ -168,7 +170,7 @@ describe('Uniqueness in database: Festival Serieses API', () => {
 
 		expect(await countNodesWithLabel('FestivalSeries')).to.equal(2);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.put(`/festival-serieses/${FESTIVAL_SERIES_2_UUID}`)
 			.send({
 				name: 'Connections'

--- a/test-e2e/uniqueness-in-db/festivals-api.test.js
+++ b/test-e2e/uniqueness-in-db/festivals-api.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { countNodesWithLabel, createNode, purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidCounterClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -32,7 +34,7 @@ describe('Uniqueness in database: Festivals API', () => {
 
 			expect(await countNodesWithLabel('Festival')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.post('/festivals')
 				.send({
 					name: 'Globe to Globe'
@@ -62,7 +64,7 @@ describe('Uniqueness in database: Festivals API', () => {
 
 			expect(await countNodesWithLabel('Festival')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.post('/festivals')
 				.send({
 					name: 'Globe to Globe'
@@ -99,7 +101,7 @@ describe('Uniqueness in database: Festivals API', () => {
 
 			expect(await countNodesWithLabel('Festival')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.post('/festivals')
 				.send({
 					name: 'Globe to Globe',
@@ -130,7 +132,7 @@ describe('Uniqueness in database: Festivals API', () => {
 
 			expect(await countNodesWithLabel('Festival')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/festivals/${FESTIVAL_1_UUID}`)
 				.send({
 					name: 'Globe to Globe',
@@ -169,7 +171,7 @@ describe('Uniqueness in database: Festivals API', () => {
 
 			expect(await countNodesWithLabel('Festival')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/festivals/${FESTIVAL_1_UUID}`)
 				.send({
 					name: 'Globe to Globe',
@@ -200,7 +202,7 @@ describe('Uniqueness in database: Festivals API', () => {
 
 			expect(await countNodesWithLabel('Festival')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/festivals/${FESTIVAL_2_UUID}`)
 				.send({
 					name: 'Globe to Globe'
@@ -262,7 +264,7 @@ describe('Uniqueness in database: Festivals API', () => {
 
 			expect(await countNodesWithLabel('FestivalSeries')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/festivals/${TWO_THOUSAND_AND_EIGHT_FESTIVAL_UUID}`)
 				.send({
 					name: '2008',
@@ -281,7 +283,7 @@ describe('Uniqueness in database: Festivals API', () => {
 
 			expect(await countNodesWithLabel('FestivalSeries')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/festivals/${TWO_THOUSAND_AND_EIGHT_FESTIVAL_UUID}`)
 				.send({
 					name: '2008',
@@ -301,7 +303,7 @@ describe('Uniqueness in database: Festivals API', () => {
 
 			expect(await countNodesWithLabel('FestivalSeries')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/festivals/${TWO_THOUSAND_AND_EIGHT_FESTIVAL_UUID}`)
 				.send({
 					name: '2008',
@@ -320,7 +322,7 @@ describe('Uniqueness in database: Festivals API', () => {
 
 			expect(await countNodesWithLabel('FestivalSeries')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/festivals/${TWO_THOUSAND_AND_EIGHT_FESTIVAL_UUID}`)
 				.send({
 					name: '2008',

--- a/test-e2e/uniqueness-in-db/materials-api.test.js
+++ b/test-e2e/uniqueness-in-db/materials-api.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { countNodesWithLabel, createNode, purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidCounterClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -32,7 +34,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.post('/materials')
 				.send({
 					name: 'Home'
@@ -106,7 +108,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.post('/materials')
 				.send({
 					name: 'Home'
@@ -149,7 +151,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.post('/materials')
 				.send({
 					name: 'Home',
@@ -224,7 +226,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${MATERIAL_1_UUID}`)
 				.send({
 					name: 'Home',
@@ -269,7 +271,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${MATERIAL_1_UUID}`)
 				.send({
 					name: 'Home',
@@ -344,7 +346,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${MATERIAL_2_UUID}`)
 				.send({
 					name: 'Home'
@@ -450,7 +452,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${THE_SEAGULL_SUBSEQUENT_VERSION_MATERIAL_UUID}`)
 				.send({
 					name: 'The Seagull',
@@ -470,7 +472,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${THE_SEAGULL_SUBSEQUENT_VERSION_MATERIAL_UUID}`)
 				.send({
 					name: 'The Seagull',
@@ -491,7 +493,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(3);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${THE_SEAGULL_SUBSEQUENT_VERSION_MATERIAL_UUID}`)
 				.send({
 					name: 'The Seagull',
@@ -511,7 +513,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(3);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${THE_SEAGULL_SUBSEQUENT_VERSION_MATERIAL_UUID}`)
 				.send({
 					name: 'The Seagull',
@@ -564,7 +566,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${DOT_MATERIAL_UUID}`)
 				.send({
 					name: 'Dot',
@@ -589,7 +591,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${DOT_MATERIAL_UUID}`)
 				.send({
 					name: 'Dot',
@@ -615,7 +617,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${DOT_MATERIAL_UUID}`)
 				.send({
 					name: 'Dot',
@@ -640,7 +642,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${DOT_MATERIAL_UUID}`)
 				.send({
 					name: 'Dot',
@@ -698,7 +700,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			expect(await countNodesWithLabel('Company')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${UNTITLED_MATERIAL_UUID}`)
 				.send({
 					name: 'Untitled',
@@ -724,7 +726,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			expect(await countNodesWithLabel('Company')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${UNTITLED_MATERIAL_UUID}`)
 				.send({
 					name: 'Untitled',
@@ -751,7 +753,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			expect(await countNodesWithLabel('Company')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${UNTITLED_MATERIAL_UUID}`)
 				.send({
 					name: 'Untitled',
@@ -777,7 +779,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			expect(await countNodesWithLabel('Company')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${UNTITLED_MATERIAL_UUID}`)
 				.send({
 					name: 'Untitled',
@@ -836,7 +838,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${THE_INDIAN_BOY_MATERIAL_UUID}`)
 				.send({
 					name: 'The Indian Boy',
@@ -863,7 +865,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${THE_INDIAN_BOY_MATERIAL_UUID}`)
 				.send({
 					name: 'The Indian Boy',
@@ -891,7 +893,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(3);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${THE_INDIAN_BOY_MATERIAL_UUID}`)
 				.send({
 					name: 'The Indian Boy',
@@ -918,7 +920,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(3);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${THE_INDIAN_BOY_MATERIAL_UUID}`)
 				.send({
 					name: 'The Indian Boy',
@@ -978,7 +980,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${THE_COAST_OF_UTOPIA_MATERIAL_UUID}`)
 				.send({
 					name: 'The Coast of Utopia',
@@ -999,7 +1001,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${THE_COAST_OF_UTOPIA_MATERIAL_UUID}`)
 				.send({
 					name: 'The Coast of Utopia',
@@ -1021,7 +1023,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(3);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${THE_COAST_OF_UTOPIA_MATERIAL_UUID}`)
 				.send({
 					name: 'The Coast of Utopia',
@@ -1042,7 +1044,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(3);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${THE_COAST_OF_UTOPIA_MATERIAL_UUID}`)
 				.send({
 					name: 'The Coast of Utopia',
@@ -1100,7 +1102,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			expect(await countNodesWithLabel('Character')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${TITUS_ANDRONICUS_MATERIAL_UUID}`)
 				.send({
 					name: 'Titus Andronicus',
@@ -1125,7 +1127,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			expect(await countNodesWithLabel('Character')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${TITUS_ANDRONICUS_MATERIAL_UUID}`)
 				.send({
 					name: 'Titus Andronicus',
@@ -1151,7 +1153,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			expect(await countNodesWithLabel('Character')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${TITUS_ANDRONICUS_MATERIAL_UUID}`)
 				.send({
 					name: 'Titus Andronicus',
@@ -1176,7 +1178,7 @@ describe('Uniqueness in database: Materials API', () => {
 
 			expect(await countNodesWithLabel('Character')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/materials/${TITUS_ANDRONICUS_MATERIAL_UUID}`)
 				.send({
 					name: 'Titus Andronicus',

--- a/test-e2e/uniqueness-in-db/people-api.test.js
+++ b/test-e2e/uniqueness-in-db/people-api.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { countNodesWithLabel, purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidCounterClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -30,7 +32,7 @@ describe('Uniqueness in database: People API', () => {
 
 		expect(await countNodesWithLabel('Person')).to.equal(0);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.post('/people')
 			.send({
 				name: 'Paul Higgins'
@@ -54,7 +56,7 @@ describe('Uniqueness in database: People API', () => {
 
 		expect(await countNodesWithLabel('Person')).to.equal(1);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.post('/people')
 			.send({
 				name: 'Paul Higgins'
@@ -85,7 +87,7 @@ describe('Uniqueness in database: People API', () => {
 
 		expect(await countNodesWithLabel('Person')).to.equal(1);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.post('/people')
 			.send({
 				name: 'Paul Higgins',
@@ -110,7 +112,7 @@ describe('Uniqueness in database: People API', () => {
 
 		expect(await countNodesWithLabel('Person')).to.equal(2);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.put(`/people/${PERSON_1_UUID}`)
 			.send({
 				name: 'Paul Higgins',
@@ -143,7 +145,7 @@ describe('Uniqueness in database: People API', () => {
 
 		expect(await countNodesWithLabel('Person')).to.equal(2);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.put(`/people/${PERSON_1_UUID}`)
 			.send({
 				name: 'Paul Higgins',
@@ -168,7 +170,7 @@ describe('Uniqueness in database: People API', () => {
 
 		expect(await countNodesWithLabel('Person')).to.equal(2);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.put(`/people/${PERSON_2_UUID}`)
 			.send({
 				name: 'Paul Higgins'

--- a/test-e2e/uniqueness-in-db/productions-api.test.js
+++ b/test-e2e/uniqueness-in-db/productions-api.test.js
@@ -1,8 +1,10 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { countNodesWithLabel, createNode, purgeDatabase } from '../test-helpers/neo4j/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -42,7 +44,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${HOME_PRODUCTION_UUID}`)
 				.send({
 					name: 'Home',
@@ -61,7 +63,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${HOME_PRODUCTION_UUID}`)
 				.send({
 					name: 'Home',
@@ -81,7 +83,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${HOME_PRODUCTION_UUID}`)
 				.send({
 					name: 'Home',
@@ -100,7 +102,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Material')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${HOME_PRODUCTION_UUID}`)
 				.send({
 					name: 'Home',
@@ -152,7 +154,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Venue')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${DIAL_M_FOR_MURDER_PRODUCTION_UUID}`)
 				.send({
 					name: 'Dial M for Murder',
@@ -171,7 +173,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Venue')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${DIAL_M_FOR_MURDER_PRODUCTION_UUID}`)
 				.send({
 					name: 'Dial M for Murder',
@@ -191,7 +193,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Venue')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${DIAL_M_FOR_MURDER_PRODUCTION_UUID}`)
 				.send({
 					name: 'Dial M for Murder',
@@ -210,7 +212,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Venue')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${DIAL_M_FOR_MURDER_PRODUCTION_UUID}`)
 				.send({
 					name: 'Dial M for Murder',
@@ -262,7 +264,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Season')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${DETAINING_JUSTICE_PRODUCTION_UUID}`)
 				.send({
 					name: 'Detaining Justice',
@@ -281,7 +283,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Season')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${DETAINING_JUSTICE_PRODUCTION_UUID}`)
 				.send({
 					name: 'Detaining Justice',
@@ -301,7 +303,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Season')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${DETAINING_JUSTICE_PRODUCTION_UUID}`)
 				.send({
 					name: 'Detaining Justice',
@@ -320,7 +322,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Season')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${DETAINING_JUSTICE_PRODUCTION_UUID}`)
 				.send({
 					name: 'Detaining Justice',
@@ -372,7 +374,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Festival')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${MEASURE_FOR_MEASURE_PRODUCTION_UUID}`)
 				.send({
 					name: 'Measure for Measure',
@@ -391,7 +393,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Festival')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${MEASURE_FOR_MEASURE_PRODUCTION_UUID}`)
 				.send({
 					name: 'Measure for Measure',
@@ -411,7 +413,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Festival')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${MEASURE_FOR_MEASURE_PRODUCTION_UUID}`)
 				.send({
 					name: 'Measure for Measure',
@@ -430,7 +432,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Festival')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${MEASURE_FOR_MEASURE_PRODUCTION_UUID}`)
 				.send({
 					name: 'Measure for Measure',
@@ -482,7 +484,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${GIRL_NO_7_PRODUCTION_UUID}`)
 				.send({
 					name: 'Girl No 7',
@@ -508,7 +510,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${GIRL_NO_7_PRODUCTION_UUID}`)
 				.send({
 					name: 'Girl No 7',
@@ -535,7 +537,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${GIRL_NO_7_PRODUCTION_UUID}`)
 				.send({
 					name: 'Girl No 7',
@@ -561,7 +563,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${GIRL_NO_7_PRODUCTION_UUID}`)
 				.send({
 					name: 'Girl No 7',
@@ -636,7 +638,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Company')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${HAMLET_PRODUCTION_UUID}`)
 				.send({
 					name: 'Hamlet',
@@ -663,7 +665,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Company')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${HAMLET_PRODUCTION_UUID}`)
 				.send({
 					name: 'Hamlet',
@@ -691,7 +693,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Company')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${HAMLET_PRODUCTION_UUID}`)
 				.send({
 					name: 'Hamlet',
@@ -718,7 +720,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Company')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${HAMLET_PRODUCTION_UUID}`)
 				.send({
 					name: 'Hamlet',
@@ -778,7 +780,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${GIRL_NO_7_PRODUCTION_UUID}`)
 				.send({
 					name: 'Girl No 7',
@@ -810,7 +812,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${GIRL_NO_7_PRODUCTION_UUID}`)
 				.send({
 					name: 'Girl No 7',
@@ -843,7 +845,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${GIRL_NO_7_PRODUCTION_UUID}`)
 				.send({
 					name: 'Girl No 7',
@@ -875,7 +877,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${GIRL_NO_7_PRODUCTION_UUID}`)
 				.send({
 					name: 'Girl No 7',
@@ -962,7 +964,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${ARISTOCRATS_PRODUCTION_UUID}`)
 				.send({
 					name: 'Aristocrats',
@@ -983,7 +985,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${ARISTOCRATS_PRODUCTION_UUID}`)
 				.send({
 					name: 'Aristocrats',
@@ -1005,7 +1007,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${ARISTOCRATS_PRODUCTION_UUID}`)
 				.send({
 					name: 'Aristocrats',
@@ -1026,7 +1028,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${ARISTOCRATS_PRODUCTION_UUID}`)
 				.send({
 					name: 'Aristocrats',
@@ -1080,7 +1082,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${GIRL_NO_7_PRODUCTION_UUID}`)
 				.send({
 					name: 'Girl No 7',
@@ -1106,7 +1108,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${GIRL_NO_7_PRODUCTION_UUID}`)
 				.send({
 					name: 'Girl No 7',
@@ -1133,7 +1135,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${GIRL_NO_7_PRODUCTION_UUID}`)
 				.send({
 					name: 'Girl No 7',
@@ -1159,7 +1161,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${GIRL_NO_7_PRODUCTION_UUID}`)
 				.send({
 					name: 'Girl No 7',
@@ -1234,7 +1236,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Company')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${MOTHER_COURAGE_AND_HER_CHILDREN_PRODUCTION_UUID}`)
 				.send({
 					name: 'Mother Courage and Her Children',
@@ -1261,7 +1263,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Company')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${MOTHER_COURAGE_AND_HER_CHILDREN_PRODUCTION_UUID}`)
 				.send({
 					name: 'Mother Courage and Her Children',
@@ -1289,7 +1291,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Company')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${MOTHER_COURAGE_AND_HER_CHILDREN_PRODUCTION_UUID}`)
 				.send({
 					name: 'Mother Courage and Her Children',
@@ -1316,7 +1318,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Company')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${MOTHER_COURAGE_AND_HER_CHILDREN_PRODUCTION_UUID}`)
 				.send({
 					name: 'Mother Courage and Her Children',
@@ -1376,7 +1378,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${MOTHER_COURAGE_AND_HER_CHILDREN_PRODUCTION_UUID}`)
 				.send({
 					name: 'Mother Courage and Her Children',
@@ -1408,7 +1410,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${MOTHER_COURAGE_AND_HER_CHILDREN_PRODUCTION_UUID}`)
 				.send({
 					name: 'Mother Courage and Her Children',
@@ -1441,7 +1443,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${MOTHER_COURAGE_AND_HER_CHILDREN_PRODUCTION_UUID}`)
 				.send({
 					name: 'Mother Courage and Her Children',
@@ -1473,7 +1475,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${MOTHER_COURAGE_AND_HER_CHILDREN_PRODUCTION_UUID}`)
 				.send({
 					name: 'Mother Courage and Her Children',
@@ -1538,7 +1540,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${MRS_AFFLECK_PRODUCTION_UUID}`)
 				.send({
 					name: 'Mrs Affleck',
@@ -1564,7 +1566,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${MRS_AFFLECK_PRODUCTION_UUID}`)
 				.send({
 					name: 'Mrs Affleck',
@@ -1591,7 +1593,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${MRS_AFFLECK_PRODUCTION_UUID}`)
 				.send({
 					name: 'Mrs Affleck',
@@ -1617,7 +1619,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${MRS_AFFLECK_PRODUCTION_UUID}`)
 				.send({
 					name: 'Mrs Affleck',
@@ -1692,7 +1694,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Company')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${THREE_SISTERS_PRODUCTION_UUID}`)
 				.send({
 					name: 'Three Sisters',
@@ -1719,7 +1721,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Company')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${THREE_SISTERS_PRODUCTION_UUID}`)
 				.send({
 					name: 'Three Sisters',
@@ -1747,7 +1749,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Company')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${THREE_SISTERS_PRODUCTION_UUID}`)
 				.send({
 					name: 'Three Sisters',
@@ -1774,7 +1776,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Company')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${THREE_SISTERS_PRODUCTION_UUID}`)
 				.send({
 					name: 'Three Sisters',
@@ -1834,7 +1836,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${HAMLET_PRODUCTION_UUID}`)
 				.send({
 					name: 'Hamlet',
@@ -1866,7 +1868,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${HAMLET_PRODUCTION_UUID}`)
 				.send({
 					name: 'Hamlet',
@@ -1899,7 +1901,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${HAMLET_PRODUCTION_UUID}`)
 				.send({
 					name: 'Hamlet',
@@ -1931,7 +1933,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${HAMLET_PRODUCTION_UUID}`)
 				.send({
 					name: 'Hamlet',
@@ -1996,7 +1998,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Company')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${LONG_DAYS_JOURNEY_INTO_NIGHT_PRODUCTION_UUID}`)
 				.send({
 					name: 'Long Day\'s Journey Into Night',
@@ -2023,7 +2025,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Company')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${LONG_DAYS_JOURNEY_INTO_NIGHT_PRODUCTION_UUID}`)
 				.send({
 					name: 'Long Day\'s Journey Into Night',
@@ -2051,7 +2053,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Company')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${LONG_DAYS_JOURNEY_INTO_NIGHT_PRODUCTION_UUID}`)
 				.send({
 					name: 'Long Day\'s Journey Into Night',
@@ -2078,7 +2080,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Company')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${LONG_DAYS_JOURNEY_INTO_NIGHT_PRODUCTION_UUID}`)
 				.send({
 					name: 'Long Day\'s Journey Into Night',
@@ -2138,7 +2140,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${NYE_PRODUCTION_UUID}`)
 				.send({
 					name: 'Nye',
@@ -2165,7 +2167,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${NYE_PRODUCTION_UUID}`)
 				.send({
 					name: 'Nye',
@@ -2193,7 +2195,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${NYE_PRODUCTION_UUID}`)
 				.send({
 					name: 'Nye',
@@ -2220,7 +2222,7 @@ describe('Uniqueness in database: Productions API', () => {
 
 			expect(await countNodesWithLabel('Person')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/productions/${NYE_PRODUCTION_UUID}`)
 				.send({
 					name: 'Nye',

--- a/test-e2e/uniqueness-in-db/seasons-api.test.js
+++ b/test-e2e/uniqueness-in-db/seasons-api.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { countNodesWithLabel, purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidCounterClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -30,7 +32,7 @@ describe('Uniqueness in database: Seasons API', () => {
 
 		expect(await countNodesWithLabel('Season')).to.equal(0);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.post('/seasons')
 			.send({
 				name: 'Donmar in the West End'
@@ -54,7 +56,7 @@ describe('Uniqueness in database: Seasons API', () => {
 
 		expect(await countNodesWithLabel('Season')).to.equal(1);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.post('/seasons')
 			.send({
 				name: 'Donmar in the West End'
@@ -85,7 +87,7 @@ describe('Uniqueness in database: Seasons API', () => {
 
 		expect(await countNodesWithLabel('Season')).to.equal(1);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.post('/seasons')
 			.send({
 				name: 'Donmar in the West End',
@@ -110,7 +112,7 @@ describe('Uniqueness in database: Seasons API', () => {
 
 		expect(await countNodesWithLabel('Season')).to.equal(2);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.put(`/seasons/${SEASON_1_UUID}`)
 			.send({
 				name: 'Donmar in the West End',
@@ -143,7 +145,7 @@ describe('Uniqueness in database: Seasons API', () => {
 
 		expect(await countNodesWithLabel('Season')).to.equal(2);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.put(`/seasons/${SEASON_1_UUID}`)
 			.send({
 				name: 'Donmar in the West End',
@@ -168,7 +170,7 @@ describe('Uniqueness in database: Seasons API', () => {
 
 		expect(await countNodesWithLabel('Season')).to.equal(2);
 
-		const response = await chai.request(app)
+		const response = await request.execute(app)
 			.put(`/seasons/${SEASON_2_UUID}`)
 			.send({
 				name: 'Donmar in the West End'

--- a/test-e2e/uniqueness-in-db/venue-api.test.js
+++ b/test-e2e/uniqueness-in-db/venue-api.test.js
@@ -1,9 +1,11 @@
-import chai, { expect } from 'chai';
-import chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { default as chaiHttp, request } from 'chai-http';
 
 import app from '../../src/app.js';
 import { countNodesWithLabel, createNode, purgeDatabase } from '../test-helpers/neo4j/index.js';
 import { stubUuidCounterClient } from '../test-helpers/index.js';
+
+const { expect } = chai;
 
 chai.use(chaiHttp);
 
@@ -32,7 +34,7 @@ describe('Uniqueness in database: Venues API', () => {
 
 			expect(await countNodesWithLabel('Venue')).to.equal(0);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.post('/venues')
 				.send({
 					name: 'New Theatre'
@@ -64,7 +66,7 @@ describe('Uniqueness in database: Venues API', () => {
 
 			expect(await countNodesWithLabel('Venue')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.post('/venues')
 				.send({
 					name: 'New Theatre'
@@ -96,7 +98,7 @@ describe('Uniqueness in database: Venues API', () => {
 
 			expect(await countNodesWithLabel('Venue')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.post('/venues')
 				.send({
 					name: 'New Theatre',
@@ -129,7 +131,7 @@ describe('Uniqueness in database: Venues API', () => {
 
 			expect(await countNodesWithLabel('Venue')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/venues/${VENUE_1_UUID}`)
 				.send({
 					name: 'New Theatre',
@@ -163,7 +165,7 @@ describe('Uniqueness in database: Venues API', () => {
 
 			expect(await countNodesWithLabel('Venue')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/venues/${VENUE_1_UUID}`)
 				.send({
 					name: 'New Theatre',
@@ -196,7 +198,7 @@ describe('Uniqueness in database: Venues API', () => {
 
 			expect(await countNodesWithLabel('Venue')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/venues/${VENUE_2_UUID}`)
 				.send({
 					name: 'New Theatre'
@@ -260,7 +262,7 @@ describe('Uniqueness in database: Venues API', () => {
 
 			expect(await countNodesWithLabel('Venue')).to.equal(1);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/venues/${SHEFFIELD_THEATRES_VENUE_UUID}`)
 				.send({
 					name: 'Sheffield Theatres',
@@ -281,7 +283,7 @@ describe('Uniqueness in database: Venues API', () => {
 
 			expect(await countNodesWithLabel('Venue')).to.equal(2);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/venues/${SHEFFIELD_THEATRES_VENUE_UUID}`)
 				.send({
 					name: 'Sheffield Theatres',
@@ -303,7 +305,7 @@ describe('Uniqueness in database: Venues API', () => {
 
 			expect(await countNodesWithLabel('Venue')).to.equal(3);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/venues/${SHEFFIELD_THEATRES_VENUE_UUID}`)
 				.send({
 					name: 'Sheffield Theatres',
@@ -324,7 +326,7 @@ describe('Uniqueness in database: Venues API', () => {
 
 			expect(await countNodesWithLabel('Venue')).to.equal(3);
 
-			const response = await chai.request(app)
+			const response = await request.execute(app)
 				.put(`/venues/${SHEFFIELD_THEATRES_VENUE_UUID}`)
 				.send({
 					name: 'Sheffield Theatres',


### PR DESCRIPTION
This PR upgrades the Chai-related packages ([chai](https://www.npmjs.com/package/chai) and [chai-http](https://www.npmjs.com/package/chai-http)) to their current latest version.

These major upgrades were dependent on first migrating this repo to use Node.js-native ECMAScript modules (as done in https://github.com/andygout/dramatis-api/pull/682).

Prior to then, the following error message would display:
> Chai now only supports EcmaScript Modules (ESM). This means your tests will need to either have import {...} from 'chai' or import('chai'). require('chai') will cause failures in nodejs. If you're using ESM and seeing failures, it may be due to a bundler or transpiler which is incorrectly converting import statements into require calls.

Mentioned as part of these major releases:
- [chai v5.0.0](https://github.com/chaijs/chai/releases/tag/v5.0.0)
  - > Chai now only supports EcmaScript Modules (ESM). This means your tests will need to either have `import {...} from 'chai'` or `import('chai')`. `require('chai')` will cause failures in nodejs. If you're using ESM and seeing failures, it may be due to a bundler or transpiler which is incorrectly converting import statements into require calls.
- [chai-http v5.0.0](https://github.com/chaijs/chai-http/releases/tag/5.0.0)
  - > move to ESM (Chai 5)