### PR TITLE
Upgrade express 4.21.2 -> 5.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "directly": "2.0.6",
     "dotenv": "16.6.1",
-    "express": "4.21.2",
+    "express": "5.1.0",
     "morgan": "1.10.1",
     "neo4j-driver": "5.28.2"
   },

--- a/src/router.js
+++ b/src/router.js
@@ -1,5 +1,3 @@
-/* eslint no-unused-vars: ["error", { "argsIgnorePattern": "next" }] */
-
 import { Router } from 'express';
 
 import {
@@ -109,6 +107,6 @@ router.delete('/venues/:uuid', venuesController.deleteRoute);
 router.get('/venues/:uuid', venuesController.showRoute);
 router.get('/venues', venuesController.listRoute);
 
-router.get('*', (request, response, next) => response.sendStatus(404));
+router.use((request, response) => response.sendStatus(404));
 
 export default router;


### PR DESCRIPTION
This PR upgrades [express](https://www.npmjs.com/package/express) from v4.21.2 to v5.1.0.

The below change is for a 404 status response: a catch-all middleware with no path.

```diff
- router.get('*', (request, response, next) => response.sendStatus(404));
+ router.use((request, response) => response.sendStatus(404));
```

### References:
- [Introducing Express v5: A New Era for the Node.js Framework](https://expressjs.com/2024/10/15/v5-release.html)
- [Migrating to Express 5](https://expressjs.com/en/guide/migrating-5)